### PR TITLE
feat(environments): adicionar overlay standalone provider-agnostic

### DIFF
--- a/environments/standalone/README.md
+++ b/environments/standalone/README.md
@@ -33,6 +33,7 @@ Um cluster K3s em um host (`k8s-host`) + um host externo para componentes statef
 | Vault keys | Re-init pós-teardown re-gera Shamir 5/3 — standalone não é cofre durável |
 | Keycloak | Sem federação Gov.br no MVP — apenas validação OIDC/JWT local |
 | Storage | `reclaimPolicy: Delete` — re-bootstrap via Tofu apaga PVs |
+| Vault PVC | `kubectl delete pvc data-<release>-vault-0` destrói o estado Raft sem peer para recuperar — single-replica, único ambiente onde isso é destrutivo sem aviso (em SP1/SP2, 2 das 3 réplicas sobrevivem) |
 | Observabilidade | Stack único (Prometheus/Loki/Tempo single-replica), retenção curta |
 | Performance | Não modela latência cross-DC — race conditions geográficas ficam invisíveis aqui |
 
@@ -78,6 +79,17 @@ Procedimento detalhado: `docs/RUNBOOKS.md` §8 (Bootstrap e Teardown — Ambient
 4. `./scripts/validate-standalone.sh` para checagem de sanidade.
 5. Registrar cluster no ArgoCD conforme acima.
 6. Vault init + verificação de auto-unseal (ver `docs/RUNBOOKS.md` §8.4).
+
+## Pré-requisitos não-implementados
+
+Charts referenciados pelo overlay que ainda são placeholders (sem `Chart.yaml`/templates) e precisam aterrissar antes do bootstrap funcionar end-to-end:
+
+- `platform/cert-manager/` — `ingress.tls.issuer: letsencrypt` neste overlay assume `cert-manager` instalado e um `ClusterIssuer` chamado `letsencrypt` configurado para HTTP-01 (issue #15).
+- `platform/traefik/` — terminação TLS e roteamento por path no FQDN único de standalone.
+- `platform/external-secrets/` — sintetiza o Secret `vault-ocikms-config` consumido pelo Vault (issue #64).
+- `platform/cloudflared/`, `platform/observability/*` — completam o stack de borda e observabilidade.
+
+Standalone entrega o overlay GitOps; os charts acima são gap pré-existente do repositório, não bloqueio específico desta topologia.
 
 ## Charts `data/*` — fora do escopo
 

--- a/environments/standalone/README.md
+++ b/environments/standalone/README.md
@@ -1,0 +1,91 @@
+# Environment: standalone
+
+Topologia paralela, provider-agnostic, single-DC e single-host. Decisão formalizada na [ADR-008](../../docs/adrs/ADR-008-topologia-standalone.md) e implementada na [Epic #40](https://github.com/unifesspa-edu-br/uniplus-infra/issues/40).
+
+Este overlay GitOps coexiste com `lab-{sp1,sp2,pa1}` e `prod-{sp1,sp2,pa1}` sem alterá-los — mantém a fidelidade arquitetural do modelo 3-DC e adiciona um modelo monolocal para validação integrada, demos e fallback emergencial.
+
+## Topologia em uma frase
+
+Um cluster K3s em um host (`k8s-host`) + um host externo para componentes stateful (`data-host`) gerenciados por systemd (Postgres, Kafka, MinIO, Redis). Vault HA Raft com 1 réplica, auto-unseal via KMS do provider. Sem peers `SP2`/`PA1`.
+
+## Quando usar
+
+- ✅ Validação integrada antes de levar mudança ao lab 3-DC
+- ✅ Demonstrações para stakeholders
+- ✅ Ambiente de aprendizado para novos contribuidores
+- ✅ Fallback operacional em indisponibilidade prolongada dos 3 DCs
+- ✅ Canário de versão de chart antes de promover para `lab-*`
+
+## Quando **não** usar
+
+- ❌ Validar HA geográfico ou failover entre DCs
+- ❌ Validar perda de PA1 ou replicação MinIO cross-site
+- ❌ Validar consenso Patroni / Kafka KRaft cross-DC
+- ❌ Atendimento de pico de edital com SLA — esse cenário exige 3-DC
+
+## Limitações conhecidas
+
+| Aspecto | Limitação |
+|---|---|
+| Resiliência | Single-host: queda da VM derruba toda a plataforma |
+| Postgres | Single-primary por banco (sem replica, sem Patroni) |
+| Vault | 1 réplica Raft (StatefulSet 3-réplica ficaria Pending no single-node) |
+| Vault keys | Re-init pós-teardown re-gera Shamir 5/3 — standalone não é cofre durável |
+| Keycloak | Sem federação Gov.br no MVP — apenas validação OIDC/JWT local |
+| Storage | `reclaimPolicy: Delete` — re-bootstrap via Tofu apaga PVs |
+| Observabilidade | Stack único (Prometheus/Loki/Tempo single-replica), retenção curta |
+| Performance | Não modela latência cross-DC — race conditions geográficas ficam invisíveis aqui |
+
+> **Risco a fiscalizar em revisão:** standalone passar e prod 3-DC falhar é um modo conhecido. Bugs sensíveis a partição de rede e latência cross-site **não** são detectáveis aqui.
+
+## Provider-specifics
+
+Por regra (ADR-008), nada provider-specific entra neste diretório:
+
+- ❌ OCIDs, ARNs, project IDs
+- ❌ Endpoints concretos de cloud (KMS, IAM, IMDS)
+- ❌ Credenciais ou tokens
+- ✅ Apenas o **nome do mecanismo** de unseal (`seal "ocikms"`, `seal "awskms"`, `seal "azurekeyvault"`, …)
+
+Identificadores e endpoints chegam ao Pod do Vault via env vars injetados a partir do Secret `vault-ocikms-config`, sintetizado por External Secrets a partir do cofre do provider (sub-issue #64).
+
+Para usar outro provider:
+
+1. Substituir o bloco `seal "ocikms"` em `vault.server.ha.raft.config` pelo seal apropriado.
+2. Ajustar `extraSecretEnvironmentVars` para os env vars exigidos pelo seal escolhido.
+3. Provisionar o KMS + Dynamic Group + Policy correspondente em `provisioning/<provider>/standalone/` (Tofu).
+
+Tudo o mais (Postgres single-primary, Keycloak sem Gov.br, observabilidade single-stack, `StorageClass: standalone-local-nvme`, ingress single-host) é universal.
+
+## Como o ApplicationSet aplica
+
+`argocd/applicationset.yaml` é genérico via label `environment: <env>`. Para o ArgoCD reconciliar este overlay basta registrar o cluster com:
+
+```bash
+argocd cluster add <kube-context> \
+  --name uniplus-standalone \
+  --label uniplus.io/managed=true \
+  --label environment=standalone
+```
+
+Procedimento detalhado: `docs/RUNBOOKS.md` §8 (Bootstrap e Teardown — Ambiente Standalone OCI).
+
+## Pré-requisitos de bootstrap
+
+1. Provisionamento OCI (manual via CLI hoje; codificação Tofu é trabalho da Story #75 → #80 da Epic #40).
+2. `./scripts/bootstrap-standalone.sh --role=standalone-k8s` no `k8s-host`.
+3. `./scripts/bootstrap-standalone.sh --role=standalone-data` no `data-host`.
+4. `./scripts/validate-standalone.sh` para checagem de sanidade.
+5. Registrar cluster no ArgoCD conforme acima.
+6. Vault init + verificação de auto-unseal (ver `docs/RUNBOOKS.md` §8.4).
+
+## Charts `data/*` — fora do escopo
+
+Standalone entrega GitOps + provisioning + bootstrap K8s completos. A matriz de validação end-to-end (Postgres, Kafka, MinIO no data-host) só fecha 100% após o Epic `data/*` aterrissar — gap pré-existente, tratado como Epic separado (ADR-008, seção "Decisões de design já tomadas").
+
+## Documentos relacionados
+
+- [ADR-008 — Topologia standalone](../../docs/adrs/ADR-008-topologia-standalone.md) — decisão e premissas
+- [docs/RUNBOOKS.md §8](../../docs/RUNBOOKS.md) — bootstrap e teardown
+- [docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md) — visão arquitetural geral
+- Epic [#40](https://github.com/unifesspa-edu-br/uniplus-infra/issues/40) — execução da topologia standalone

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -115,6 +115,13 @@ vault:
       enabled: true
       replicas: 1
 
+      # Com replicas=1 o chart upstream renderiza PDB com maxUnavailable=0,
+      # o que bloqueia kubectl drain do k8s-host (upgrade K3s, manutenção)
+      # sem benefício real — não há outro Pod para preservar. Desligamos o
+      # PDB neste overlay; lab/prod 3-DC mantêm o default (enabled=true).
+      disruptionBudget:
+        enabled: false
+
       raft:
         enabled: true
         setNodeId: true
@@ -172,13 +179,13 @@ vault:
       storageClass: standalone-local-nvme
 
 # Vault Transit não roda em standalone — auto-unseal usa KMS do provider
-# (ADR-008). Mantém o chart desligado para o ApplicationSet pular o sync.
+# (ADR-008), e o cluster não tem peer PA1 para hospedar o Transit. Desligar
+# o chart faz o ApplicationSet pular o sync; com pa1HostIP="" (default do
+# chart vault/) o egress de NetworkPolicy para PA1 fica inerte e o Secret
+# vault-transit-endpoint não é consumido. transitNodePort=8200 default
+# satisfaz o values.schema.json sem efeito prático.
 vaultTransit:
   enabled: false
-
-# Topologia Transit ausente — standalone não consome o Secret vault-transit-endpoint
-# nem precisa de NetworkPolicy de egress para PA1. Mantemos os defaults do chart
-# (pa1HostIP="" desliga o egress, transitNodePort=8200 fica inerte).
 
 # NetworkPolicy do chart vault/ — sem egress Transit (vaultTransit.enabled=false).
 networkPolicy:

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -1,0 +1,205 @@
+# Ambiente: standalone
+# Topologia paralela provider-agnostic — ADR-008.
+#
+# Modelo single-DC, single-host para K8s + 1 host externo para componentes
+# stateful (Postgres, Kafka, MinIO, Redis) gerenciados por systemd. NÃO valida
+# resiliência geográfica nem failover entre DCs — ver environments/standalone/README.md.
+#
+# Provider de referência: OCI (issue #47, Epic #40). O único campo provider-
+# specific é `vault.server.ha.raft.config` (bloco `seal "ocikms"`); para outro
+# provider, substituir por `seal "awskms"`, `seal "azurekeyvault"`, etc.
+# Nenhum OCID/ARN/endpoint entra neste arquivo — esses valores chegam via
+# External Secrets / variáveis de ambiente injetadas no Pod do Vault.
+
+cluster:
+  name: standalone
+  region: standalone
+  dc: standalone
+
+# Hostname público único — todos os apps (web, APIs, Keycloak, Vault UI) sob
+# o mesmo FQDN com pathing no Traefik. Override de host concreto fica fora
+# deste arquivo provider-agnostic; o operador injeta via External Secret ou
+# parametriza por --set ao registrar o cluster no ArgoCD.
+ingress:
+  host: standalone.example
+  tls:
+    enabled: true
+    issuer: letsencrypt  # cert-manager emite via HTTP-01 (single-host simplifica DNS-01)
+
+# Postgres single-primary por banco — sem replica (data-host é único).
+# Patroni é dispensado nesta topologia; chart consumidor deve interpretar
+# `role: primary` sem replica peer como deploy single-instance.
+postgres:
+  portal:
+    role: primary
+  selecao:
+    role: primary
+  ingresso:
+    role: primary
+
+# Recursos enxutos — VMs OCI E4.Flex de referência (k8s-host: 4 OCPU/24GB,
+# data-host: 2 OCPU/16GB). Suficiente para sanidade integrada e demos.
+resources:
+  api:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  frontend:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  clamav:
+    requests:
+      cpu: 200m
+      memory: 1Gi
+    limits:
+      cpu: 1500m
+      memory: 2Gi
+
+# 1 réplica de tudo — single-point por design (ADR-008).
+replicas:
+  apis: 1
+  frontends: 1
+  clamav: 1
+  keycloak: 1
+  redis: 1
+
+# Observabilidade single-stack com retenção curta — standalone não substitui
+# a observabilidade do lab/prod 3-DC, serve apenas para validação local.
+observability:
+  prometheus:
+    retention: 7d
+    storage: 10Gi
+  loki:
+    retention: 7d
+    storage: 15Gi
+  tempo:
+    retention: 3d
+    storage: 5Gi
+
+# ============================================================================
+# StorageClass do tier standalone (#74, ADR-008).
+# rancher.io/local-path mapeado para /var/lib/uniplus/* no NVMe local da VM.
+# ============================================================================
+storage:
+  enabled: true
+  storageClass:
+    name: standalone-local-nvme
+    isDefault: false
+    provisioner: rancher.io/local-path
+    # Standalone é monolocal e descartável (re-bootstrap via Tofu); Delete
+    # evita acúmulo de PVs órfãos. Re-init do Vault re-gera Shamir keys —
+    # decisão consciente: standalone NÃO é cofre durável.
+    reclaimPolicy: Delete
+
+# ============================================================================
+# Vault HA Raft single-replica com auto-unseal via OCI KMS.
+# Replicas=1 na topologia single-host (StatefulSet 3-réplica ficaria Pending).
+# Mantém Raft como storage backend para preservar fidelidade arquitetural
+# com lab/prod 3-DC — só o número de peers difere.
+# ============================================================================
+vault:
+  enabled: true
+
+  global:
+    tlsDisable: true  # TLS terminado no Traefik até cert-manager (#15)
+
+  server:
+    ha:
+      enabled: true
+      replicas: 1
+
+      raft:
+        enabled: true
+        setNodeId: true
+        # Substitui o config default do chart `platform/vault/` para incluir
+        # o bloco `seal "ocikms"`. OCID do Key, endpoints crypto/management
+        # e auth_type vêm via env vars injetados a partir de Secret
+        # `vault-ocikms-config` (External Secret consumindo OCI Vault — #64).
+        #
+        # auth_type_api_key="false" força autenticação por Resource Principal
+        # (Dynamic Group + IAM Policy) — instance principal da VM k8s-host.
+        # Nenhum OCID literal entra aqui (regra ADR-008).
+        config: |
+          ui = true
+
+          listener "tcp" {
+            tls_disable     = 1
+            address         = "[::]:8200"
+            cluster_address = "[::]:8201"
+          }
+
+          storage "raft" {
+            path = "/vault/data"
+          }
+
+          seal "ocikms" {
+            key_id              = "${VAULT_SEAL_OCIKMS_KEY_ID}"
+            crypto_endpoint     = "${VAULT_SEAL_OCIKMS_CRYPTO_ENDPOINT}"
+            management_endpoint = "${VAULT_SEAL_OCIKMS_MANAGEMENT_ENDPOINT}"
+            auth_type_api_key   = "false"
+          }
+
+          service_registration "kubernetes" {}
+
+    # Env vars injetados via Secret vault-ocikms-config (criado por External
+    # Secrets a partir do OCI Vault — sub-issue #64). Estrutura esperada:
+    #   data.key_id              → OCID da chave master no OCI KMS
+    #   data.crypto_endpoint     → https://<vault-id>-crypto.kms.<region>.oci.oraclecloud.com
+    #   data.management_endpoint → https://<vault-id>-management.kms.<region>.oci.oraclecloud.com
+    extraSecretEnvironmentVars:
+      - envName: VAULT_SEAL_OCIKMS_KEY_ID
+        secretName: vault-ocikms-config
+        secretKey: key_id
+      - envName: VAULT_SEAL_OCIKMS_CRYPTO_ENDPOINT
+        secretName: vault-ocikms-config
+        secretKey: crypto_endpoint
+      - envName: VAULT_SEAL_OCIKMS_MANAGEMENT_ENDPOINT
+        secretName: vault-ocikms-config
+        secretKey: management_endpoint
+
+    dataStorage:
+      size: 5Gi
+      storageClass: standalone-local-nvme
+    auditStorage:
+      size: 5Gi
+      storageClass: standalone-local-nvme
+
+# Vault Transit não roda em standalone — auto-unseal usa KMS do provider
+# (ADR-008). Mantém o chart desligado para o ApplicationSet pular o sync.
+vaultTransit:
+  enabled: false
+
+# Topologia Transit ausente — standalone não consome o Secret vault-transit-endpoint
+# nem precisa de NetworkPolicy de egress para PA1. Mantemos os defaults do chart
+# (pa1HostIP="" desliga o egress, transitNodePort=8200 fica inerte).
+
+# NetworkPolicy do chart vault/ — sem egress Transit (vaultTransit.enabled=false).
+networkPolicy:
+  enabled: true
+  externalSecretsNamespace: external-secrets
+  traefikNamespace: traefik
+
+# ----------------------------------------------------------------------------
+# Keycloak local (apps/keycloak-replica) — sem federação Gov.br no MVP.
+# 1 réplica, valida apenas o contrato OIDC/JWT entre frontends e APIs.
+# Federação Gov.br fica fora do escopo standalone (depende de cadastro
+# institucional do client OIDC; demos podem usar usuários locais).
+# ----------------------------------------------------------------------------
+keycloak:
+  enabled: true
+  govbr:
+    enabled: false
+
+# ----------------------------------------------------------------------------
+# Componentes stateful no data-host (Postgres, Kafka, MinIO, Redis) rodam
+# FORA do K8s, gerenciados por systemd em /var/lib/uniplus/* (ADR-002 +
+# ADR-005). Endpoints chegam às apps via External Secrets sintetizados a
+# partir do bootstrap; não são valores deste arquivo.
+# ----------------------------------------------------------------------------

--- a/platform/vault/values.schema.json
+++ b/platform/vault/values.schema.json
@@ -62,7 +62,7 @@
                   "type": "integer",
                   "minimum": 1,
                   "maximum": 7,
-                  "description": "Sempre 3 conforme ADR-007 (topologia idêntica em todas as fases)."
+                  "description": "3 nas topologias 3-DC (lab/prod/hml SP1+SP2+PA1) conforme ADR-007. 1 na topologia standalone (single-host) conforme ADR-008 — Raft com peer único, mantido como backend para fidelidade arquitetural."
                 },
                 "raft": {
                   "type": "object",


### PR DESCRIPTION
## Sumário

Adiciona o overlay GitOps `environments/standalone/` (single-DC, single-host) conforme [ADR-008](../blob/main/docs/adrs/ADR-008-topologia-standalone.md) e Epic #40. Coexiste com `lab-{sp1,sp2,pa1}` e `prod-{sp1,sp2,pa1}` sem alterá-los — mantém fidelidade arquitetural do modelo 3-DC e adiciona um modelo monolocal para validação integrada, demos e fallback.

## Arquivos

- `environments/standalone/values.yaml` — overlay GitOps provider-agnostic
- `environments/standalone/README.md` — quando usar/não usar, limitações, pré-requisitos, regras provider-agnostic
- `platform/vault/values.schema.json` — `vault.server.ha.replicas.description` atualizada para refletir standalone (1 réplica) ao lado das topologias 3-DC

## Decisões de design

- **Vault HA Raft, 1 réplica** — StatefulSet 3-réplica ficaria `Pending` no single-node; mantém Raft como backend para preservar fidelidade com lab/prod, só varia o número de peers.
- **PDB desligado em standalone** (`server.ha.disruptionBudget.enabled: false`) — com replicas=1 o chart upstream renderia `maxUnavailable: 0`, bloqueando `kubectl drain` do `k8s-host` sem benefício real.
- **Auto-unseal `seal "ocikms"`** — OCID do Key e endpoints crypto/management vêm via env vars (`VAULT_SEAL_OCIKMS_*`) injetados a partir do Secret `vault-ocikms-config`. Esse Secret é sintetizado por External Secrets na sub-issue #64; este PR apenas referencia o contrato.
- **`auth_type_api_key="false"`** — autenticação por Resource Principal (Dynamic Group + IAM Policy da VM `k8s-host`). Forma string segue o exemplo oficial dos docs do Vault para OCI KMS.
- **Provider-agnóstico (regra ADR-008)** — nenhum OCID/ARN/endpoint literal no arquivo. `ingress.host: standalone.example` é placeholder; FQDN concreto entra via External Secret/parâmetro de cluster.
- **StorageClass `standalone-local-nvme`** — `rancher.io/local-path` com `reclaimPolicy: Delete` (standalone é descartável; re-bootstrap via Tofu re-cria os PVs).
- **Postgres single-primary** nos 3 bancos (`portal`, `selecao`, `ingresso`), sem Patroni.
- **Keycloak local sem Gov.br** — valida apenas contrato OIDC/JWT entre frontends e APIs no MVP.
- **`vaultTransit.enabled: false`** — defaults do chart (`pa1HostIP=""`, `transitNodePort=8200` inerte) desligam egress Transit sem precisar de override extra.

## Validações executadas

- `yamllint -c .yamllint.yaml environments/standalone/` → clean
- `helm lint <chart> -f environments/standalone/values.yaml` em **todos os charts com `Chart.yaml`** (apps/*, platform/storage, platform/vault, platform/vault-transit) → 0 falhas. Os 9 placeholders sem `Chart.yaml` (`platform/{argocd,cert-manager,cloudflared,external-secrets,traefik,observability/*}`) são pulados — gap pré-existente do repo, não regressão deste PR; estão listados no README como pré-requisitos não-implementados.
- `helm template platform/vault -f environments/standalone/values.yaml` → render OK com `seal "ocikms"`, env vars `VAULT_SEAL_OCIKMS_*`, PVCs em `standalone-local-nvme`. Após o fix do PDB, nenhum `PodDisruptionBudget` é renderizado.
- `helm template platform/storage -f environments/standalone/values.yaml` → render OK com StorageClass `standalone-local-nvme` / `rancher.io/local-path` / `reclaimPolicy: Delete`.

## Risco a fiscalizar em revisão

Standalone passar e prod 3-DC falhar é um modo conhecido — bugs sensíveis a partição de rede e latência cross-site não são detectáveis aqui (registrado no README, seção "Limitações conhecidas").

## Próximos passos (não neste PR)

- #74 — adicionar `standalone-local-nvme` à tabela de tiers em `platform/storage` (PR #96, já aberto)
- #64 — Vault init + verificação auto-unseal OCI KMS, cria o Secret `vault-ocikms-config`
- #86 — validar reconciliação ArgoCD de `apps/` e `platform/` no cluster real

## Test plan

- [ ] Revisar `values.yaml` e `README.md` para aderência à ADR-008
- [ ] Confirmar `helm lint` em todos os charts com `Chart.yaml` com o overlay (já executado localmente)
- [ ] Confirmar que nenhum identificador provider-specific entra no arquivo
- [ ] Após merge, prosseguir com #74 (StorageClass) e #86 (reconciliação ArgoCD)

Closes #73
Refs ADR-008, Epic #40