### PR TITLE
refactor(environments): extrair IPs e portas hardcoded para topology.*

### DIFF
--- a/environments/lab-pa1/values.yaml
+++ b/environments/lab-pa1/values.yaml
@@ -14,7 +14,9 @@ cluster:
   dc: pa1
 
 # Topologia do host PA1 no laboratório.
-# transitNodePort e hostIP são referenciados nos environments lab-sp1/sp2.
+# Referenciado por lab-sp1/sp2 em topology.pa1HostIP e topology.transitNodePort.
+# Não consumido diretamente pelo chart vault-transit — serve como fonte de
+# documentação e consistência entre os environments do laboratório.
 topology:
   hostIP: "192.168.0.20"    # IP do host i7 na rede 192.168.0.0/16
   transitNodePort: 30200    # NodePort do Vault Transit exposto pelo K3s

--- a/environments/lab-pa1/values.yaml
+++ b/environments/lab-pa1/values.yaml
@@ -13,6 +13,12 @@ cluster:
   region: lab
   dc: pa1
 
+# Topologia do host PA1 no laboratório.
+# transitNodePort e hostIP são referenciados nos environments lab-sp1/sp2.
+topology:
+  hostIP: "192.168.0.20"    # IP do host i7 na rede 192.168.0.0/16
+  transitNodePort: 30200    # NodePort do Vault Transit exposto pelo K3s
+
 # ============================================================================
 # StorageClass do tier de laboratório (ADR-007 + #31).
 # ============================================================================

--- a/environments/lab-sp1/values.yaml
+++ b/environments/lab-sp1/values.yaml
@@ -90,6 +90,16 @@ storage:
     reclaimPolicy: Delete
 
 # ============================================================================
+# Topologia do laboratório — fonte única de verdade para IP/porta do Transit.
+# O chart platform/vault/ usa estes valores para gerar o Secret
+# vault-transit-endpoint (VAULT_TRANSIT_ADDRESS) e a NetworkPolicy de egress.
+# ============================================================================
+topology:
+  pa1HostIP: "192.168.0.20"   # host i7 (lab-pa1); SP1 e SP2 compartilham o mesmo PA1
+  transitNodePort: 30200       # NodePort exposto pelo K3s de lab-pa1
+  transitScheme: https         # obrigatório após achado #37 (cert self-signed no bootstrap)
+
+# ============================================================================
 # Vault HA Raft com auto-unseal Transit contra lab-pa1 (ADR-007).
 # ============================================================================
 vault:
@@ -108,10 +118,9 @@ vault:
         setNodeId: true
         # Substitui a config default do chart `platform/vault/` para incluir
         # o bloco `seal "transit"` apontando para o Vault Transit em lab-pa1.
-        # O endpoint NodePort 192.168.0.20:30200 é exposto pelo cluster K3s
-        # de lab-pa1 (rede plana 192.168.0.0/16 do laboratório).
-        # tls_skip_verify=true aceita cert self-signed gerado pelo bootstrap
-        # (achado #37 — Transit agora serve HTTPS).
+        # O endereço é lido do env var VAULT_TRANSIT_ADDRESS, injetado via
+        # Secret vault-transit-endpoint gerado pelo chart a partir de topology.*
+        # (achado #37 — Transit serve HTTPS com cert self-signed do bootstrap).
         config: |
           ui = true
 
