### PR TITLE
feat(scripts): suporte a role standalone em teardown-lab.sh e atualizar README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,44 +1,94 @@
 # Scripts
 
-Scripts auxiliares para setup, validação e teardown do laboratório.
+Scripts de operação do laboratório e do ambiente standalone OCI.
 
 | Script | Função |
 |--------|--------|
-| `bootstrap-lab.sh` | Provisiona laboratório do zero em uma máquina Linux |
-| `validate-cluster.sh` | Valida saúde do cluster (use após bootstrap ou para diagnóstico) |
-| `teardown-lab.sh` | Remove o laboratório (CUIDADO: destrutivo) |
+| `bootstrap-lab.sh` | Provisiona o laboratório do zero em uma máquina Linux (roles sp1/sp2/pa1) |
+| `bootstrap-standalone.sh` | Provisiona o ambiente standalone OCI (roles standalone-k8s e standalone-data) |
+| `validate-cluster.sh` | Valida saúde do cluster de laboratório (sp1/sp2/pa1) |
+| `validate-standalone.sh` | Valida saúde do ambiente standalone OCI (k8s-host + data-host) |
+| `teardown-lab.sh` | Remove o laboratório ou standalone (CUIDADO: destrutivo) |
 
-## Uso
+## Laboratório (sp1 / sp2 / pa1)
 
 ```bash
-# Tornar executáveis (uma vez)
-chmod +x scripts/*.sh
-
-# Bootstrap da máquina principal (Ryzen)
+# Bootstrap da máquina principal (Ryzen — Arch Linux)
 ./scripts/bootstrap-lab.sh --role=sp1
 
-# Bootstrap da máquina secundária (i7)
+# Bootstrap da máquina secundária (i7 — Ubuntu Server)
 ./scripts/bootstrap-lab.sh --role=sp2
 
-# Bootstrap do DC institucional UNIFESSPA simulado (cluster K3s + containers Docker, no host i7)
+# Bootstrap do DC institucional UNIFESSPA simulado (K3s + containers Docker)
 ./scripts/bootstrap-lab.sh --role=pa1
 
-# Com Cloudflare Tunnel
+# Com Cloudflare Tunnel (requer login interativo)
 ./scripts/bootstrap-lab.sh --role=sp1 --enable-cloudflared
 
-# Modo dry-run (apenas mostra o que seria feito)
+# Modo dry-run
 ./scripts/bootstrap-lab.sh --role=sp1 --dry-run
 
-# Validar cluster após bootstrap
+# Validar cluster
 ./scripts/validate-cluster.sh
 
-# Tear down (cuidado!)
+# Teardown (cuidado!)
 ./scripts/teardown-lab.sh
 ```
 
-## Roadmap de scripts adicionais
+## Standalone OCI (dois hosts Ubuntu)
 
-Conforme o lab evoluir, planejamos adicionar:
+Ambiente de homologação e produção inicial: um `k8s-host` (K3s + ArgoCD) e um
+`data-host` (Docker + volumes LVM para Postgres, Kafka, MinIO, Vault e Redis).
+
+### Bootstrap
+
+```bash
+# No k8s-host — K3s + Helm + ArgoCD
+./scripts/bootstrap-standalone.sh --role=standalone-k8s
+
+# No data-host — Docker + LVM + mount points
+./scripts/bootstrap-standalone.sh --role=standalone-data
+
+# Dry-run (mostra o que seria feito, sem executar)
+./scripts/bootstrap-standalone.sh --role=standalone-k8s --dry-run
+./scripts/bootstrap-standalone.sh --role=standalone-data --dry-run
+
+# Flags disponíveis
+#   --skip-k3s        Pula instalação do K3s (standalone-k8s)
+#   --skip-docker     Pula instalação do Docker (standalone-data)
+#   --enable-cloudflared  Inclui setup do Cloudflare Tunnel (standalone-k8s)
+```
+
+### Variáveis de ambiente (standalone-data)
+
+O bootstrap do data-host descobre os block volumes OCI automaticamente por
+tamanho. Topologia esperada: 1 × 50 GB (Vault), 1 × 100 GB (Kafka),
+2 × 200 GB (Postgres e MinIO). Verificar com `lsblk` antes de rodar.
+
+### Validação
+
+```bash
+# No k8s-host (valida os dois hosts)
+./scripts/validate-standalone.sh
+
+# Sobrepor IP do data-host (padrão: 10.0.2.87)
+DATA_HOST_IP=10.0.2.87 ./scripts/validate-standalone.sh
+```
+
+Saída esperada em ambiente completo: **`X OK, 0 ERROS, Y AVISOS`**.
+Avisos são esperados enquanto serviços ainda não provisionados (Vault, dados).
+
+### Teardown
+
+```bash
+# Teardown do k8s-host (desinstala K3s — dados do data-host preservados)
+./scripts/teardown-lab.sh --role=standalone-k8s
+
+# Teardown do data-host (para containers, desmonta LVM — dados nos block volumes preservados)
+./scripts/teardown-lab.sh --role=standalone-data
+```
+
+## Roadmap
 
 - [ ] `chaos/kill-postgres-primary.sh` — Cenário 3 do VALIDATION-PLAN
 - [ ] `chaos/network-partition.sh` — Cenário 4 (split-brain)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -54,9 +54,8 @@ Ambiente de homologação e produção inicial: um `k8s-host` (K3s + ArgoCD) e u
 ./scripts/bootstrap-standalone.sh --role=standalone-data --dry-run
 
 # Flags disponíveis
