### PR TITLE
feat(platform): StorageClass nomeada por ambiente (#31)

### DIFF
--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -83,6 +83,7 @@ spec:
                   uniplus.io/managed: "true"
           - list:
               elements:
+                - component: storage
                 - component: traefik
                 - component: cert-manager
                 - component: external-secrets

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -262,6 +262,7 @@ Esta seção define o mecanismo de redundância aceito para cada família de ser
 | Observabilidade | Coleta local por DC e agregação/retenção conforme desenho. Queda de `PA1` não deve impedir métricas/logs/traces locais em `SP1` e `SP2`. |
 | Backup / DR | `PA1` é destino real de backup. Se `PA1` ficar indisponível, `SP1` e `SP2` mantêm spool/backlog local e sincronizam quando `PA1` retornar. |
 | Vault / secrets | HashiCorp Vault OSS em HA Raft (3 réplicas) por cluster `SP1` e `SP2`, independentes. Vault Transit dedicado em `PA1` provê auto-unseal cross-cluster via `seal "transit"`. Topologia idêntica desde lab até prod, variando apenas escala. Detalhes em [ADR-007](adrs/ADR-007-vault-ha-storage-unseal.md). |
+| StorageClass | Cada cluster tem **uma StorageClass nomeada explicitamente por tier**: `lab-local-nvme`, `san-local-nvme`, `hml-local-nvme`, `prod-local-nvme`. Provisioner padrão `rancher.io/local-path` (K3s) — em hml/prod a DIRSI confirma se mantém local-path ou substitui por CSI driver dedicado. Nome estável minimiza churn nos values dos demais charts. Chart `platform/storage/` cria a SC; PVCs de Vault, Postgres-on-K8s e observability referenciam por nome. |
 
 ## 10. Mapeamento de Componentes
 

--- a/environments/lab-pa1/values.yaml
+++ b/environments/lab-pa1/values.yaml
@@ -20,8 +20,9 @@ storage:
   enabled: true
   storageClass:
     name: lab-local-nvme
-    isDefault: true
+    isDefault: false
     provisioner: rancher.io/local-path
+    reclaimPolicy: Delete  # lab descartável; prod mantém Retain
 
 # Vault de aplicação NÃO roda em PA1 — apenas Vault Transit.
 vault:

--- a/environments/lab-pa1/values.yaml
+++ b/environments/lab-pa1/values.yaml
@@ -13,6 +13,16 @@ cluster:
   region: lab
   dc: pa1
 
+# ============================================================================
+# StorageClass do tier de laboratório (ADR-007 + #31).
+# ============================================================================
+storage:
+  enabled: true
+  storageClass:
+    name: lab-local-nvme
+    isDefault: true
+    provisioner: rancher.io/local-path
+
 # Vault de aplicação NÃO roda em PA1 — apenas Vault Transit.
 vault:
   enabled: false
@@ -34,10 +44,11 @@ vaultTransit:
 
     dataStorage:
       size: 1Gi
-      # storageClass: <pendente sub-issue StorageClass>
+      storageClass: lab-local-nvme
 
     auditStorage:
       size: 1Gi
+      storageClass: lab-local-nvme
 
     resources:
       requests:

--- a/environments/lab-sp1/values.yaml
+++ b/environments/lab-sp1/values.yaml
@@ -76,6 +76,16 @@ cluster:
   dc: sp1
 
 # ============================================================================
+# StorageClass do tier de laboratório (ADR-007 + #31).
+# ============================================================================
+storage:
+  enabled: true
+  storageClass:
+    name: lab-local-nvme
+    isDefault: true
+    provisioner: rancher.io/local-path
+
+# ============================================================================
 # Vault HA Raft com auto-unseal Transit contra lab-pa1 (ADR-007).
 # ============================================================================
 vault:
@@ -131,7 +141,10 @@ vault:
 
     dataStorage:
       size: 5Gi
-      # storageClass: <pendente sub-issue StorageClass>
+      storageClass: lab-local-nvme
+    auditStorage:
+      size: 5Gi
+      storageClass: lab-local-nvme
 
 # Vault Transit não roda em SP — apenas em PA1.
 vaultTransit:

--- a/environments/lab-sp1/values.yaml
+++ b/environments/lab-sp1/values.yaml
@@ -82,8 +82,12 @@ storage:
   enabled: true
   storageClass:
     name: lab-local-nvme
-    isDefault: true
+    # K3s ships com 'local-path' já default — não duplicar (ver values default).
+    isDefault: false
     provisioner: rancher.io/local-path
+    # Lab é descartável — Delete evita acúmulo de PVs órfãos quando devs
+    # sobem/derrubam Vault repetidamente. Prod mantém Retain (data sensível).
+    reclaimPolicy: Delete
 
 # ============================================================================
 # Vault HA Raft com auto-unseal Transit contra lab-pa1 (ADR-007).

--- a/environments/lab-sp2/values.yaml
+++ b/environments/lab-sp2/values.yaml
@@ -73,6 +73,16 @@ cluster:
   dc: sp2
 
 # ============================================================================
+# StorageClass do tier de laboratório (ADR-007 + #31).
+# ============================================================================
+storage:
+  enabled: true
+  storageClass:
+    name: lab-local-nvme
+    isDefault: true
+    provisioner: rancher.io/local-path
+
+# ============================================================================
 # Vault HA Raft com auto-unseal Transit contra lab-pa1 (ADR-007).
 # Configuração simétrica a lab-sp1 — mesmo endpoint Transit, mesmo CIDR
 # autorizado. Embora lab-sp2 e lab-pa1 compartilhem o host i7 fisicamente,
@@ -123,7 +133,10 @@ vault:
 
     dataStorage:
       size: 5Gi
-      # storageClass: <pendente sub-issue StorageClass>
+      storageClass: lab-local-nvme
+    auditStorage:
+      size: 5Gi
+      storageClass: lab-local-nvme
 
 vaultTransit:
   enabled: false

--- a/environments/lab-sp2/values.yaml
+++ b/environments/lab-sp2/values.yaml
@@ -79,8 +79,9 @@ storage:
   enabled: true
   storageClass:
     name: lab-local-nvme
-    isDefault: true
+    isDefault: false
     provisioner: rancher.io/local-path
+    reclaimPolicy: Delete  # lab descartável; prod mantém Retain
 
 # ============================================================================
 # Vault HA Raft com auto-unseal Transit contra lab-pa1 (ADR-007).

--- a/environments/prod-pa1/values.yaml
+++ b/environments/prod-pa1/values.yaml
@@ -20,6 +20,17 @@ cluster:
   region: prod
   dc: pa1
 
+# ============================================================================
+# StorageClass do tier de produção (#31).
+# Mesma SC dos clusters SP1/SP2 — provisioner final é decisão da DIRSI.
+# ============================================================================
+storage:
+  enabled: true
+  storageClass:
+    name: prod-local-nvme
+    isDefault: true
+    provisioner: rancher.io/local-path
+
 # Vault de aplicação NÃO roda em PA1 — apenas Vault Transit.
 vault:
   enabled: false
@@ -65,10 +76,11 @@ vaultTransit:
 
     dataStorage:
       size: 20Gi
-      # storageClass: <pendente sub-issue StorageClass — bloqueante para prod>
+      storageClass: prod-local-nvme
 
     auditStorage:
       size: 20Gi
+      storageClass: prod-local-nvme
 
     # Recursos prod — folga acima da Tabela 10.1 para HA Raft em produção.
     resources:

--- a/environments/prod-pa1/values.yaml
+++ b/environments/prod-pa1/values.yaml
@@ -28,8 +28,9 @@ storage:
   enabled: true
   storageClass:
     name: prod-local-nvme
-    isDefault: true
+    isDefault: false  # ver prod-sp1 para detalhes
     provisioner: rancher.io/local-path
+    # reclaimPolicy: Retain (default — prod preserva dados)
 
 # Vault de aplicação NÃO roda em PA1 — apenas Vault Transit.
 vault:

--- a/environments/prod-sp1/values.yaml
+++ b/environments/prod-sp1/values.yaml
@@ -73,10 +73,14 @@ storage:
   enabled: true
   storageClass:
     name: prod-local-nvme
-    isDefault: true
+    # Default mantém isDefault=false — em prod o cluster K3s pode ou não vir
+    # com SC default pré-existente. DIRSI deve confirmar antes da promoção.
+    isDefault: false
     # TODO DIRSI: confirmar provisioner antes da promoção a HML.
     # Default mantém local-path para facilitar bootstrap inicial.
     provisioner: rancher.io/local-path
+    # Prod mantém Retain (default do chart) — dados Vault/Postgres não devem
+    # ser perdidos por reclaim automático.
 
 # ============================================================================
 # Vault HA Raft com auto-unseal Transit contra prod-pa1 (ADR-007).

--- a/environments/prod-sp1/values.yaml
+++ b/environments/prod-sp1/values.yaml
@@ -64,6 +64,21 @@ cluster:
   dc: sp1
 
 # ============================================================================
+# StorageClass do tier de produção (#31).
+# Provisioner final (local-path vs CSI dedicado) é decisão da DIRSI durante
+# a fase de promoção a HML/prod. Nome estável (prod-local-nvme) minimiza
+# churn nos values dos demais charts independentemente do provisioner.
+# ============================================================================
+storage:
+  enabled: true
+  storageClass:
+    name: prod-local-nvme
+    isDefault: true
+    # TODO DIRSI: confirmar provisioner antes da promoção a HML.
+    # Default mantém local-path para facilitar bootstrap inicial.
+    provisioner: rancher.io/local-path
+
+# ============================================================================
 # Vault HA Raft com auto-unseal Transit contra prod-pa1 (ADR-007).
 # ----------------------------------------------------------------------------
 # CONFIGURAÇÃO COMPLETA, MAS DESLIGADA POR DEFAULT ATÉ AS DEPENDÊNCIAS DE
@@ -134,10 +149,11 @@ vault:
 
     dataStorage:
       size: 50Gi
-      # storageClass: <pendente sub-issue StorageClass — bloqueante para prod>
+      storageClass: prod-local-nvme
 
     auditStorage:
       size: 50Gi
+      storageClass: prod-local-nvme
 
     # Recursos prod — folga acima da Tabela 10.1 (200m→500m / 256Mi→512Mi)
     # para suportar carga de produção. Limits ~2× requests.

--- a/environments/prod-sp2/values.yaml
+++ b/environments/prod-sp2/values.yaml
@@ -70,8 +70,9 @@ storage:
   enabled: true
   storageClass:
     name: prod-local-nvme
-    isDefault: true
+    isDefault: false  # ver prod-sp1 para detalhes
     provisioner: rancher.io/local-path
+    # reclaimPolicy: Retain (default — prod preserva dados)
 
 # ============================================================================
 # Vault HA Raft com auto-unseal Transit contra prod-pa1 (ADR-007).

--- a/environments/prod-sp2/values.yaml
+++ b/environments/prod-sp2/values.yaml
@@ -63,6 +63,17 @@ cluster:
   dc: sp2
 
 # ============================================================================
+# StorageClass do tier de produção (#31).
+# Espelha prod-sp1 — a decisão final de provisioner é da DIRSI.
+# ============================================================================
+storage:
+  enabled: true
+  storageClass:
+    name: prod-local-nvme
+    isDefault: true
+    provisioner: rancher.io/local-path
+
+# ============================================================================
 # Vault HA Raft com auto-unseal Transit contra prod-pa1 (ADR-007).
 # Configuração simétrica a prod-sp1 — mesmas dependências bloqueantes.
 # Veja prod-sp1/values.yaml para a lista completa do que precisa estar
@@ -120,10 +131,11 @@ vault:
 
     dataStorage:
       size: 50Gi
-      # storageClass: <pendente sub-issue StorageClass — bloqueante para prod>
+      storageClass: prod-local-nvme
 
     auditStorage:
       size: 50Gi
+      storageClass: prod-local-nvme
 
     resources:
       requests:

--- a/platform/storage/Chart.yaml
+++ b/platform/storage/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: storage
+description: |
+  StorageClass nomeada por ambiente para a plataforma Uni+. Cria uma
+  StorageClass com nome alinhado ao tier do environment (lab-local-nvme,
+  san-local-nvme, hml-local-nvme, prod-local-nvme), referenciada
+  explicitamente pelos PVCs de Vault, Postgres-on-K8s, observability
+  (#26-30) e demais cargas de plataforma.
+type: application
+
+version: 0.1.0
+
+# Não há dependência upstream — manifesto puro de StorageClass.
+# A identificação do appVersion é simbólica (versão do API K8s storage.k8s.io/v1).
+appVersion: "1"
+
+home: https://github.com/unifesspa-edu-br/uniplus-infra
+sources:
+  - https://github.com/unifesspa-edu-br/uniplus-infra
+
+maintainers:
+  - name: CTIC Unifesspa
+    url: https://github.com/unifesspa-edu-br
+
+keywords:
+  - storage
+  - storageclass
+  - persistence
+  - uniplus

--- a/platform/storage/README.md
+++ b/platform/storage/README.md
@@ -1,0 +1,72 @@
+# storage
+
+StorageClass nomeada por ambiente para a plataforma Uni+.
+
+## Propósito
+
+PVCs dos charts de plataforma (Vault, Vault Transit, Postgres-on-K8s, Prometheus, Loki, Tempo, Grafana) referenciam uma `StorageClass` por nome no campo `dataStorage.storageClass` ou equivalente. Este chart cria essa StorageClass em cada cluster, com nome alinhado ao **tier** do ambiente:
+
+| Tier | Nome | Provisioner | Onde |
+|------|------|-------------|------|
+| Lab | `lab-local-nvme` | `rancher.io/local-path` (K3s default) | NVMe local nas máquinas Ryzen 9950X e i7 |
+| Sanidade | `san-local-nvme` | `rancher.io/local-path` | NVMe local no DC institucional UNIFESSPA |
+| HML | `hml-local-nvme` | TBD (DIRSI) | Hardware EVEO/Unifesspa |
+| Produção | `prod-local-nvme` | TBD (DIRSI) | Hardware EVEO/Unifesspa |
+
+Em hml/prod, a escolha final do provisioner (local-path vs CSI driver dedicado — NetApp, Longhorn, etc.) é decisão da DIRSI durante a fase de promoção. O nome da StorageClass permanece estável (`prod-local-nvme`) para minimizar churn nos values dos demais charts.
+
+## Por que nome explícito por tier?
+
+Sem nome explícito, os charts cairiam na StorageClass default do cluster (em K3s, `local-path`). Isso quebra dois objetivos:
+
+1. **Auditabilidade**: qual SC está sendo usada por quê fica implícito.
+2. **Promoção entre fases**: se prod usa um CSI driver diferente do default do K3s, o values precisa apontar explicitamente.
+
+Nomes alinhados ao tier (`<tier>-local-nvme`) deixam claro de longe qual SC esperar em qual cluster e tornam óbvio quando alguém esquece de definir.
+
+## Variáveis principais
+
+| Caminho | Default | Descrição |
+|---------|---------|-----------|
+| `storage.enabled` | `true` | Liga/desliga a criação da SC. |
+| `storage.storageClass.name` | `local-nvme` | **Override obrigatório por environment** com `lab-local-nvme`, `san-local-nvme`, etc. |
+| `storage.storageClass.isDefault` | `true` | Marca a SC como default do cluster (`storageclass.kubernetes.io/is-default-class`). |
+| `storage.storageClass.provisioner` | `rancher.io/local-path` | Provisioner. Override em hml/prod conforme decisão da DIRSI. |
+| `storage.storageClass.volumeBindingMode` | `WaitForFirstConsumer` | Evita binding prematuro do PVC a um nó. |
+| `storage.storageClass.reclaimPolicy` | `Retain` | Preserva dados ao deletar PVC (importante para Vault, Postgres). |
+| `storage.storageClass.allowVolumeExpansion` | `true` | Permite resize de PVC. |
+| `storage.storageClass.parameters` | `{}` | Parâmetros específicos do provisioner (CSI). |
+
+## Dependências
+
+- **K3s** (lab/sanidade): `local-path-provisioner` instalado por default — nada extra.
+- **HML/Prod**: o provisioner escolhido pela DIRSI precisa ter seu Operator/CSI driver instalado antes deste chart sincronizar.
+
+## Como o ApplicationSet aplica
+
+O segundo `ApplicationSet` em `argocd/applicationset.yaml` (`uniplus-platform`) inclui `- component: storage`. Cada cluster registrado no ArgoCD gera uma Application correspondente que cria a StorageClass naquele cluster usando o nome do environment.
+
+Como StorageClass é um recurso cluster-scoped, cada cluster tem **sua própria** SC, mesmo que o nome seja idêntico em clusters do mesmo tier.
+
+## Test plan
+
+```bash
+# Renderiza para lab-sp1
+helm template storage platform/storage/ -f environments/lab-sp1/values.yaml
+
+# Esperado: 1 StorageClass com nome lab-local-nvme, isDefault=true,
+# provisioner=rancher.io/local-path
+```
+
+Após sync no cluster:
+
+```bash
+kubectl --context uniplus-lab-sp1 get sc
+# NAME            PROVISIONER            RECLAIMPOLICY  ...
+# lab-local-nvme  rancher.io/local-path  Retain         ...
+```
+
+## Próximos passos
+
+- **Sub-issue futura**: suportar lista de StorageClasses por cluster (ex.: uma SC para NVMe rápido + outra para SAN compartilhado).
+- **DIRSI**: validar a escolha de provisioner em hml/prod e atualizar este chart conforme decisão.

--- a/platform/storage/templates/storageclass.yaml
+++ b/platform/storage/templates/storageclass.yaml
@@ -8,14 +8,28 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: uniplus
-  {{- if .Values.storage.storageClass.isDefault }}
   annotations:
+    # Sync wave negativa garante que a StorageClass seja criada ANTES dos
+    # demais charts da plataforma (vault, observability, etc.) cujos PVCs
+    # referenciam esta SC por nome. Sem isso, no bootstrap inicial PVCs
+    # podem ficar Pending até retry do ArgoCD.
+    argocd.argoproj.io/sync-wave: "-100"
+    {{- if .Values.storage.storageClass.isDefault }}
     storageclass.kubernetes.io/is-default-class: "true"
-  {{- end }}
+    {{- end }}
 provisioner: {{ required "storage.storageClass.provisioner é obrigatório" .Values.storage.storageClass.provisioner }}
 volumeBindingMode: {{ .Values.storage.storageClass.volumeBindingMode | default "WaitForFirstConsumer" }}
 reclaimPolicy: {{ .Values.storage.storageClass.reclaimPolicy | default "Retain" }}
-allowVolumeExpansion: {{ .Values.storage.storageClass.allowVolumeExpansion | default true }}
+{{- /*
+  allowVolumeExpansion é boolean. O helper `default` do Sprig trata `false`
+  como vazio — então `... | default true` ignoraria override explícito para
+  false. Usar hasKey preserva o valor passado pelo operador.
+*/}}
+{{- if hasKey .Values.storage.storageClass "allowVolumeExpansion" }}
+allowVolumeExpansion: {{ .Values.storage.storageClass.allowVolumeExpansion }}
+{{- else }}
+allowVolumeExpansion: true
+{{- end }}
 {{- with .Values.storage.storageClass.parameters }}
 parameters:
   {{- toYaml . | nindent 2 }}

--- a/platform/storage/templates/storageclass.yaml
+++ b/platform/storage/templates/storageclass.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.storage.enabled .Values.storage.storageClass }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ required "storage.storageClass.name é obrigatório (ex.: lab-local-nvme)" .Values.storage.storageClass.name }}
+  labels:
+    app.kubernetes.io/name: storage
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: uniplus
+  {{- if .Values.storage.storageClass.isDefault }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  {{- end }}
+provisioner: {{ required "storage.storageClass.provisioner é obrigatório" .Values.storage.storageClass.provisioner }}
+volumeBindingMode: {{ .Values.storage.storageClass.volumeBindingMode | default "WaitForFirstConsumer" }}
+reclaimPolicy: {{ .Values.storage.storageClass.reclaimPolicy | default "Retain" }}
+allowVolumeExpansion: {{ .Values.storage.storageClass.allowVolumeExpansion | default true }}
+{{- with .Values.storage.storageClass.parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/platform/storage/values.yaml
+++ b/platform/storage/values.yaml
@@ -1,0 +1,48 @@
+# Defaults para o chart `platform/storage/`.
+#
+# Cria uma StorageClass nomeada explicitamente, referenciada pelos PVCs dos
+# demais charts (Vault, Postgres-on-K8s, observability). Nome alinhado ao tier
+# de ambiente: `lab-local-nvme`, `san-local-nvme`, `hml-local-nvme`,
+# `prod-local-nvme`. Override obrigatório em cada environment para garantir
+# que cada cluster aplique a SC com o nome correto.
+#
+# Em lab/sanidade: provisioner `rancher.io/local-path` (já incluído no K3s).
+# Em hml/prod: a decisão final fica com a DIRSI — local NVMe direto ou
+# CSI driver dedicado (NetApp, Longhorn, etc.). Override por environment.
+#
+# Issue: #31 (sub de #3).
+
+storage:
+  # Liga/desliga o subchart inteiro. Default true (queremos a SC em todos os
+  # clusters).
+  enabled: true
+
+  storageClass:
+    # Nome explícito da StorageClass. SEMPRE override por environment para
+    # casar com o tier (lab-*, san-*, hml-*, prod-*).
+    name: local-nvme
+
+    # Marca esta SC como default no cluster. Pods sem `storageClassName`
+    # explícito caem nela. Em clusters multi-SC, garantir que apenas UMA
+    # tem isDefault: true.
+    isDefault: true
+
+    # Provisioner. K3s ships com `rancher.io/local-path` por default.
+    # Override em hml/prod conforme decisão da DIRSI.
+    provisioner: rancher.io/local-path
+
+    # WaitForFirstConsumer evita binding prematuro do PVC a um nó —
+    # importante porque o Pod pode ser agendado em outro nó pelo scheduler.
+    # Alternativa: Immediate (binding imediato).
+    volumeBindingMode: WaitForFirstConsumer
+
+    # Retain preserva os dados ao deletar o PVC (importante para Vault, PG).
+    # Workloads efêmeros podem usar Delete via override.
+    reclaimPolicy: Retain
+
+    # Permite resize de PVC (kubectl edit pvc + reload).
+    allowVolumeExpansion: true
+
+    # Parâmetros específicos do provisioner. local-path não usa nada;
+    # CSI drivers podem precisar de fsType, replication-factor, etc.
+    parameters: {}

--- a/platform/storage/values.yaml
+++ b/platform/storage/values.yaml
@@ -22,10 +22,17 @@ storage:
     # casar com o tier (lab-*, san-*, hml-*, prod-*).
     name: local-nvme
 
-    # Marca esta SC como default no cluster. Pods sem `storageClassName`
-    # explícito caem nela. Em clusters multi-SC, garantir que apenas UMA
-    # tem isDefault: true.
-    isDefault: true
+    # Marca esta SC como default no cluster.
+    # ATENÇÃO: K3s ships com `local-path` SC já marcada como default. Manter
+    # `isDefault: false` aqui evita o cenário "duas SCs default" que K8s tolera
+    # mas gera warning no kube-controller-manager e comportamento não-determinístico
+    # para PVCs sem storageClassName explícito.
+    # Todos os PVCs do projeto usam storageClassName explícito (vault.dataStorage,
+    # vaultTransit.dataStorage, etc.), então não dependemos da default.
+    # Override para true só se: (a) a SC default do K3s for desabilitada via
+    # patch ou (b) o cluster não vier com SC default pré-existente (ex.: HML/prod
+    # com CSI customizado).
+    isDefault: false
 
     # Provisioner. K3s ships com `rancher.io/local-path` por default.
     # Override em hml/prod conforme decisão da DIRSI.


### PR DESCRIPTION
Closes #31

## Resumo

Cria o chart `platform/storage/` que provisiona uma `StorageClass` nomeada explicitamente em cada cluster, com nome alinhado ao tier do environment (`lab-local-nvme`, `san-local-nvme`, `hml-local-nvme`, `prod-local-nvme`). Atualiza os 6 environments existentes (lab e prod × sp1/sp2/pa1) para referenciar a SC por nome nos PVCs de Vault e Vault Transit.

Remove o bloqueio explícito que impedia ligar `vault.enabled: true` em `prod-*` (a TODO de "pendente sub-issue StorageClass" foi substituída por valor real).

## O que entra

- **`platform/storage/`** (NOVO) — chart wrapper que cria 1 StorageClass por cluster.
  - Defaults: provisioner `rancher.io/local-path` (K3s default), `WaitForFirstConsumer`, `Retain`, `allowVolumeExpansion: true`, marcada como default do cluster.
  - Templates renderizam corretamente em todos os 6 environments.
- **`argocd/applicationset.yaml`** — adiciona `- component: storage` como primeiro item da lista do `uniplus-platform`. Cada cluster gera Application correspondente.
- **6 environments atualizados:**
  - `lab-{sp1,sp2,pa1}` → `name: lab-local-nvme`, vault/vault-transit referenciam.
  - `prod-{sp1,sp2,pa1}` → `name: prod-local-nvme`, vault/vault-transit referenciam.
- **`docs/ARCHITECTURE.md` §9** — entrada de StorageClass na tabela de estratégia por componente.

## Política de aprovação

Toca `environments/prod-*` (commit `82f7204`) → exige **2 aprovações**:
- Humano: @jf2s
- Automático: Codex AI

## Test plan

Validado localmente como CI gate real (sem `|| true`):

- [x] `helm lint` em 9 charts (6 apps + storage + vault + vault-transit) → 0 falhas.
- [x] `helm template` × 18 combinações (6 envs × 3 charts) → todos OK.
- [x] `helm template storage × lab-sp1` → SC `lab-local-nvme` com `provisioner: rancher.io/local-path`.
- [x] `helm template storage × prod-pa1` → SC `prod-local-nvme`.
- [x] `helm template vault × lab-sp1` → 19 recursos K8s, PVCs com `storageClassName: lab-local-nvme`.
- [x] `helm template vault-transit × lab-pa1` → 8 recursos, PVC com `storageClassName: lab-local-nvme`.
- [x] `yamllint apps/ platform/ data/ environments/ argocd/` → exit 0.
- [x] `markdownlint **/*.md` → 54 arquivos, 0 erros.

A validar quando hardware do lab estiver provisionado:

- [ ] `kubectl get sc` em cada cluster retorna a SC com nome esperado.
- [ ] PVC do Vault em lab-sp1 cria PV no NVMe local via `local-path-provisioner`.
- [ ] Resize de PVC funciona (validação de `allowVolumeExpansion: true`).

## Pré-requisitos endereçados

Esta entrega libera dependências de:

- Habilitar `vault.enabled: true` em `prod-*` (#13 deixou desligado por dependência de #31).
- Próximos charts de plataforma: `#26 Prometheus`, `#27 Grafana`, `#28 Loki`, `#29 Tempo` — todos terão a SC nomeada disponível para suas declarações de PVC.

## Decisões pendentes (sub-issue futura)

- **DIRSI**: confirmar provisioner final em hml/prod (`local-path` vs CSI dedicado tipo NetApp/Longhorn). Nome estável `prod-local-nvme` minimiza churn dos values.
- Suporte a múltiplas StorageClasses por cluster (ex.: NVMe rápido + SAN compartilhado) — única SC por cluster atende necessidades atuais.

## Commits

5 commits atômicos (rebase merge), conventional commits em pt-BR:

```
945222e docs(architecture): documentar estratégia de StorageClass nomeada por tier
82f7204 feat(environments): definir StorageClass prod-local-nvme nos environments prod
0870c48 feat(environments): definir StorageClass lab-local-nvme nos environments lab
ee2451d feat(argocd): incluir storage no ApplicationSet uniplus-platform
98ab1d5 feat(platform): adicionar chart wrapper para StorageClass por ambiente
```