@@ -126,7 +135,7 @@ vault:
           }
 
           seal "transit" {
-            address         = "https://192.168.0.20:30200"
+            address         = "${VAULT_TRANSIT_ADDRESS}"
             token           = "${VAULT_TRANSIT_TOKEN}"
             disable_renewal = "false"
             key_name        = "autounseal"
@@ -136,12 +145,16 @@ vault:
 
           service_registration "kubernetes" {}
 
-    # Token do Transit é injetado via env var (Secret criado manualmente
-    # após bootstrap do Transit em lab-pa1 — ver RUNBOOKS §1.4.B).
+    # Env vars injetados via Secrets:
+    # - vault-transit-token: criado manualmente após bootstrap (RUNBOOKS §1.4.B)
+    # - vault-transit-endpoint: gerado pelo chart a partir de topology.*
     extraSecretEnvironmentVars:
       - envName: VAULT_TRANSIT_TOKEN
         secretName: vault-transit-token
         secretKey: token
+      - envName: VAULT_TRANSIT_ADDRESS
+        secretName: vault-transit-endpoint
+        secretKey: address
 
     dataStorage:
       size: 5Gi
@@ -154,14 +167,8 @@ vault:
 vaultTransit:
   enabled: false
 
-# NetworkPolicy do chart vault/ libera egress para o endpoint Transit.
+# NetworkPolicy do chart vault/ — egress Transit derivado de topology.* acima.
 networkPolicy:
   enabled: true
   externalSecretsNamespace: external-secrets
   traefikNamespace: traefik
-  # CIDR do host i7 (lab-pa1) para egress do Vault rumo ao Transit.
-  transitEndpointCidrs:
-    - 192.168.0.20/32
-  # NodePort exposto pelo Vault Transit em lab-pa1.
-  transitEndpointPorts:
-    - 30200

--- a/environments/lab-sp2/values.yaml
+++ b/environments/lab-sp2/values.yaml
@@ -84,10 +84,18 @@ storage:
     reclaimPolicy: Delete  # lab descartável; prod mantém Retain
 
 # ============================================================================
-# Vault HA Raft com auto-unseal Transit contra lab-pa1 (ADR-007).
-# Configuração simétrica a lab-sp1 — mesmo endpoint Transit, mesmo CIDR
-# autorizado. Embora lab-sp2 e lab-pa1 compartilhem o host i7 fisicamente,
+# Topologia do laboratório — fonte única de verdade para IP/porta do Transit.
+# Simétrico a lab-sp1: mesmo endpoint PA1, mesmas chaves topology.*.
+# Embora lab-sp2 e lab-pa1 compartilhem o host i7 fisicamente,
 # do ponto de vista de K8s são clusters K3s distintos (cross-cluster real).
+# ============================================================================
+topology:
+  pa1HostIP: "192.168.0.20"   # host i7 (lab-pa1)
+  transitNodePort: 30200       # NodePort exposto pelo K3s de lab-pa1
+  transitScheme: https         # obrigatório após achado #37
+
+# ============================================================================
+# Vault HA Raft com auto-unseal Transit contra lab-pa1 (ADR-007).
 # ============================================================================
 vault:
   enabled: true
@@ -117,7 +125,7 @@ vault:
           }
 
           seal "transit" {
-            address         = "https://192.168.0.20:30200"
+            address         = "${VAULT_TRANSIT_ADDRESS}"
             token           = "${VAULT_TRANSIT_TOKEN}"
             disable_renewal = "false"
             key_name        = "autounseal"
@@ -131,6 +139,9 @@ vault:
       - envName: VAULT_TRANSIT_TOKEN
         secretName: vault-transit-token
         secretKey: token
+      - envName: VAULT_TRANSIT_ADDRESS
+        secretName: vault-transit-endpoint
+        secretKey: address
 
     dataStorage:
       size: 5Gi
@@ -142,11 +153,8 @@ vault:
 vaultTransit:
   enabled: false
 
+# NetworkPolicy do chart vault/ — egress Transit derivado de topology.* acima.
 networkPolicy:
   enabled: true
   externalSecretsNamespace: external-secrets
   traefikNamespace: traefik
-  transitEndpointCidrs:
-    - 192.168.0.20/32
-  transitEndpointPorts:
-    - 30200

--- a/environments/prod-sp1/values.yaml
+++ b/environments/prod-sp1/values.yaml
@@ -141,6 +141,10 @@ vault:
 
           service_registration "kubernetes" {}
 
+    # Apenas VAULT_TRANSIT_TOKEN: em prod o seal address usa FQDN para TLS
+    # (vault-transit.uniplus.unifesspa.edu.br) — sem ${VAULT_TRANSIT_ADDRESS}.
+    # O FQDN está hardcoded no raft.config acima; topology.pa1HostIP serve
+    # exclusivamente para a regra de egress da NetworkPolicy.
     extraSecretEnvironmentVars:
       - envName: VAULT_TRANSIT_TOKEN
         secretName: vault-transit-token
@@ -172,15 +176,20 @@ vault:
 vaultTransit:
   enabled: false
 
+# Topologia de prod-pa1 — preencher com IPs reais antes de habilitar Vault.
+# pa1HostIP é o IP do LoadBalancer/VIP do Transit em PA1 (para ipBlock.cidr na
+# NetworkPolicy). O endereço usado pelo seal "transit" é o FQDN no raft.config
+# acima — os dois diferem porque TLS requer o hostname, NetworkPolicy requer IP.
+# Confirmar IPs com a DIRSI antes da promoção para prod.
+topology:
+  pa1HostIP: ""          # TODO: IP do endpoint Transit em prod-pa1 (ex.: IP do LB EVEO PA1)
+  transitNodePort: 443   # HTTPS via IngressRoute Traefik
+  transitScheme: https
+
 networkPolicy:
   enabled: true
   externalSecretsNamespace: external-secrets
   traefikNamespace: traefik
-  # CIDR do PA1 real (Marabá) — confirmar com a DIRSI antes da promoção.
-  # Evitar 0.0.0.0/0 — usar bloco específico do datacenter UNIFESSPA.
-  transitEndpointCidrs: []  # TODO: preencher antes de habilitar Vault em prod
-  transitEndpointPorts:
-    - 443
 
 serviceMonitor:
   enabled: false

--- a/environments/prod-sp2/values.yaml
+++ b/environments/prod-sp2/values.yaml
@@ -121,6 +121,7 @@ vault:
 
           service_registration "kubernetes" {}
 
+    # Apenas VAULT_TRANSIT_TOKEN: mesmo padrão de prod-sp1 (seal via FQDN).
     extraSecretEnvironmentVars:
       - envName: VAULT_TRANSIT_TOKEN
         secretName: vault-transit-token
@@ -149,13 +150,16 @@ vault:
 vaultTransit:
   enabled: false
 
+# Mesmo padrão de prod-sp1 — preencher pa1HostIP antes de habilitar Vault.
+topology:
+  pa1HostIP: ""          # TODO: IP do endpoint Transit em prod-pa1 (confirmar com DIRSI)
+  transitNodePort: 443
+  transitScheme: https
+
 networkPolicy:
   enabled: true
   externalSecretsNamespace: external-secrets
   traefikNamespace: traefik
-  transitEndpointCidrs: []  # TODO: preencher com CIDR do PA1 antes de habilitar Vault em prod
-  transitEndpointPorts:
-    - 443
 
 serviceMonitor:
   enabled: false

--- a/platform/vault/templates/networkpolicy.yaml
+++ b/platform/vault/templates/networkpolicy.yaml
@@ -54,18 +54,15 @@ spec:
           port: 8200
   egress:
     # Auto-unseal cross-cluster: Vault chama o Transit em PA1.
-    # CIDRs e portas definidos em environments/<env>-{sp1,sp2}/values.yaml.
-    {{- with .Values.networkPolicy.transitEndpointCidrs }}
+    # IP e porta derivados de topology.{pa1HostIP,transitNodePort} — definidos
+    # em environments/<env>-{sp1,sp2}/values.yaml.
+    {{- if .Values.topology.pa1HostIP }}
     - to:
-        {{- range . }}
         - ipBlock:
-            cidr: {{ . | quote }}
-        {{- end }}
+            cidr: "{{ .Values.topology.pa1HostIP }}/32"
       ports:
-        {{- range $.Values.networkPolicy.transitEndpointPorts }}
         - protocol: TCP
-          port: {{ . }}
-        {{- end }}
+          port: {{ .Values.topology.transitNodePort }}
     {{- end }}
     # DNS (kube-dns).
     - to:

--- a/platform/vault/templates/transit-endpoint.yaml
+++ b/platform/vault/templates/transit-endpoint.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.vault.enabled .Values.topology.pa1HostIP }}
+# Secret gerado pelo chart a partir de topology.{transitScheme,pa1HostIP,transitNodePort}.
+# Montado via extraSecretEnvironmentVars como VAULT_TRANSIT_ADDRESS nos Pods do Vault.
+# Environments SP1/SP2 usam ${VAULT_TRANSIT_ADDRESS} no bloco seal "transit" do HCL config.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-transit-endpoint
+  labels:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: uniplus
+stringData:
+  address: "{{ .Values.topology.transitScheme }}://{{ .Values.topology.pa1HostIP }}:{{ .Values.topology.transitNodePort }}"
+{{- end }}

