### PR TITLE
security(vault/scripts): hardening NetworkPolicy egress, TLS auto-unseal lab e supply chain bootstrap

### DIFF
--- a/environments/lab-pa1/values.yaml
+++ b/environments/lab-pa1/values.yaml
@@ -34,14 +34,38 @@ vaultTransit:
   enabled: true
 
   global:
-    # cert-manager (#15) ainda placeholder — TLS interno desabilitado por enquanto.
-    # Habilitar quando #14 + #15 estiverem prontos.
-    tlsDisable: true
+    # TLS habilitado com cert self-signed gerado pelo bootstrap-lab.sh (achado #37).
+    # Secret `vault-transit-tls` criado em namespace `vault-transit` durante bootstrap.
+    # Quando cert-manager (#15) estiver pronto, substituir pelo cert gerenciado.
+    tlsDisable: false
 
   server:
     ha:
       enabled: false
       replicas: 1
+
+    # Monta o Secret TLS gerado pelo bootstrap em /vault/userconfig/vault-transit-tls/.
+    extraVolumes:
+      - type: secret
+        name: vault-transit-tls
+
+    # Config completa do listener com TLS habilitado.
+    standalone:
+      config: |
+        ui = true
+
+        listener "tcp" {
+          address         = "[::]:8200"
+          cluster_address = "[::]:8201"
+          tls_cert_file   = "/vault/userconfig/vault-transit-tls/tls.crt"
+          tls_key_file    = "/vault/userconfig/vault-transit-tls/tls.key"
+        }
+
+        storage "file" {
+          path = "/vault/data"
+        }
+
+        service_registration "kubernetes" {}
 
     dataStorage:
       size: 1Gi

--- a/environments/lab-sp1/values.yaml
+++ b/environments/lab-sp1/values.yaml
@@ -110,8 +110,8 @@ vault:
         # o bloco `seal "transit"` apontando para o Vault Transit em lab-pa1.
         # O endpoint NodePort 192.168.0.20:30200 é exposto pelo cluster K3s
         # de lab-pa1 (rede plana 192.168.0.0/16 do laboratório).
-        # tls_skip_verify=true aceita cert self-signed enquanto cert-manager
-        # (#15) ainda é placeholder.
+        # tls_skip_verify=true aceita cert self-signed gerado pelo bootstrap
+        # (achado #37 — Transit agora serve HTTPS).
         config: |
           ui = true
 
