### PR TITLE
fix(tooling): helm-template grep guard para não abortar loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,9 @@ helm-template:  ## Renderiza todos os charts × environments (smoke local)
 	@# Capturar exit code via `if helm template`, não `OUT=$(helm template ...)`.
 	@# Com .SHELLFLAGS=-euo pipefail -c, atribuição com falha aborta o loop
 	@# imediatamente — usuário nunca vê quais outras combinações falharam.
+	@# No ramo de falha, o `grep | head` pode não encontrar 'Error/error'
+	@# (ex.: 'helm: command not found') e, sob pipefail, exit 1 do grep
+	@# abortaria o loop — fallback para `tail` garante que algo seja exibido.
 	@for chart_dir in $(CHART_DIRS); do \
 	    chart_name=$$(basename "$$chart_dir"); \
 	    for env in $(ENVS); do \
@@ -163,7 +166,8 @@ helm-template:  ## Renderiza todos os charts × environments (smoke local)
 	            printf "  $(GREEN)✓$(RESET) $$chart_name × $$env  ($$KINDS recursos)\n"; \
 	        else \
 	            printf "  $(RED)✗$(RESET) $$chart_name × $$env\n"; \
-	            echo "$$OUT" | grep -A2 -E "Error|error" | head -5; \
+	            { echo "$$OUT" | grep -A2 -E "Error|error" | head -5 \
+	                || echo "$$OUT" | tail -10; } || true; \
 	        fi; \
 	    done; \
 	done


### PR DESCRIPTION
Fix do finding [tardio do Codex no PR #39](https://github.com/unifesspa-edu-br/uniplus-infra/pull/39#discussion_r3178776454) que ficou não-resolvido (criado entre meu último push e o approve do jf2s — exigiu `--admin` para mergear o #39).

## Bug residual

Após o commit `b21113d` (PR #39) que reescreveu o pattern `OUT=$(...); if grep` para `if OUT=$(...); then ... else ...`, ainda restou um caminho de falha no ramo `else` do recipe `helm-template`:

```makefile
echo "$OUT" | grep -A2 -E "Error|error" | head -5
```

Sob `.SHELLFLAGS := -euo pipefail -c`, se a saída de `helm template` falhou **sem** as palavras "Error" ou "error" (ex.: `helm: command not found`, processo killed, OOM), `grep` retorna exit 1 → `pipefail` propaga → recipe aborta antes de continuar a iteração da matriz chart × env.

Reprodução:

```console
$ bash -c 'set -euo pipefail; echo "helm: command not found" | grep -A2 -E "Error|error" | head -5'
$ echo $?
1
```

## Fix

```makefile
{ echo "$OUT" | grep -A2 -E "Error|error" | head -5 \
    || echo "$OUT" | tail -10; } || true;
```

- Tenta `grep` primeiro (output mais útil quando helm produz erro estruturado).
- Fallback para `tail -10` garante que algo seja exibido mesmo com saída atípica.
- `|| true` externo como defesa final — qualquer falha residual no ramo diagnóstico não propaga.

## Test plan

- [x] Reprodução do bug isolado: `bash -c 'set -euo pipefail; echo "helm: command not found" | grep ...'` → exit 1
- [x] `make helm-template` (PATH normal) → 36 combinações chart × env, todas verdes
- [x] `make validate` → 6 jobs passam
- [x] CI rodará automaticamente

## Tamanho

1 commit, 5 inserções / 1 deleção, só o `Makefile`.

Refs: #35, comment não-resolvido [no PR #39](https://github.com/unifesspa-edu-br/uniplus-infra/pull/39#discussion_r3178776454)