-#   --skip-k3s        Pula instalação do K3s (standalone-k8s)
-#   --skip-docker     Pula instalação do Docker (standalone-data)
-#   --enable-cloudflared  Inclui setup do Cloudflare Tunnel (standalone-k8s)
+#   --skip-k3s      Pula instalação do K3s (standalone-k8s)
+#   --skip-docker   Pula instalação do Docker (standalone-data)
 ```
 
 ### Variáveis de ambiente (standalone-data)

--- a/scripts/teardown-lab.sh
+++ b/scripts/teardown-lab.sh
@@ -81,6 +81,11 @@ teardown_standalone_k8s() {
         sudo systemctl disable cloudflared
     fi
 
+    if command -v helm &>/dev/null; then
+        echo "→ Removendo Helm..."
+        sudo rm -f /usr/local/bin/helm
+    fi
+
     echo ""
     echo -e "${GREEN}Teardown standalone-k8s concluído.${NC}"
     echo "Re-bootstrap: ./scripts/bootstrap-standalone.sh --role=standalone-k8s"
@@ -102,12 +107,15 @@ teardown_standalone_data() {
     echo ""
     confirm
 
-    echo "→ Parando containers Docker..."
-    docker ps -aq | xargs -r docker stop || true
-    docker ps -aq | xargs -r docker rm  || true
-
-    echo "→ Removendo volumes Docker..."
-    docker volume prune -f || true
+    if command -v docker &>/dev/null; then
+        echo "→ Parando containers Docker..."
+        docker ps -aq | xargs -r docker stop || true
+        docker ps -aq | xargs -r docker rm  || true
+        echo "→ Removendo volumes Docker..."
+        docker volume prune -f || true
+    else
+        echo "  Docker não encontrado. Pulando remoção de containers."
+    fi
 
     echo "→ Desmontando volumes LVM..."
     for svc in postgres kafka minio vault; do

--- a/scripts/teardown-lab.sh
+++ b/scripts/teardown-lab.sh
@@ -2,59 +2,182 @@
 # ============================================================================
 # teardown-lab.sh
 #
-# Remove o laboratório completamente. CUIDADO: destrói dados.
+# Remove o laboratório ou o ambiente standalone. CUIDADO: destrói dados.
+#
+# Uso:
+#   ./teardown-lab.sh                          # lab genérico (sp1/sp2/pa1)
+#   ./teardown-lab.sh --role=standalone-k8s    # k8s-host OCI
+#   ./teardown-lab.sh --role=standalone-data   # data-host OCI
 # ============================================================================
 
 set -euo pipefail
 
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
 NC='\033[0m'
 
-echo -e "${RED}⚠️  TEARDOWN DO LABORATÓRIO UNI+${NC}"
-echo ""
-echo "Esta operação irá:"
-echo "  - Parar e remover todos os containers"
-echo "  - Desinstalar K3s"
-echo "  - Remover volumes Docker (perda de dados!)"
-echo "  - Remover Cloudflare Tunnel local"
-echo ""
-echo -e "${YELLOW}Backups e dados em /var/lib/postgres, /var/lib/kafka e /var/lib/minio NÃO serão removidos.${NC}"
-echo ""
-read -rp "Tem CERTEZA que quer continuar? Digite 'CONFIRMO' para prosseguir: " confirm
+DATA_BASE="/var/lib/uniplus"
 
-if [[ "$confirm" != "CONFIRMO" ]]; then
-    echo "Operação cancelada."
-    exit 0
+# ============== Parse args ==============
+ROLE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --role=*) ROLE="${1#*=}"; shift ;;
+        -h|--help)
+            echo "Uso: $0 [--role=standalone-k8s|standalone-data]"
+            echo "  Sem --role: teardown genérico do laboratório (sp1/sp2/pa1)."
+            exit 0
+            ;;
+        *) echo -e "${RED}Opção inválida: $1${NC}" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -n "$ROLE" && "$ROLE" != "standalone-k8s" && "$ROLE" != "standalone-data" ]]; then
+    echo -e "${RED}Role inválido: '$ROLE'. Use standalone-k8s ou standalone-data.${NC}" >&2
+    exit 1
 fi
 
-echo ""
-echo "Iniciando teardown..."
+# ============== Helpers ==============
+confirm() {
+    read -rp "Tem CERTEZA? Digite 'CONFIRMO' para prosseguir: " answer
+    if [[ "$answer" != "CONFIRMO" ]]; then
+        echo "Operação cancelada."
+        exit 0
+    fi
+    echo ""
+}
 
-# Parar containers
-echo "→ Parando containers Docker..."
-docker ps -aq | xargs -r docker stop || true
-docker ps -aq | xargs -r docker rm || true
+# ============================================================================
+# standalone-k8s
+# ============================================================================
+teardown_standalone_k8s() {
+    echo -e "${RED}⚠️  TEARDOWN standalone-k8s${NC}"
+    echo ""
+    echo "Esta operação irá:"
+    echo "  - Desinstalar K3s e apagar todo o estado do cluster"
+    echo "  - Remover ~/.kube/config"
+    echo "  - Parar cloudflared (se ativo)"
+    echo ""
+    echo -e "${YELLOW}Não afeta volumes de dados do data-host.${NC}"
+    echo ""
+    confirm
 
-# Remover volumes (apenas Docker, não os do host)
-echo "→ Removendo volumes Docker..."
-docker volume prune -f || true
+    if command -v k3s-uninstall.sh &>/dev/null; then
+        echo "→ Desinstalando K3s..."
+        sudo /usr/local/bin/k3s-uninstall.sh || true
+    else
+        echo "  K3s não encontrado. Pulando."
+    fi
 
-# Desinstalar K3s
-if command -v k3s-uninstall.sh &> /dev/null; then
-    echo "→ Desinstalando K3s..."
-    sudo /usr/local/bin/k3s-uninstall.sh || true
-fi
+    if [[ -f "$HOME/.kube/config" ]]; then
+        echo "→ Removendo kubeconfig..."
+        rm -f "$HOME/.kube/config"
+    fi
 
-# Cloudflared
-if systemctl is-active --quiet cloudflared 2>/dev/null; then
-    echo "→ Parando cloudflared..."
-    sudo systemctl stop cloudflared
-    sudo systemctl disable cloudflared
-fi
+    if systemctl is-active --quiet cloudflared 2>/dev/null; then
+        echo "→ Parando cloudflared..."
+        sudo systemctl stop cloudflared
+        sudo systemctl disable cloudflared
+    fi
 
-echo ""
-echo "Teardown completo."
-echo ""
-echo "Dados em /var/lib/postgres, /var/lib/kafka e /var/lib/minio foram preservados."
-echo "Para remover manualmente: sudo rm -rf /var/lib/{postgres,kafka,minio}/*"
+    echo ""
+    echo -e "${GREEN}Teardown standalone-k8s concluído.${NC}"
+    echo "Re-bootstrap: ./scripts/bootstrap-standalone.sh --role=standalone-k8s"
+}
+
+# ============================================================================
+# standalone-data
+# ============================================================================
+teardown_standalone_data() {
+    echo -e "${RED}⚠️  TEARDOWN standalone-data${NC}"
+    echo ""
+    echo "Esta operação irá:"
+    echo "  - Parar e remover todos os containers Docker"
+    echo "  - Remover volumes Docker"
+    echo "  - Desmontar volumes LVM de $DATA_BASE/{postgres,kafka,minio,vault}"
+    echo "  - Remover entradas do /etc/fstab"
+    echo ""
+    echo -e "${YELLOW}Dados nos block volumes OCI são PRESERVADOS (LVM intacto, apenas desmontado).${NC}"
+    echo ""
+    confirm
+
+    echo "→ Parando containers Docker..."
+    docker ps -aq | xargs -r docker stop || true
+    docker ps -aq | xargs -r docker rm  || true
+
+    echo "→ Removendo volumes Docker..."
+    docker volume prune -f || true
+
+    echo "→ Desmontando volumes LVM..."
+    for svc in postgres kafka minio vault; do
+        if mountpoint -q "$DATA_BASE/$svc" 2>/dev/null; then
+            sudo umount "$DATA_BASE/$svc"
+            echo "  Desmontado: $DATA_BASE/$svc"
+        else
+            echo "  $DATA_BASE/$svc não estava montado. Pulando."
+        fi
+    done
+
+    echo "→ Removendo entradas do /etc/fstab..."
+    for vg in vg-postgres vg-kafka vg-minio vg-vault; do
+        sudo sed -i "\|/dev/$vg|d" /etc/fstab
+    done
+
+    echo ""
+    echo -e "${GREEN}Teardown standalone-data concluído.${NC}"
+    echo -e "${YELLOW}Dados nos block volumes OCI foram preservados.${NC}"
+    echo "Re-bootstrap: ./scripts/bootstrap-standalone.sh --role=standalone-data"
+}
+
+# ============================================================================
+# Genérico (lab sp1/sp2/pa1) — comportamento original preservado
+# ============================================================================
+teardown_generic() {
+    echo -e "${RED}⚠️  TEARDOWN DO LABORATÓRIO UNI+${NC}"
+    echo ""
+    echo "Esta operação irá:"
+    echo "  - Parar e remover todos os containers"
+    echo "  - Desinstalar K3s"
+    echo "  - Remover volumes Docker (perda de dados!)"
+    echo "  - Remover Cloudflare Tunnel local"
+    echo ""
+    echo -e "${YELLOW}Backups e dados em /var/lib/postgres, /var/lib/kafka e /var/lib/minio NÃO serão removidos.${NC}"
+    echo ""
+    confirm
+
+    echo "Iniciando teardown..."
+
+    echo "→ Parando containers Docker..."
+    docker ps -aq | xargs -r docker stop || true
+    docker ps -aq | xargs -r docker rm  || true
+
+    echo "→ Removendo volumes Docker..."
+    docker volume prune -f || true
+
+    if command -v k3s-uninstall.sh &>/dev/null; then
+        echo "→ Desinstalando K3s..."
+        sudo /usr/local/bin/k3s-uninstall.sh || true
+    fi
+
+    if systemctl is-active --quiet cloudflared 2>/dev/null; then
+        echo "→ Parando cloudflared..."
+        sudo systemctl stop cloudflared
+        sudo systemctl disable cloudflared
+    fi
+
+    echo ""
+    echo "Teardown completo."
+    echo ""
+    echo "Dados em /var/lib/postgres, /var/lib/kafka e /var/lib/minio foram preservados."
+    echo "Para remover manualmente: sudo rm -rf /var/lib/{postgres,kafka,minio}/*"
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+case "$ROLE" in
+    standalone-k8s)  teardown_standalone_k8s ;;
+    standalone-data) teardown_standalone_data ;;
+    "")              teardown_generic ;;
+esac


### PR DESCRIPTION
## Resumo

- **`teardown-lab.sh`** ganha suporte a `--role=standalone-k8s` e `--role=standalone-data`
  - `standalone-k8s`: desinstala K3s, remove `~/.kube/config`, para cloudflared
  - `standalone-data`: para containers Docker, desmonta volumes LVM, remove entradas do `/etc/fstab` — dados nos block volumes OCI preservados
  - Comportamento genérico (sem `--role`) preservado sem alteração
- **`scripts/README.md`** documentado do zero: tabela de scripts, fluxo lab e standalone, flags, variáveis de ambiente e teardown role-aware

## Validado nos hosts OCI reais

Ciclo completo executado:
1. `teardown-lab.sh --role=standalone-k8s` → K3s desinstalado
2. `teardown-lab.sh --role=standalone-data` → volumes desmontados (dados preservados)
3. `bootstrap-standalone.sh --role=standalone-k8s` → K3s + ArgoCD restaurados
4. `bootstrap-standalone.sh --role=standalone-data` → LVM remontado
5. `validate-standalone.sh` → **23 OK, 0 ERROS, 8 AVISOS**

Closes #61
Closes #84