@@ -126,7 +126,7 @@ vault:
           }
 
           seal "transit" {
-            address         = "http://192.168.0.20:30200"
+            address         = "https://192.168.0.20:30200"
             token           = "${VAULT_TRANSIT_TOKEN}"
             disable_renewal = "false"
             key_name        = "autounseal"

--- a/environments/lab-sp2/values.yaml
+++ b/environments/lab-sp2/values.yaml
@@ -117,7 +117,7 @@ vault:
           }
 
           seal "transit" {
-            address         = "http://192.168.0.20:30200"
+            address         = "https://192.168.0.20:30200"
             token           = "${VAULT_TRANSIT_TOKEN}"
             disable_renewal = "false"
             key_name        = "autounseal"

--- a/platform/vault/templates/networkpolicy.yaml
+++ b/platform/vault/templates/networkpolicy.yaml
@@ -77,10 +77,18 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
-    # Kubernetes API (service registration).
-    - ports:
+    # Kubernetes API (service registration). Restrito ao service CIDR do cluster
+    # para impedir egress livre a *:443/*:6443 na internet (achado de segurança).
+    {{- with .Values.networkPolicy.kubeApiCidrs }}
+    - to:
+        {{- range . }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
         - protocol: TCP
           port: 6443
         - protocol: TCP
           port: 443
+    {{- end }}
 {{- end }}

--- a/platform/vault/values.yaml
+++ b/platform/vault/values.yaml
@@ -115,6 +115,12 @@ networkPolicy:
   transitEndpointCidrs: []
   transitEndpointPorts:
     - 8200
+  # CIDRs restritos para egress ao Kubernetes API server (service registration).
+  # Padrão: service CIDR do K3s (10.43.0.0/16) — cobre o ClusterIP do
+  # serviço `kubernetes` em `default` sem permitir destinos externos em 443/6443.
+  # Ajustar em environments/ se o service CIDR do cluster for diferente.
+  kubeApiCidrs:
+    - 10.43.0.0/16
 
 # ServiceMonitor para Prometheus (Vault expõe métricas em /v1/sys/metrics).
 # Desligado por default — ligar quando #26 (Prometheus chart) estiver pronto.

--- a/platform/vault/values.yaml
+++ b/platform/vault/values.yaml
@@ -119,6 +119,9 @@ networkPolicy:
   # Padrão: service CIDR do K3s (10.43.0.0/16) — cobre o ClusterIP do
   # serviço `kubernetes` em `default` sem permitir destinos externos em 443/6443.
   # Ajustar em environments/ se o service CIDR do cluster for diferente.
+  # ATENÇÃO: lista vazia suprime a regra inteiramente — service_registration
+  # "kubernetes" {} falhará. Só usar [] se o cluster não precisar de
+  # service registration (ex.: Vault sem injeção de secrets via K8s).
   kubeApiCidrs:
     - 10.43.0.0/16
 

--- a/scripts/bootstrap-lab.sh
+++ b/scripts/bootstrap-lab.sh
@@ -21,6 +21,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# ============== Versões pinadas (supply chain) ==============
+# Atualizar ao promover o lab para nova versão estável validada.
+K3S_VERSION="v1.31.4+k3s1"
+HELM_VERSION="v3.16.4"
+CLOUDFLARED_VERSION="2024.12.2"
+
 # ============== Defaults ==============
 ROLE=""
 SKIP_K3S=false
@@ -165,7 +171,10 @@ step_install_docker() {
     os=$(detect_os)
     
     if [[ "$os" == "ubuntu" ]]; then
-        run "curl -fsSL https://get.docker.com | sudo sh"
+        # Pacote do repositório oficial Ubuntu — evita curl-pipe-sh como root.
+        run "sudo apt-get update -qq"
+        run "sudo apt-get install -y docker.io docker-compose-v2"
+        run "sudo systemctl enable --now docker"
         run "sudo usermod -aG docker $USER"
     elif [[ "$os" == "arch" ]]; then
         run "sudo pacman -Sy --noconfirm docker docker-compose"
@@ -208,12 +217,12 @@ step_install_k3s() {
         exit 1
     fi
 
-    log_info "Instalando K3s (cluster independente para $ROLE)..."
+    log_info "Instalando K3s $K3S_VERSION (cluster independente para $ROLE)..."
 
     local node_ip
     node_ip=$(hostname -I | awk '{print $1}')
 
-    run "curl -sfL https://get.k3s.io | sh -s - \
+    run "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=$K3S_VERSION sh -s - \
         --node-name $node_name \
         --cluster-init \
         --tls-san $node_name \
@@ -234,10 +243,17 @@ step_install_helm() {
         log_success "Helm já instalado: $(helm version --short)"
         return
     fi
-    
-    log_info "Instalando Helm..."
-    run "curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash"
-    log_success "Helm instalado."
+
+    log_info "Instalando Helm $HELM_VERSION..."
+    local helm_tar="/tmp/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+    local helm_sha="/tmp/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum"
+    run "curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o $helm_tar"
+    run "curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum -o $helm_sha"
+    run "sha256sum -c $helm_sha"
+    run "tar -xzf $helm_tar -C /tmp linux-amd64/helm"
+    run "sudo install /tmp/linux-amd64/helm /usr/local/bin/helm"
+    run "rm -rf $helm_tar $helm_sha /tmp/linux-amd64"
+    log_success "Helm $HELM_VERSION instalado."
 }
 
 step_install_argocd() {
@@ -276,6 +292,34 @@ step_setup_pa1_extras() {
     echo "  3. docker compose up -d"
 }
 
+step_setup_vault_transit_tls() {
+    if [[ "$ROLE" != "pa1" ]]; then
+        return
+    fi
+
+    log_info "Gerando certificado TLS self-signed para Vault Transit (achado #37)..."
+
+    local cert_dir="/tmp/vault-transit-tls-$$"
+    run "mkdir -p $cert_dir"
+    run "openssl req -x509 -newkey rsa:4096 \
+        -keyout $cert_dir/tls.key \
+        -out $cert_dir/tls.crt \
+        -days 3650 -nodes \
+        -subj '/CN=vault-transit.uniplus.lab/O=UniPlus Lab' \
+        -addext 'subjectAltName=IP:192.168.0.20,DNS:vault-transit'"
+
+    run "kubectl create namespace vault-transit --dry-run=client -o yaml | kubectl apply -f -"
+    run "kubectl create secret tls vault-transit-tls \
+        --cert=$cert_dir/tls.crt \
+        --key=$cert_dir/tls.key \
+        -n vault-transit \
+        --dry-run=client -o yaml | kubectl apply -f -"
+
+    run "rm -rf $cert_dir"
+    log_success "Secret vault-transit-tls criado em namespace vault-transit."
+    log_warn "Cert self-signed válido por 3650 dias. Substituir por cert gerenciado quando cert-manager (#15) estiver pronto."
+}
+
 step_setup_cloudflared() {
     if $SKIP_CLOUDFLARED; then
         log_warn "Pulando Cloudflare Tunnel (use --enable-cloudflared para incluir)"
@@ -285,9 +329,15 @@ step_setup_cloudflared() {
     if command -v cloudflared &> /dev/null; then
         log_success "cloudflared já instalado"
     else
-        log_info "Instalando cloudflared..."
-        run "curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /tmp/cloudflared"
-        run "sudo install /tmp/cloudflared /usr/local/bin/cloudflared"
+        log_info "Instalando cloudflared $CLOUDFLARED_VERSION..."
+        local cf_bin="/tmp/cloudflared-linux-amd64"
+        local cf_sha="/tmp/cloudflared-linux-amd64.sha256"
+        run "curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64 -o $cf_bin"
+        run "curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64.sha256 -o $cf_sha"
+        # Formato do arquivo: apenas o hash, sem nome de arquivo — usar sha256sum -c
+        run "echo \"\$(cat $cf_sha)  $cf_bin\" | sha256sum -c"
+        run "sudo install $cf_bin /usr/local/bin/cloudflared"
+        run "rm -f $cf_bin $cf_sha"
     fi
     
     log_warn "Configuração interativa do Cloudflare Tunnel:"
@@ -348,6 +398,9 @@ step_summary() {
         echo ""
         echo "  5. Subir containers Docker isolados (etcd, keycloak-master,"
         echo "     minio-master, backup-target) — ver passo manual acima."
+        echo ""
+        echo "  Nota: cert TLS self-signed do Transit criado em vault-transit/vault-transit-tls."
+        echo "        Substituir por cert gerenciado quando cert-manager (#15) estiver pronto."
     fi
     
     echo ""
@@ -368,5 +421,6 @@ step_install_k3s
 step_install_helm
 step_install_argocd
 step_setup_pa1_extras
+step_setup_vault_transit_tls
 step_setup_cloudflared
 step_summary

--- a/scripts/bootstrap-lab.sh
+++ b/scripts/bootstrap-lab.sh
@@ -249,7 +249,9 @@ step_install_helm() {
     local helm_sha="/tmp/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum"
     run "curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o $helm_tar"
     run "curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum -o $helm_sha"
-    run "sha256sum -c $helm_sha"
+    # O arquivo sha256sum contém o basename sem path — extrair só o hash e
+    # construir a linha com o path completo para sha256sum -c funcionar.
+    run "echo \"\$(awk '{print \$1}' $helm_sha)  $helm_tar\" | sha256sum -c"
     run "tar -xzf $helm_tar -C /tmp linux-amd64/helm"
     run "sudo install /tmp/linux-amd64/helm /usr/local/bin/helm"
     run "rm -rf $helm_tar $helm_sha /tmp/linux-amd64"
@@ -304,7 +306,7 @@ step_setup_vault_transit_tls() {
     run "openssl req -x509 -newkey rsa:4096 \
         -keyout $cert_dir/tls.key \
         -out $cert_dir/tls.crt \
-        -days 3650 -nodes \
+        -days 3650 -noenc \
         -subj '/CN=vault-transit.uniplus.lab/O=UniPlus Lab' \
         -addext 'subjectAltName=IP:192.168.0.20,DNS:vault-transit'"
 


### PR DESCRIPTION
## Contexto

Endereça os 3 achados de segurança da issue #37 (security review pós-merge do PR #36).

## Achado 1 — NetworkPolicy egress irrestrito (`MEDIUM`)

**Arquivo:** `platform/vault/templates/networkpolicy.yaml`

A regra de egress para o Kubernetes API (`6443/443`) não tinha `to:`, permitindo qualquer destino na internet.

**Fix:** adicionado `kubeApiCidrs` no `values.yaml` (default `10.43.0.0/16` — service CIDR K3s) e a regra agora usa `ipBlock` explícito. Configurável por environment.

## Achado 2 — Token de auto-unseal em HTTP claro no lab (`MEDIUM`)

**Arquivos:** `environments/lab-pa1/values.yaml`, `environments/lab-sp1/values.yaml`, `environments/lab-sp2/values.yaml`

O seal Transit usava `http://192.168.0.20:30200`, enviando `X-Vault-Token` em texto claro na rede 192.168.0.0/16 do lab.

**Fix:** Vault Transit em `lab-pa1` configurado com TLS (cert self-signed, gerado pelo `bootstrap-lab.sh --role=pa1` via `openssl` + Secret K8s). `lab-sp1`/`lab-sp2` passam a usar `https://` mantendo `tls_skip_verify=true`. Quando `cert-manager` (#15) estiver pronto, substituir pelo cert gerenciado.

## Achado 3 — `bootstrap-lab.sh` curl-pipe-sudo-sh sem verificação (`LOW-MEDIUM`)

**Arquivo:** `scripts/bootstrap-lab.sh`

- **Docker (Ubuntu):** substituído `curl ... | sudo sh` por `apt-get install docker.io` (pacote nativo).
- **K3s:** versão pinada via `INSTALL_K3S_VERSION=v1.31.4+k3s1`.
- **Helm:** tarball baixado da URL versionada + verificação `sha256sum`.
- **cloudflared:** versão pinada `2024.12.2` + verificação SHA256 do release.

Versões centralizadas em constantes no topo do script para facilitar atualização.

## Test plan

- [ ] `helm lint platform/vault/` — sem erros
- [ ] `helm template platform/vault/ -f environments/lab-sp1/values.yaml` — NetworkPolicy egress tem `ipBlock: 10.43.0.0/16`
- [ ] `helm template platform/vault-transit/ -f environments/lab-pa1/values.yaml` — porta `https`, cert montado em `/vault/userconfig/vault-transit-tls/`
- [ ] `bash -n scripts/bootstrap-lab.sh` — sintaxe OK
- [ ] Smoke em lab: `bootstrap-lab.sh --role=pa1 --dry-run` lista os passos sem curl-pipe-sh

Closes #37