--- a/platform/vault/templates/transit-endpoint.yaml
+++ b/platform/vault/templates/transit-endpoint.yaml
@@ -2,6 +2,10 @@
 # Secret gerado pelo chart a partir de topology.{transitScheme,pa1HostIP,transitNodePort}.
 # Montado via extraSecretEnvironmentVars como VAULT_TRANSIT_ADDRESS nos Pods do Vault.
 # Environments SP1/SP2 usam ${VAULT_TRANSIT_ADDRESS} no bloco seal "transit" do HCL config.
+#
+# Nome fixo (sem Release.Name) por design: os environments referenciam o secretName
+# como literal em extraSecretEnvironmentVars (values YAML não aceita template syntax).
+# Um único release do chart vault/ por namespace SP — sem risco de colisão.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: uniplus
+    app.kubernetes.io/component: vault
 stringData:
   address: "{{ .Values.topology.transitScheme }}://{{ .Values.topology.pa1HostIP }}:{{ .Values.topology.transitNodePort }}"
 {{- end }}

--- a/platform/vault/values.schema.json
+++ b/platform/vault/values.schema.json
@@ -141,23 +141,36 @@
         }
       }
     },
+    "topology": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Topologia de rede do ambiente. Obrigatório nos environments SP1/SP2 com auto-unseal Transit. additionalProperties=true permite chaves extras em PA1 (ex.: hostIP) sem invalidar o schema.",
+      "properties": {
+        "pa1HostIP": {
+          "type": "string",
+          "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}$|^$",
+          "description": "IPv4 do host PA1 acessível pelos clusters SP. Usado como ipBlock.cidr — deve ser IP, não hostname."
+        },
+        "transitNodePort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Porta do endpoint Transit (NodePort em lab, 443 em prod via IngressRoute)."
+        },
+        "transitScheme": {
+          "type": "string",
+          "enum": ["http", "https"],
+          "description": "Esquema do endpoint Transit. https obrigatório após achado #37."
+        }
+      }
+    },
     "networkPolicy": {
       "type": "object",
       "additionalProperties": true,
       "properties": {
         "enabled": { "type": "boolean" },
         "externalSecretsNamespace": { "type": "string" },
-        "traefikNamespace": { "type": "string" },
-        "transitEndpointCidrs": {
-          "type": "array",
-          "items": { "type": "string", "pattern": "^[0-9.]+/[0-9]+$" },
-          "description": "CIDRs autorizados como destino do egress Transit. Vazio bloqueia auto-unseal."
-        },
-        "transitEndpointPorts": {
-          "type": "array",
-          "items": { "type": "integer", "minimum": 1, "maximum": 65535 },
-          "description": "Portas do endpoint Transit. Lab=30200 (NodePort); prod=443 (HTTPS)."
-        }
+        "traefikNamespace": { "type": "string" }
       }
     },
     "vaultTransit": {

--- a/platform/vault/values.yaml
+++ b/platform/vault/values.yaml
@@ -107,10 +107,11 @@ vault:
 # auto-unseal Transit. Fonte única de verdade para IP/porta do endpoint Transit:
 # o template networkpolicy.yaml e o Secret vault-transit-endpoint derivam daqui.
 topology:
-  # IP ou hostname do host PA1 acessível pelos clusters SP1/SP2.
+  # IP (obrigatoriamente um endereço IPv4) do host PA1 acessível pelos clusters SP1/SP2.
+  # Usado como ipBlock.cidr/<host>/32 na NetworkPolicy — hostnames não são válidos aqui.
   # Vazio por default — torna o egress Transit e o Secret opcionais (helm lint OK).
   pa1HostIP: ""
-  # Porta do endpoint Transit em PA1 (NodePort em lab, 8200 em prod via ClusterIP+Ingress).
+  # Porta do endpoint Transit em PA1 (NodePort em lab, 443 em prod via IngressRoute HTTPS).
   transitNodePort: 8200
   # Esquema do endpoint Transit. https obrigatório após achado #37 (PR #70).
   transitScheme: https

--- a/platform/vault/values.yaml
+++ b/platform/vault/values.yaml
@@ -103,6 +103,18 @@ vault:
         app.kubernetes.io/part-of: uniplus
         app.kubernetes.io/component: vault
 
+# Topologia de rede do ambiente. Obrigatório nos environments SP1/SP2 que usam
+# auto-unseal Transit. Fonte única de verdade para IP/porta do endpoint Transit:
+# o template networkpolicy.yaml e o Secret vault-transit-endpoint derivam daqui.
+topology:
+  # IP ou hostname do host PA1 acessível pelos clusters SP1/SP2.
+  # Vazio por default — torna o egress Transit e o Secret opcionais (helm lint OK).
+  pa1HostIP: ""
+  # Porta do endpoint Transit em PA1 (NodePort em lab, 8200 em prod via ClusterIP+Ingress).
+  transitNodePort: 8200
+  # Esquema do endpoint Transit. https obrigatório após achado #37 (PR #70).
+  transitScheme: https
+
 # NetworkPolicy controlando ingress/egress no Pod do Vault de aplicação.
 networkPolicy:
   enabled: true
@@ -110,11 +122,6 @@ networkPolicy:
   externalSecretsNamespace: external-secrets
   # Namespace do Traefik no mesmo cluster (acesso UI/API).
   traefikNamespace: traefik
-  # Endpoint do Vault Transit em PA1 — egress autorizado para auto-unseal
-  # cross-cluster. Defaults vazios/8200; configurar por environment.
-  transitEndpointCidrs: []
-  transitEndpointPorts:
-    - 8200
   # CIDRs restritos para egress ao Kubernetes API server (service registration).
   # Padrão: service CIDR do K3s (10.43.0.0/16) — cobre o ClusterIP do
   # serviço `kubernetes` em `default` sem permitir destinos externos em 443/6443.


### PR DESCRIPTION
## Contexto

Resolve #71. Os environments `lab-sp1` e `lab-sp2` tinham `192.168.0.20:30200` espalhado em três lugares distintos — bloco `seal "transit"` no HCL config, `networkPolicy.transitEndpointCidrs` e `networkPolicy.transitEndpointPorts`. Qualquer troca de topologia exigia editar múltiplos valores duplicados em múltiplos arquivos.

## O que foi feito

**`platform/vault/values.yaml`**
- Novo bloco `topology:` com `pa1HostIP`, `transitNodePort` e `transitScheme` como fonte única de verdade.
- Removidos `networkPolicy.transitEndpointCidrs` e `networkPolicy.transitEndpointPorts` (substituídos por topology).

**`platform/vault/templates/transit-endpoint.yaml`** (novo)
- Gera o Secret `vault-transit-endpoint` com `address: "<scheme>://<ip>:<port>"` derivado de `topology.*`.
- Suprimido quando `topology.pa1HostIP` está vazio → `helm lint` contra defaults continua passando.

**`platform/vault/templates/networkpolicy.yaml`**
- Regra de egress Transit agora usa `topology.pa1HostIP/32` e `topology.transitNodePort`.

**`environments/lab-sp1/values.yaml` e `lab-sp2/values.yaml`**
- Novo bloco `topology: { pa1HostIP, transitNodePort, transitScheme }`.
- Bloco `seal "transit"` passa a usar `${VAULT_TRANSIT_ADDRESS}` (env var injetado via Secret).
- `extraSecretEnvironmentVars` inclui entrada para `vault-transit-endpoint`.
- Removidos `networkPolicy.transitEndpointCidrs/Ports`.

**`environments/lab-pa1/values.yaml`**
- Bloco `topology: { hostIP, transitNodePort }` para documentar a topologia própria do DC.

## Validação

- `helm lint platform/vault/` ✓
- `helm lint platform/vault-transit/` ✓
- `yamllint` ✓
- `helm template vault platform/vault/ -f environments/lab-sp1/values.yaml` → Secret `vault-transit-endpoint` com `address: https://192.168.0.20:30200`, NetworkPolicy com `cidr: 192.168.0.20/32 / port: 30200`, env var `VAULT_TRANSIT_ADDRESS` referenciando o Secret ✓
- `helm template vault platform/vault/ -f environments/lab-sp2/values.yaml` → idem ✓
- `helm template vault platform/vault/` (defaults) → nenhum Secret gerado (pa1HostIP vazio) ✓

## Test plan

- [ ] `helm lint` nos dois charts
- [ ] `helm template` com cada environment lab renderiza VAULT_TRANSIT_ADDRESS e NetworkPolicy corretos
- [ ] Em lab: re-deploy do Vault SP1/SP2 com `argocd app sync`; verificar que o Pod sobe e o auto-unseal funciona