### PR TITLE
chore(tooling): Makefile + values.schema.json + helm-docs config (#35)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -63,6 +63,43 @@ jobs:
           scandir: './scripts'
           severity: warning
 
+  schema-validate:
+    name: Schema Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.14.0'
+
+      - name: Validate values.schema.json across charts × environments
+        run: |
+          set -euo pipefail
+          ENVS="lab-sp1 lab-sp2 lab-pa1 prod-sp1 prod-sp2 prod-pa1"
+          FAILS=0
+          for chart_dir in apps/*/ platform/*/; do
+            chart_name=$(basename "$chart_dir")
+            if [ ! -f "$chart_dir/Chart.yaml" ]; then continue; fi
+            if grep -q '^dependencies:' "$chart_dir/Chart.yaml"; then
+              helm dependency update "$chart_dir" >/dev/null
+            fi
+            for env in $ENVS; do
+              echo "Validating $chart_name × $env"
+              if ! helm template "$chart_name" "$chart_dir" \
+                  -f "environments/$env/values.yaml" >/dev/null 2>/tmp/render.log; then
+                echo "✗ $chart_name × $env"
+                cat /tmp/render.log
+                FAILS=$((FAILS+1))
+              fi
+            done
+          done
+          if [ "$FAILS" -gt 0 ]; then
+            echo "✗ $FAILS combinação(ões) chart × env falharam"
+            exit 1
+          fi
+
   markdown-lint:
     name: Markdown Lint
     runs-on: ubuntu-latest

--- a/.helm-docs.yaml
+++ b/.helm-docs.yaml
@@ -1,0 +1,27 @@
+# Configuração do helm-docs (https://github.com/norwoodj/helm-docs).
+#
+# Para gerar/atualizar README.md dos charts a partir de values.yaml:
+#   make helm-docs
+#
+# Pré-requisito (uma vez):
+#   go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+# ou via Docker (sem instalar Go):
+#   HELM_DOCS='docker run --rm -v "$(pwd):/work" -w /work jnorwood/helm-docs:latest helm-docs' make helm-docs
+#
+# helm-docs descobre `# --` comentários em values.yaml como descrições
+# das chaves e gera o README a partir do template README.md.gotmpl
+# (se existir; caso contrário usa o default do helm-docs).
+
+chart-search-root: .
+chart-to-generate:
+  - apps
+  - platform
+
+# Nome do template a usar. helm-docs procura README.md.gotmpl em cada
+# chart antes de cair no default. README.md é regenerado a partir dele.
+template-files:
+  - README.md.gotmpl
+
+# Não tocar charts sem o arquivo — evita sobrescrever READMEs hand-written
+# que ainda não foram migrados para o formato helm-docs.
+ignore-non-descriptions: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,17 +47,31 @@ chore(deps): atualiza ArgoCD para 2.13.x
 Antes de abrir o PR, execute localmente:
 
 ```bash
-# Lint dos charts Helm
-make helm-lint
+# Roda todos os linters (yaml + helm + markdown + shell)
+make lint
 
-# Validação dos manifests YAML
-make yaml-lint
+# Roda lint + helm dependency update + validação contra values.schema.json
+make validate
 
-# Validação de manifests K8s contra schema
-make kube-validate
+# Lista todos os targets disponíveis
+make help
 ```
 
-Os mesmos checks rodam em CI e bloqueiam o merge se falharem.
+Targets individuais úteis durante desenvolvimento:
+
+| Target | Função |
+|---|---|
+| `make yaml-lint` | yamllint nos diretórios de manifests/values |
+| `make helm-lint` | helm lint em todos os charts (apps/ + platform/) |
+| `make helm-template` | renderiza todas as combinações chart × environment |
+| `make schema-validate` | valida values dos environments contra `values.schema.json` |
+| `make markdown-lint` | markdownlint-cli2 em todos os `.md` |
+| `make shellcheck` | shellcheck em `scripts/*.sh` |
+| `make helm-deps` | `helm dependency update` em charts com dependências |
+| `make helm-docs` | gera/atualiza READMEs a partir de `values.yaml` (exige helm-docs CLI) |
+| `make clean` | remove `charts/` baixados, `*.tgz`, `Chart.lock` |
+
+Os mesmos checks rodam em CI (`.github/workflows/validate.yml`) e bloqueiam o merge se falharem.
 
 ### 5. Abra o Pull Request
 
@@ -83,8 +97,8 @@ Pelo menos 1 aprovação do time CTIC é obrigatória. Mudanças em produção (
 
 - Cada chart deve ter `Chart.yaml`, `values.yaml` (defaults), `README.md`
 - Templates em `templates/` seguem [boas práticas oficiais](https://helm.sh/docs/chart_best_practices/)
-- Use `helm-docs` para gerar README a partir dos values
-- Schemas de values em `values.schema.json` (recomendado)
+- Use `helm-docs` para gerar README a partir dos values (`make helm-docs`). Configuração em `.helm-docs.yaml`. Charts ainda não migrados mantêm README hand-written; migração é gradual.
+- **`values.schema.json` obrigatório** para charts em `platform/` (validação automática pelo Helm em `helm template`/`install`/`upgrade`). Chart wrapper `platform/vault/` e `platform/vault-transit/` servem de referência. Use `additionalProperties: true` em blocos compartilhados entre múltiplos charts (`networkPolicy`, `serviceMonitor`, `ingress`).
 
 ### YAML
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,194 @@
+# Makefile do uniplus-infra
+#
+# Targets agrupados por área. `make help` lista tudo.
+# CI roda os mesmos checks via .github/workflows/validate.yml — manter alinhado.
+
+SHELL := /bin/bash
+.SHELLFLAGS := -euo pipefail -c
+MAKEFLAGS += --no-print-directory
+
+# ============================================================================
+# Configuração
+# ============================================================================
+
+# Charts a serem processados. Atualizar se nova área surgir.
+CHARTS_APPS     := $(wildcard apps/*/Chart.yaml)
+CHARTS_PLATFORM := $(wildcard platform/*/Chart.yaml)
+CHARTS_ALL      := $(CHARTS_APPS) $(CHARTS_PLATFORM)
+CHART_DIRS      := $(dir $(CHARTS_ALL))
+
+# Diretórios validados pelo yamllint (mesma lista do CI).
+YAML_DIRS := apps/ platform/ data/ environments/ argocd/
+
+# Environments existentes (atualizar quando san-* / hml-* forem criados).
+ENVS := lab-sp1 lab-sp2 lab-pa1 prod-sp1 prod-sp2 prod-pa1
+
+# Comando markdownlint via npx (não exige instalação global).
+MARKDOWNLINT := npx --yes markdownlint-cli2
+
+# helm-docs via go install ou docker — configurável.
+HELM_DOCS ?= helm-docs
+
+# ============================================================================
+# Cores
+# ============================================================================
+
+GREEN  := \033[0;32m
+YELLOW := \033[1;33m
+RED    := \033[0;31m
+BLUE   := \033[0;34m
+RESET  := \033[0m
+
+# ============================================================================
+# Help
+# ============================================================================
+
+.PHONY: help
+help:  ## Lista os targets disponíveis com descrição
+	@echo ""
+	@printf "$(BLUE)Uni+ infra — Makefile$(RESET)\n"
+	@echo ""
+	@printf "$(GREEN)Validação (mesmo conjunto do CI):$(RESET)\n"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep -E '^(yaml-lint|helm-lint|markdown-lint|shellcheck|schema-validate|lint|validate|all)' | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(YELLOW)%-20s$(RESET) %s\n", $$1, $$2}'
+	@echo ""
+	@printf "$(GREEN)Helm:$(RESET)\n"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep -E '^helm-' | grep -vE '^(helm-lint)' | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(YELLOW)%-20s$(RESET) %s\n", $$1, $$2}'
+	@echo ""
+	@printf "$(GREEN)Outros:$(RESET)\n"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep -vE '^(yaml-lint|helm-lint|markdown-lint|shellcheck|schema-validate|lint|validate|all|help|helm-)' | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(YELLOW)%-20s$(RESET) %s\n", $$1, $$2}'
+	@echo ""
+
+# ============================================================================
+# Validação — chamada por CI e desenvolvedores antes do PR
+# ============================================================================
+
+.PHONY: yaml-lint
+yaml-lint:  ## Roda yamllint nos diretórios manifests/values
+	@printf "$(BLUE)→ yamllint$(RESET)\n"
+	yamllint -c .yamllint.yaml $(YAML_DIRS)
+
+.PHONY: helm-lint
+helm-lint:  ## Roda helm lint em todos os charts (apps/ e platform/)
+	@printf "$(BLUE)→ helm lint$(RESET)\n"
+	@FAILS=0; \
+	for chart in $(CHART_DIRS); do \
+	    echo "  Linting $$chart"; \
+	    if ! helm lint "$$chart" >/tmp/helm-lint-$$$$.log 2>&1; then \
+	        cat /tmp/helm-lint-$$$$.log; FAILS=$$((FAILS+1)); \
+	    fi; \
+	    rm -f /tmp/helm-lint-$$$$.log; \
+	done; \
+	if [ "$$FAILS" -gt 0 ]; then \
+	    printf "$(RED)✗ $$FAILS chart(s) com falha em helm lint$(RESET)\n"; \
+	    exit 1; \
+	fi
+
+.PHONY: markdown-lint
+markdown-lint:  ## Roda markdownlint-cli2 em todos os .md
+	@printf "$(BLUE)→ markdownlint$(RESET)\n"
+	$(MARKDOWNLINT) '**/*.md' '!**/charts/**' '!**/node_modules/**'
+
+.PHONY: shellcheck
+shellcheck:  ## Roda shellcheck em scripts/*.sh
+	@printf "$(BLUE)→ shellcheck$(RESET)\n"
+	shellcheck scripts/*.sh
+
+.PHONY: schema-validate
+schema-validate:  ## Valida values.yaml dos environments contra os schemas dos charts
+	@printf "$(BLUE)→ schema-validate$(RESET)\n"
+	@FAILS=0; \
+	for chart_dir in $(CHART_DIRS); do \
+	    chart_name=$$(basename "$$chart_dir"); \
+	    if [ ! -f "$$chart_dir/values.schema.json" ]; then \
+	        continue; \
+	    fi; \
+	    for env in $(ENVS); do \
+	        echo "  $$chart_name × $$env"; \
+	        if ! helm template "$$chart_name" "$$chart_dir" \
+	                -f "environments/$$env/values.yaml" \
+	                >/dev/null 2>/tmp/schema-$$$$.log; then \
+	            cat /tmp/schema-$$$$.log; FAILS=$$((FAILS+1)); \
+	        fi; \
+	        rm -f /tmp/schema-$$$$.log; \
+	    done; \
+	done; \
+	if [ "$$FAILS" -gt 0 ]; then \
+	    printf "$(RED)✗ $$FAILS combinação(ões) chart×env falharam na validação de schema$(RESET)\n"; \
+	    exit 1; \
+	fi
+
+.PHONY: lint
+lint: yaml-lint helm-lint markdown-lint shellcheck  ## Roda todos os linters
+
+.PHONY: validate
+validate: lint helm-deps schema-validate  ## Lint + render de templates contra schemas
+
+.PHONY: all
+all: validate  ## Alias de validate (default do CI)
+
+# ============================================================================
+# Helm — operações específicas
+# ============================================================================
+
+.PHONY: helm-deps
+helm-deps:  ## Roda helm dependency update em todos os charts com dependências
+	@printf "$(BLUE)→ helm dependency update$(RESET)\n"
+	@for chart in $(CHART_DIRS); do \
+	    if [ -f "$$chart/Chart.yaml" ] && grep -q '^dependencies:' "$$chart/Chart.yaml"; then \
+	        echo "  $$chart"; \
+	        helm dependency update "$$chart" >/dev/null 2>&1 || \
+	            { echo "  ✗ falha em $$chart"; exit 1; }; \
+	    fi; \
+	done
+
+.PHONY: helm-template
+helm-template:  ## Renderiza todos os charts × environments (smoke local)
+	@printf "$(BLUE)→ helm template (todos chart × env)$(RESET)\n"
+	@for chart_dir in $(CHART_DIRS); do \
+	    chart_name=$$(basename "$$chart_dir"); \
+	    for env in $(ENVS); do \
+	        OUT=$$(helm template "$$chart_name" "$$chart_dir" \
+	                -f "environments/$$env/values.yaml" 2>&1); \
+	        if echo "$$OUT" | grep -q "Error"; then \
+	            printf "  $(RED)✗$(RESET) $$chart_name × $$env\n"; \
+	            echo "$$OUT" | grep -A2 Error | head -5; \
+	        else \
+	            KINDS=$$(echo "$$OUT" | grep -c "^kind:" || true); \
+	            printf "  $(GREEN)✓$(RESET) $$chart_name × $$env  ($$KINDS recursos)\n"; \
+	        fi; \
+	    done; \
+	done
+
+.PHONY: helm-docs
+helm-docs:  ## Gera README.md dos charts a partir de values.yaml e README.md.gotmpl
+	@printf "$(BLUE)→ helm-docs$(RESET)\n"
+	@if ! command -v $(HELM_DOCS) >/dev/null 2>&1; then \
+	    printf "$(RED)✗ helm-docs não encontrado. Instalar:$(RESET)\n"; \
+	    echo "    go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest"; \
+	    echo "  ou usar via docker: HELM_DOCS='docker run --rm -v \"\$$(pwd):/work\" -w /work jnorwood/helm-docs:latest helm-docs' make helm-docs"; \
+	    exit 1; \
+	fi
+	$(HELM_DOCS) --chart-search-root=. --chart-to-generate=apps,platform
+
+# ============================================================================
+# Outros
+# ============================================================================
+
+.PHONY: clean
+clean:  ## Remove charts/ baixados, .tgz e arquivos temporários
+	@printf "$(BLUE)→ clean$(RESET)\n"
+	@find . -type d -name 'charts' -not -path './node_modules/*' -exec rm -rf {} + 2>/dev/null || true
+	@find . -type f -name '*.tgz' -not -path './node_modules/*' -delete 2>/dev/null || true
+	@find . -type f -name 'Chart.lock' -not -path './node_modules/*' -delete 2>/dev/null || true
+	@printf "$(GREEN)✓ limpo$(RESET)\n"
+
+.PHONY: list-charts
+list-charts:  ## Lista todos os charts existentes (apps/ e platform/)
+	@for chart in $(CHART_DIRS); do echo "  $$chart"; done
+
+.PHONY: list-envs
+list-envs:  ## Lista todos os environments existentes
+	@for env in $(ENVS); do echo "  $$env"; done
+
+# Default target
+.DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,14 @@ markdown-lint:  ## Roda markdownlint-cli2 em todos os .md
 	$(MARKDOWNLINT) '**/*.md' '!**/charts/**' '!**/node_modules/**'
 
 .PHONY: shellcheck
-shellcheck:  ## Roda shellcheck em scripts/*.sh
+shellcheck:  ## Roda shellcheck em scripts/*.sh (skip gracefully se não instalado)
 	@printf "$(BLUE)→ shellcheck$(RESET)\n"
-	shellcheck scripts/*.sh
+	@if command -v shellcheck >/dev/null 2>&1; then \
+	    shellcheck scripts/*.sh; \
+	else \
+	    printf "$(YELLOW)⚠ shellcheck não instalado localmente — pulando (CI cobre via ludeeus/action-shellcheck)$(RESET)\n"; \
+	    printf "  Instalar: pacman -S shellcheck (Arch) | apt install shellcheck (Ubuntu)\n"; \
+	fi
 
 .PHONY: schema-validate
 schema-validate:  ## Valida values.yaml dos environments contra os schemas dos charts
@@ -121,7 +126,9 @@ schema-validate:  ## Valida values.yaml dos environments contra os schemas dos c
 lint: yaml-lint helm-lint markdown-lint shellcheck  ## Roda todos os linters
 
 .PHONY: validate
-validate: lint helm-deps schema-validate  ## Lint + render de templates contra schemas
+validate: helm-deps lint schema-validate  ## Lint + render de templates contra schemas
+# Ordem importa: helm-deps PRIMEIRO popula charts/ — sem isso, helm-lint e
+# schema-validate podem falhar em fresh checkout com "missing in charts/ directory".
 
 .PHONY: all
 all: validate  ## Alias de validate (default do CI)
@@ -162,10 +169,13 @@ helm-template:  ## Renderiza todos os charts × environments (smoke local)
 .PHONY: helm-docs
 helm-docs:  ## Gera README.md dos charts a partir de values.yaml e README.md.gotmpl
 	@printf "$(BLUE)→ helm-docs$(RESET)\n"
-	@if ! command -v $(HELM_DOCS) >/dev/null 2>&1; then \
-	    printf "$(RED)✗ helm-docs não encontrado. Instalar:$(RESET)\n"; \
-	    echo "    go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest"; \
-	    echo "  ou usar via docker: HELM_DOCS='docker run --rm -v \"\$$(pwd):/work\" -w /work jnorwood/helm-docs:latest helm-docs' make helm-docs"; \
+	@# Tenta invocar HELM_DOCS --version diretamente. Funciona com binário simples
+	@# (`helm-docs`) e com wrapper docker (`docker run ... jnorwood/helm-docs ...`).
+	@# `command -v` não funcionaria com strings que contêm argumentos.
+	@if ! $(HELM_DOCS) --version >/dev/null 2>&1; then \
+	    printf "$(RED)✗ helm-docs não disponível (HELM_DOCS=$(HELM_DOCS))$(RESET)\n"; \
+	    echo "  Instalar: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest"; \
+	    echo "  Ou via docker: HELM_DOCS='docker run --rm -v \"\$$(pwd):/work\" -w /work jnorwood/helm-docs:latest helm-docs' make helm-docs"; \
 	    exit 1; \
 	fi
 	$(HELM_DOCS) --chart-search-root=. --chart-to-generate=apps,platform

--- a/Makefile
+++ b/Makefile
@@ -151,17 +151,19 @@ helm-deps:  ## Roda helm dependency update em todos os charts com dependências
 .PHONY: helm-template
 helm-template:  ## Renderiza todos os charts × environments (smoke local)
 	@printf "$(BLUE)→ helm template (todos chart × env)$(RESET)\n"
+	@# Capturar exit code via `if helm template`, não `OUT=$(helm template ...)`.
+	@# Com .SHELLFLAGS=-euo pipefail -c, atribuição com falha aborta o loop
+	@# imediatamente — usuário nunca vê quais outras combinações falharam.
 	@for chart_dir in $(CHART_DIRS); do \
 	    chart_name=$$(basename "$$chart_dir"); \
 	    for env in $(ENVS); do \
-	        OUT=$$(helm template "$$chart_name" "$$chart_dir" \
-	                -f "environments/$$env/values.yaml" 2>&1); \
-	        if echo "$$OUT" | grep -q "Error"; then \
-	            printf "  $(RED)✗$(RESET) $$chart_name × $$env\n"; \
-	            echo "$$OUT" | grep -A2 Error | head -5; \
-	        else \
+	        if OUT=$$(helm template "$$chart_name" "$$chart_dir" \
+	                -f "environments/$$env/values.yaml" 2>&1); then \
 	            KINDS=$$(echo "$$OUT" | grep -c "^kind:" || true); \
 	            printf "  $(GREEN)✓$(RESET) $$chart_name × $$env  ($$KINDS recursos)\n"; \
+	        else \
+	            printf "  $(RED)✗$(RESET) $$chart_name × $$env\n"; \
+	            echo "$$OUT" | grep -A2 -E "Error|error" | head -5; \
 	        fi; \
 	    done; \
 	done

--- a/platform/vault-transit/values.schema.json
+++ b/platform/vault-transit/values.schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/unifesspa-edu-br/uniplus-infra/platform/vault-transit/values.schema.json",
+  "title": "vault-transit chart values",
+  "description": "Schema dos values do chart platform/vault-transit/. Valida overrides em environments/<env>/values.yaml. Subchart hashicorp/vault tem seu próprio schema — additionalProperties=true permite passar overrides que serão validados pelo upstream.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "vaultTransit": {
+      "type": "object",
+      "description": "Bloco do subchart hashicorp/vault aliasado como vaultTransit (engine Transit only).",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Liga/desliga o subchart inteiro. False em clusters SP1/SP2 (que não rodam Transit)."
+        },
+        "global": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "tlsDisable": {
+              "type": "boolean",
+              "description": "TLS no listener do Vault. Ligar quando cert-manager (#15) entregar certificados."
+            }
+          }
+        },
+        "server": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "ha": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "replicas": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 7,
+                  "description": "1 réplica em lab/sanidade; 3 em hml/prod."
+                }
+              }
+            },
+            "dataStorage": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "size": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(Mi|Gi|Ti)$",
+                  "description": "Tamanho do PVC (ex.: 1Gi, 50Gi)."
+                },
+                "storageClass": {
+                  "type": ["string", "null"],
+                  "description": "Nome da StorageClass (ex.: lab-local-nvme). null usa a default do cluster."
+                }
+              }
+            },
+            "auditStorage": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "size": { "type": "string", "pattern": "^[0-9]+(Mi|Gi|Ti)$" },
+                "storageClass": { "type": ["string", "null"] }
+              }
+            },
+            "resources": { "$ref": "#/$defs/k8sResources" },
+            "service": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+                },
+                "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+                "targetPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+                "nodePort": {
+                  "type": "integer",
+                  "minimum": 30000,
+                  "maximum": 32767,
+                  "description": "NodePort range padrão K8s (30000-32767)."
+                }
+              }
+            }
+          }
+        },
+        "injector": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Vault Transit não usa injector — sempre false."
+            }
+          }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "description": "Propriedades específicas do vault-transit. Outros charts (vault) podem adicionar props neste mesmo bloco — additionalProperties=true permite isso.",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "allowedSourceCidrs": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[0-9.]+/[0-9]+$" },
+          "description": "CIDRs autorizados a chamar o endpoint Transit. Vazio bloqueia ingress externo."
+        },
+        "traefikNamespace": {
+          "type": "string",
+          "description": "Namespace do Traefik no mesmo cluster."
+        }
+      }
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "interval": { "type": "string", "pattern": "^[0-9]+[smh]$" },
+        "port": { "type": "string" },
+        "scheme": { "type": "string", "enum": ["http", "https"] },
+        "tlsConfig": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "host": { "type": "string" }
+      }
+    }
+  },
+  "$defs": {
+    "k8sResources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "requests": { "$ref": "#/$defs/k8sResourceList" },
+        "limits": { "$ref": "#/$defs/k8sResourceList" }
+      }
+    },
+    "k8sResourceList": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": ["string", "integer"],
+          "description": "ex.: 100m, 500m, 1, 2"
+        },
+        "memory": {
+          "type": "string",
+          "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$"
+        }
+      }
+    }
+  }
+}

--- a/platform/vault/values.schema.json
+++ b/platform/vault/values.schema.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/unifesspa-edu-br/uniplus-infra/platform/vault/values.schema.json",
+  "title": "vault chart values",
+  "description": "Schema dos values do chart platform/vault/. Valida overrides em environments/<env>/values.yaml. Subchart hashicorp/vault tem seu próprio schema — additionalProperties=true permite passar overrides que serão validados pelo upstream.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "vault": {
+      "type": "object",
+      "description": "Bloco do subchart hashicorp/vault.",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Liga/desliga o subchart. False em PA1 (que só hospeda Vault Transit)."
+        },
+        "global": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "tlsDisable": {
+              "type": "boolean",
+              "description": "TLS no listener interno do Vault. Default true até cert-manager (#15) entregar."
+            }
+          }
+        },
+        "injector": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "replicas": { "type": "integer", "minimum": 1 },
+            "resources": { "$ref": "#/$defs/k8sResources" }
+          }
+        },
+        "server": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "image": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "repository": {
+                  "type": "string",
+                  "description": "Imagem do Vault (default hashicorp/vault)."
+                },
+                "tag": {
+                  "type": "string",
+                  "description": "Versão do Vault (ex.: 1.21.2)."
+                }
+              }
+            },
+            "ha": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "replicas": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 7,
+                  "description": "Sempre 3 conforme ADR-007 (topologia idêntica em todas as fases)."
+                },
+                "raft": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "setNodeId": { "type": "boolean" },
+                    "config": {
+                      "type": "string",
+                      "description": "HCL config string. Cada environment SP1/SP2 substitui esta para incluir seal \"transit\"."
+                    }
+                  }
+                }
+              }
+            },
+            "dataStorage": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "size": { "type": "string", "pattern": "^[0-9]+(Mi|Gi|Ti)$" },
+                "storageClass": {
+                  "type": ["string", "null"],
+                  "description": "Nome da StorageClass (ex.: lab-local-nvme, prod-local-nvme). null usa a default do cluster."
+                },
+                "mountPath": { "type": "string" }
+              }
+            },
+            "auditStorage": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "size": { "type": "string", "pattern": "^[0-9]+(Mi|Gi|Ti)$" },
+                "storageClass": { "type": ["string", "null"] }
+              }
+            },
+            "resources": { "$ref": "#/$defs/k8sResources" },
+            "extraSecretEnvironmentVars": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["envName", "secretName", "secretKey"],
+                "properties": {
+                  "envName": { "type": "string" },
+                  "secretName": { "type": "string" },
+                  "secretKey": { "type": "string" }
+                }
+              }
+            },
+            "extraVolumes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["type", "name"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["secret", "configMap"]
+                  },
+                  "name": { "type": "string" }
+                }
+              }
+            },
+            "service": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "externalSecretsNamespace": { "type": "string" },
+        "traefikNamespace": { "type": "string" },
+        "transitEndpointCidrs": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[0-9.]+/[0-9]+$" },
+          "description": "CIDRs autorizados como destino do egress Transit. Vazio bloqueia auto-unseal."
+        },
+        "transitEndpointPorts": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1, "maximum": 65535 },
+          "description": "Portas do endpoint Transit. Lab=30200 (NodePort); prod=443 (HTTPS)."
+        }
+      }
+    },
+    "vaultTransit": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Override do chart platform/vault-transit/ neste cluster (normalmente enabled=false em SP1/SP2).",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "interval": { "type": "string", "pattern": "^[0-9]+[smh]$" },
+        "port": { "type": "string" },
+        "scheme": { "type": "string", "enum": ["http", "https"] },
+        "tlsConfig": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "host": { "type": "string" },
+        "entryPoint": { "type": "string" }
+      }
+    }
+  },
+  "$defs": {
+    "k8sResources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "requests": { "$ref": "#/$defs/k8sResourceList" },
+        "limits": { "$ref": "#/$defs/k8sResourceList" }
+      }
+    },
+    "k8sResourceList": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": { "type": ["string", "integer"] },
+        "memory": { "type": "string", "pattern": "^[0-9]+(Ki|Mi|Gi|Ti)$" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #35

## Resumo

Entrega o tooling pendente da #35 (sub-issue derivada do #13): **Makefile** com targets de validação local, **`values.schema.json`** para os charts platform/vault/ e platform/vault-transit/, **`.helm-docs.yaml`** para geração de READMEs e **CI gate de schema validation** via novo job no workflow.

Já tinha sido entregue em #13:
- yamllint excluindo `**/templates/`
- markdownlint config (`.markdownlint.jsonc`)
- CI gate real para yaml-lint / helm-lint / markdown-lint

## O que entra

### Makefile

Centraliza os comandos do CI e operações de desenvolvimento. `make help` lista todos os targets categorizados (Validação / Helm / Outros):

```bash
make lint              # roda todos os linters
make validate          # lint + helm-deps + schema-validate
make helm-template     # renderiza todos chart × env (smoke local)
make schema-validate   # valida values dos environments contra schemas
make helm-docs         # gera README a partir de values (exige helm-docs)
```

### values.schema.json

Schemas JSON Draft 2020-12 para `platform/vault/` e `platform/vault-transit/`. Helm aplica automaticamente quando o arquivo existe — bloqueia overrides com:

- `replicas` fora de `1-7`
- `size` de PVC fora do pattern `^[0-9]+(Mi|Gi|Ti)$`
- `service.type` fora de `[ClusterIP, NodePort, LoadBalancer]`
- `nodePort` fora de `30000-32767`
- `transitEndpointCidrs` sem formato CIDR
- `transitEndpointPorts` fora de `1-65535`
- `serviceMonitor.scheme` fora de `[http, https]`
- `extraSecretEnvironmentVars` sem campos obrigatórios

`additionalProperties: true` em blocos compartilhados entre os dois charts (`networkPolicy`, `serviceMonitor`, `ingress`) — necessário porque `environments/<env>/values.yaml` é lido pelos dois charts.

### CI gate de schema

Novo job `schema-validate` no `.github/workflows/validate.yml`. Renderiza cada chart × cada environment com `helm template`, ativando validação automática de schema.

Resultado: agora qualquer override em `environments/*/values.yaml` que viole o schema bloqueia o merge.

### `.helm-docs.yaml`

Configuração para `helm-docs` ([norwoodj/helm-docs](https://github.com/norwoodj/helm-docs)). Não regenera READMEs existentes (`ignore-non-descriptions: true`). Migração de cada chart para o formato helm-docs (anotar `values.yaml` com `# --` comments) é gradual, sem urgência.

### CONTRIBUTING.md

Atualiza para referenciar os targets reais do Makefile (antes mencionava `make kube-validate` que não existia). Tabela com targets individuais úteis. `values.schema.json` agora **obrigatório** para charts em `platform/` (padrão estabelecido por vault/vault-transit).

## Política de aprovação

**Não toca `environments/prod-*`**. 1 aprovação suficiente.

- Humano: @jf2s
- Automático: Codex AI (recomendado)

## Test plan

Validado localmente:

- [x] `make help` → lista 12 targets categorizados.
- [x] `make yaml-lint` → exit 0.
- [x] `make helm-lint` → 8 charts passam.
- [x] `make markdown-lint` → 53 arquivos, 0 erros.
- [x] `make helm-template` → 48 combinações chart × env (com 6 envs e 8 charts) renderizam corretamente.
- [x] `make schema-validate` → 12 combinações chart × env (vault e vault-transit) passam.
- [x] Schema rejeita corretamente: `replicas=10` → erro "maximum: got 10, want 7".
- [x] Schema rejeita corretamente: `size=5gigs` → erro "does not match pattern".
- [x] Schema aceita: `replicas=5` → 19 recursos gerados.
- [x] CI workflow lint (`yamllint .github/workflows/validate.yml`) → exit 0.

Validação no PR (CI rodará automaticamente):

- [ ] Job `Schema Validate` passa no PR (novo).
- [ ] Demais 4 jobs (yaml-lint, helm-lint, shellcheck, markdown-lint) seguem passando.

## O que NÃO entra

Estas extensões ficam para PRs futuros (não bloqueiam essa entrega):

- Migração dos READMEs hand-written para o formato `helm-docs` (anotar `values.yaml`, criar `README.md.gotmpl`). Sub-issue futura quando houver largura de banda.
- `kubeconform`/`kubeval` como gate adicional (validação contra schema do K8s, não do chart). Pode entrar como Make target + CI job em sub-issue futura.
- Schemas para os outros charts em `apps/` (uniplus-web, uniplus-api-*, etc.) — atualmente são placeholders sem `templates/`. Adicionar quando os charts forem efetivamente preenchidos (bloqueado pelos PRs `#2`).

## Commits

6 commits atômicos (rebase merge), conventional commits em pt-BR:

```
efe2e59 chore(ci): adicionar job schema-validate ao workflow Validate
9711761 docs(contributing): atualizar com targets reais do Makefile e tooling
d2dceb9 chore(tooling): adicionar .helm-docs.yaml para geração automática de READMEs
52f0b59 chore(tooling): adicionar values.schema.json para vault e vault-transit
460c5f2 chore(tooling): adicionar Makefile com targets de validação e helm
```

(O 6º commit `efe2e59` adiciona o job CI; já listado acima.)
