### PR TITLE
feat(storage): documentar tier standalone-local-nvme em platform/storage

### DIFF
--- a/platform/storage/Chart.yaml
+++ b/platform/storage/Chart.yaml
@@ -3,9 +3,9 @@ name: storage
 description: |
   StorageClass nomeada por ambiente para a plataforma Uni+. Cria uma
   StorageClass com nome alinhado ao tier do environment (lab-local-nvme,
-  san-local-nvme, hml-local-nvme, prod-local-nvme), referenciada
-  explicitamente pelos PVCs de Vault, Postgres-on-K8s, observability
-  (#26-30) e demais cargas de plataforma.
+  san-local-nvme, hml-local-nvme, prod-local-nvme, standalone-local-nvme),
+  referenciada explicitamente pelos PVCs de Vault, Postgres-on-K8s,
+  observability (#26-30) e demais cargas de plataforma.
 type: application
 
 version: 0.1.0

--- a/platform/storage/README.md
+++ b/platform/storage/README.md
@@ -16,7 +16,7 @@ PVCs dos charts de plataforma (Vault, Vault Transit, Postgres-on-K8s, Prometheus
 
 Em hml/prod, a escolha final do provisioner (local-path vs CSI driver dedicado — NetApp, Longhorn, etc.) é decisão da DIRSI durante a fase de promoção. O nome da StorageClass permanece estável (`prod-local-nvme`) para minimizar churn nos values dos demais charts.
 
-O tier **standalone** (ADR-008) usa `reclaimPolicy: Delete` em vez do default `Retain` — o ambiente é monolocal e descartável (re-bootstrap via Tofu re-cria os PVs), e o `Retain` acumularia PVs órfãos. O override está em `environments/standalone/values.yaml`.
+O tier **standalone** (ADR-008) usa `reclaimPolicy: Delete` em vez do default `Retain` — o ambiente é monolocal e descartável (re-bootstrap via Tofu re-cria os PVs), e o `Retain` acumularia PVs órfãos. O override é injetado pelo overlay `environments/standalone/values.yaml`, introduzido em #73 (PR [#95](https://github.com/unifesspa-edu-br/uniplus-infra/pull/95)).
 
 ## Por que nome explícito por tier?
 

--- a/platform/storage/README.md
+++ b/platform/storage/README.md
@@ -10,10 +10,13 @@ PVCs dos charts de plataforma (Vault, Vault Transit, Postgres-on-K8s, Prometheus
 |------|------|-------------|------|
 | Lab | `lab-local-nvme` | `rancher.io/local-path` (K3s default) | NVMe local nas máquinas Ryzen 9950X e i7 |
 | Sanidade | `san-local-nvme` | `rancher.io/local-path` | NVMe local no DC institucional UNIFESSPA |
+| Standalone | `standalone-local-nvme` | `rancher.io/local-path` | NVMe local na VM `k8s-host` (single-DC, ADR-008) |
 | HML | `hml-local-nvme` | TBD (DIRSI) | Hardware EVEO/Unifesspa |
 | Produção | `prod-local-nvme` | TBD (DIRSI) | Hardware EVEO/Unifesspa |
 
 Em hml/prod, a escolha final do provisioner (local-path vs CSI driver dedicado — NetApp, Longhorn, etc.) é decisão da DIRSI durante a fase de promoção. O nome da StorageClass permanece estável (`prod-local-nvme`) para minimizar churn nos values dos demais charts.
+
+O tier **standalone** (ADR-008) usa `reclaimPolicy: Delete` em vez do default `Retain` — o ambiente é monolocal e descartável (re-bootstrap via Tofu re-cria os PVs), e o `Retain` acumularia PVs órfãos. O override está em `environments/standalone/values.yaml`.
 
 ## Por que nome explícito por tier?
 
@@ -29,7 +32,7 @@ Nomes alinhados ao tier (`<tier>-local-nvme`) deixam claro de longe qual SC espe
 | Caminho | Default | Descrição |
 |---------|---------|-----------|
 | `storage.enabled` | `true` | Liga/desliga a criação da SC. |
-| `storage.storageClass.name` | `local-nvme` | **Override obrigatório por environment** com `lab-local-nvme`, `san-local-nvme`, etc. |
+| `storage.storageClass.name` | `local-nvme` | **Override obrigatório por environment** com `lab-local-nvme`, `san-local-nvme`, `standalone-local-nvme`, `hml-local-nvme` ou `prod-local-nvme`. |
 | `storage.storageClass.isDefault` | `true` | Marca a SC como default do cluster (`storageclass.kubernetes.io/is-default-class`). |
 | `storage.storageClass.provisioner` | `rancher.io/local-path` | Provisioner. Override em hml/prod conforme decisão da DIRSI. |
 | `storage.storageClass.volumeBindingMode` | `WaitForFirstConsumer` | Evita binding prematuro do PVC a um nó. |

--- a/platform/storage/README.md
+++ b/platform/storage/README.md
@@ -16,7 +16,7 @@ PVCs dos charts de plataforma (Vault, Vault Transit, Postgres-on-K8s, Prometheus
 
 Em hml/prod, a escolha final do provisioner (local-path vs CSI driver dedicado — NetApp, Longhorn, etc.) é decisão da DIRSI durante a fase de promoção. O nome da StorageClass permanece estável (`prod-local-nvme`) para minimizar churn nos values dos demais charts.
 
-O tier **standalone** (ADR-008) usa `reclaimPolicy: Delete` em vez do default `Retain` — o ambiente é monolocal e descartável (re-bootstrap via Tofu re-cria os PVs), e o `Retain` acumularia PVs órfãos. O override é injetado pelo overlay `environments/standalone/values.yaml`, introduzido em #73 (PR [#95](https://github.com/unifesspa-edu-br/uniplus-infra/pull/95)).
+O tier **standalone** (ADR-008) usa `reclaimPolicy: Delete` em vez do default `Retain` — o ambiente é monolocal e descartável (re-bootstrap via Tofu re-cria os PVs), e o `Retain` acumularia PVs órfãos. O override é injetado pelo overlay [`environments/standalone/values.yaml`](../../environments/standalone/values.yaml), introduzido em #95.
 
 ## Por que nome explícito por tier?
 
@@ -33,7 +33,7 @@ Nomes alinhados ao tier (`<tier>-local-nvme`) deixam claro de longe qual SC espe
 |---------|---------|-----------|
 | `storage.enabled` | `true` | Liga/desliga a criação da SC. |
 | `storage.storageClass.name` | `local-nvme` | **Override obrigatório por environment** com `lab-local-nvme`, `san-local-nvme`, `standalone-local-nvme`, `hml-local-nvme` ou `prod-local-nvme`. |
-| `storage.storageClass.isDefault` | `true` | Marca a SC como default do cluster (`storageclass.kubernetes.io/is-default-class`). |
+| `storage.storageClass.isDefault` | `false` | Marca a SC como default do cluster (`storageclass.kubernetes.io/is-default-class`). Mantido `false` para não competir com a SC default do K3s (`local-path`); override para `true` apenas em clusters sem SC default pré-existente. |
 | `storage.storageClass.provisioner` | `rancher.io/local-path` | Provisioner. Override em hml/prod conforme decisão da DIRSI. |
 | `storage.storageClass.volumeBindingMode` | `WaitForFirstConsumer` | Evita binding prematuro do PVC a um nó. |
 | `storage.storageClass.reclaimPolicy` | `Retain` | Preserva dados ao deletar PVC (importante para Vault, Postgres). |

--- a/platform/storage/values.yaml
+++ b/platform/storage/values.yaml
@@ -3,12 +3,15 @@
 # Cria uma StorageClass nomeada explicitamente, referenciada pelos PVCs dos
 # demais charts (Vault, Postgres-on-K8s, observability). Nome alinhado ao tier
 # de ambiente: `lab-local-nvme`, `san-local-nvme`, `hml-local-nvme`,
-# `prod-local-nvme`. Override obrigatório em cada environment para garantir
-# que cada cluster aplique a SC com o nome correto.
+# `prod-local-nvme`, `standalone-local-nvme`. Override obrigatório em cada
+# environment para garantir que cada cluster aplique a SC com o nome correto.
 #
-# Em lab/sanidade: provisioner `rancher.io/local-path` (já incluído no K3s).
-# Em hml/prod: a decisão final fica com a DIRSI — local NVMe direto ou
-# CSI driver dedicado (NetApp, Longhorn, etc.). Override por environment.
+# Em lab/sanidade/standalone: provisioner `rancher.io/local-path` (já incluído
+# no K3s). Em hml/prod: a decisão final fica com a DIRSI — local NVMe direto
+# ou CSI driver dedicado (NetApp, Longhorn, etc.). Override por environment.
+#
+# Standalone (ADR-008) override `reclaimPolicy: Delete` (ambiente descartável,
+# re-bootstrap via Tofu); demais tiers mantêm o default `Retain`.
 #
 # Issue: #31 (sub de #3).
 


### PR DESCRIPTION
## Sumário

Adiciona o tier `standalone-local-nvme` à matriz de StorageClasses do chart `platform/storage`, ao lado de `lab-*`, `san-*`, `hml-*` e `prod-*`. Mesmo provisioner `rancher.io/local-path` dos demais tiers; o override de **nome** e **`reclaimPolicy: Delete`** (em vez do default `Retain`) já é injetado pelo overlay `environments/standalone/values.yaml` (#73 / PR #95).

## Por que `reclaimPolicy: Delete` em standalone

Standalone é monolocal e descartável — re-bootstrap via Tofu re-cria os PVs (ADR-008). `Retain` acumularia PVs órfãos a cada teardown. Demais tiers mantêm o default `Retain` para preservar dados sensíveis (Vault, Postgres) ao deletar PVCs.

## Arquivos modificados

- `platform/storage/Chart.yaml` — incluir `standalone-local-nvme` na descrição do chart
- `platform/storage/values.yaml` — estender comentário com `standalone` e nota sobre o `reclaimPolicy` override
- `platform/storage/README.md` — adicionar linha Standalone à tabela de tiers, parágrafo explicativo sobre o `reclaimPolicy` e atualizar a referência aos overrides na variável `storage.storageClass.name`

Mudança puramente documental — nenhum manifest renderizado é alterado por este PR. O comportamento concreto vem do override em `environments/standalone/values.yaml` (#73).

## Validações

- \`yamllint -c .yamllint.yaml platform/storage/\` → clean
- \`helm lint platform/storage/\` → 0 falhas (1 INFO sobre \`icon\`, pré-existente)
- \`helm template platform/storage/ --set storage.storageClass.name=standalone-local-nvme --set storage.storageClass.reclaimPolicy=Delete\` → render OK (\`name: standalone-local-nvme\`, \`provisioner: rancher.io/local-path\`, \`reclaimPolicy: Delete\`)

> Validação combinada com o overlay \`environments/standalone/values.yaml\` foi executada localmente no contexto de #73 (PR #95). Após o merge dos dois PRs, o helm lint completo do chart com o overlay roda no CI normal.

## Test plan

- [ ] Confirmar que a tabela em `README.md` reflete a topologia standalone
- [ ] Confirmar que o `Chart.yaml` lista os 5 tiers atuais
- [ ] Após merge de #95 + este, rodar \`helm lint platform/storage/ -f environments/standalone/values.yaml\` no CI

Closes #74
Refs ADR-008, Epic #40, #73 (PR #95)