### PR TITLE
fix(argocd): habilitar goTemplate nos ApplicationSets + matriz de reconciliação standalone

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -52,6 +52,8 @@ E injeta **2 valueFiles**:
 - `values.yaml` (defaults do chart)
 - `environments/<environment>/values.yaml` (overrides do cluster)
 
+Os dois ApplicationSets declaram `spec.goTemplate: true` + `goTemplateOptions: [missingkey=error]`. Sem isso o controller cai em fasttemplate e renderiza literais como `{{.app}}`, `{{.metadata.labels.environment}}` e a função Sprig `replace` — todos os Applications gerados colidem no mesmo nome e o AppSet falha com `ApplicationValidationError`. Manter ao adicionar generators ou trocar a sintaxe dos templates.
+
 ## Aplicação
 
 Após o ArgoCD estar instalado:

--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -14,6 +14,13 @@ metadata:
   name: uniplus-apps
   namespace: argocd
 spec:
+  # Templates usam Go text/template + Sprig (acesso a nested maps como
+  # {{.metadata.labels.environment}}). Sem goTemplate=true o controller
+  # cai no modo fasttemplate e renderiza tudo literal — todos os Applications
+  # colidem no mesmo nome e o AppSet entra em ApplicationValidationError.
+  goTemplate: true
+  goTemplateOptions:
+    - missingkey=error
   generators:
     - matrix:
         generators:
@@ -74,6 +81,10 @@ metadata:
   name: uniplus-platform
   namespace: argocd
 spec:
+  # Ver comentário em uniplus-apps — função `replace` é Sprig, exige goTemplate.
+  goTemplate: true
+  goTemplateOptions:
+    - missingkey=error
   generators:
     - matrix:
         generators:

--- a/environments/standalone/README.md
+++ b/environments/standalone/README.md
@@ -99,20 +99,36 @@ Standalone entrega GitOps + provisioning + bootstrap K8s completos. A matriz de 
 
 Resultado da validação executada em 2026-05-05 contra o cluster `uniplus-standalone` (issue #86), aplicando `argocd/project.yaml` + `argocd/applicationset.yaml` após registrar o cluster com labels `uniplus.io/managed=true` + `environment=standalone`. Esta seção é o "estado da arte" que o standalone entrega hoje — fixa a expectativa de quem registra um novo cluster e impede falsos positivos em futuras sessões de validação.
 
-| Application | Sync | Health | Diagnóstico |
-|---|---|---|---|
-| `platform-storage-uniplus-standalone` | Synced | Healthy | StorageClass `standalone-local-nvme` criada e em uso pelos PVCs do Vault. |
-| `platform-vault-uniplus-standalone` | Synced | Progressing | Recursos aterrissam (StatefulSet, Services, RBAC, NetworkPolicy, Webhook). PVCs Bound. Pod-0 fica em `CreateContainerConfigError` com `Error: secret "vault-ocikms-config" not found` — comportamento esperado até que **#64** (Vault init + auto-unseal OCI KMS) sintetize o Secret via External Secrets. |
-| `platform-vault-transit-uniplus-standalone` | Synced | Healthy | `vaultTransit.enabled: false` no overlay → render vazio. Correto: standalone usa OCI KMS, não Transit em PA1. |
-| `platform-cert-manager-uniplus-standalone` | Unknown | Healthy | Chart placeholder sem `Chart.yaml` (gap pré-existente — issue #15). `ComparisonError`: `no such file or directory ... platform/cert-manager/Chart.yaml`. |
-| `platform-traefik-uniplus-standalone` | Unknown | Healthy | Idem placeholder. |
-| `platform-external-secrets-uniplus-standalone` | Unknown | Healthy | Idem placeholder — bloqueia #64 (sem ESO não há como sintetizar `vault-ocikms-config`). |
-| `platform-cloudflared-uniplus-standalone` | Unknown | Healthy | Idem placeholder. |
-| `platform-observability-{prometheus,grafana,loki,tempo,otel-collector}-uniplus-standalone` | Unknown | Healthy | Idem placeholder. |
-| `uniplus-web-uniplus-standalone` | Synced | Healthy | Chart sem templates → render vazio. "Healthy" reflete zero recursos, não app rodando. |
-| `uniplus-api-{portal,selecao,ingresso}-uniplus-standalone` | Synced | Healthy | Idem render vazio. Endpoints de Postgres/Redis/Kafka/MinIO chegariam via External Secrets a partir do data-host quando o Epic `data/*` aterrissar. |
-| `clamav-scanner-uniplus-standalone` | Synced | Healthy | Idem render vazio. |
-| `keycloak-replica-uniplus-standalone` | Synced | Healthy | Idem render vazio. |
+Todos os Unknown abaixo são charts placeholder (apenas `README.md` com aviso `Status: placeholder inicial`, sem `Chart.yaml`). São sub-issues da Feature **#3** (`feat(platform): criar Helm charts dos 10 componentes em platform/`) — gap pré-existente, não específico do standalone.
+
+| Application | Sync | Health | Issue | Diagnóstico |
+|---|---|---|---|---|
+| `platform-storage-uniplus-standalone` | Synced | Healthy | — | StorageClass `standalone-local-nvme` criada e em uso pelos PVCs do Vault. |
+| `platform-vault-uniplus-standalone` | Synced | Progressing | #64 | Recursos aterrissam (StatefulSet, Services, RBAC, NetworkPolicy, Webhook). PVCs Bound. Pod-0 fica em `CreateContainerConfigError` com `Error: secret "vault-ocikms-config" not found` — comportamento esperado até que #64 (Vault init + auto-unseal OCI KMS) sintetize o Secret via External Secrets. |
+| `platform-vault-transit-uniplus-standalone` | Synced | Healthy | — | `vaultTransit.enabled: false` no overlay → render vazio. Correto: standalone usa OCI KMS, não Transit em PA1. |
+| `platform-cert-manager-uniplus-standalone` | Unknown | Healthy | [#15][i15] | Placeholder. `ComparisonError`: `no such file or directory ... platform/cert-manager/Chart.yaml`. |
+| `platform-traefik-uniplus-standalone` | Unknown | Healthy | [#14][i14] | Placeholder. |
+| `platform-external-secrets-uniplus-standalone` | Unknown | Healthy | [#24][i24] | Placeholder — também bloqueia #64 (sem ESO não há como sintetizar `vault-ocikms-config`). |
+| `platform-cloudflared-uniplus-standalone` | Unknown | Healthy | [#25][i25] | Placeholder. |
+| `platform-observability-prometheus-uniplus-standalone` | Unknown | Healthy | [#26][i26] | Placeholder. |
+| `platform-observability-grafana-uniplus-standalone` | Unknown | Healthy | [#27][i27] | Placeholder. |
+| `platform-observability-loki-uniplus-standalone` | Unknown | Healthy | [#28][i28] | Placeholder. |
+| `platform-observability-tempo-uniplus-standalone` | Unknown | Healthy | [#29][i29] | Placeholder. |
+| `platform-observability-otel-collector-uniplus-standalone` | Unknown | Healthy | [#30][i30] | Placeholder. |
+| `uniplus-web-uniplus-standalone` | Synced | Healthy | — | Chart sem templates → render vazio. "Healthy" reflete zero recursos, não app rodando. |
+| `uniplus-api-{portal,selecao,ingresso}-uniplus-standalone` | Synced | Healthy | — | Idem render vazio. Endpoints de Postgres/Redis/Kafka/MinIO chegariam via External Secrets a partir do data-host quando o Epic `data/*` aterrissar. |
+| `clamav-scanner-uniplus-standalone` | Synced | Healthy | — | Idem render vazio. |
+| `keycloak-replica-uniplus-standalone` | Synced | Healthy | — | Idem render vazio. |
+
+[i14]: https://github.com/unifesspa-edu-br/uniplus-infra/issues/14
+[i15]: https://github.com/unifesspa-edu-br/uniplus-infra/issues/15
+[i24]: https://github.com/unifesspa-edu-br/uniplus-infra/issues/24
+[i25]: https://github.com/unifesspa-edu-br/uniplus-infra/issues/25
+[i26]: https://github.com/unifesspa-edu-br/uniplus-infra/issues/26
+[i27]: https://github.com/unifesspa-edu-br/uniplus-infra/issues/27
+[i28]: https://github.com/unifesspa-edu-br/uniplus-infra/issues/28
+[i29]: https://github.com/unifesspa-edu-br/uniplus-infra/issues/29
+[i30]: https://github.com/unifesspa-edu-br/uniplus-infra/issues/30
 
 **Ajustes de values descobertos:** nenhum específico ao overlay standalone. O `values.yaml` deste diretório cobre os charts reais (`platform/storage`, `platform/vault`, `platform/vault-transit`) sem necessidade de override adicional.
 

--- a/environments/standalone/README.md
+++ b/environments/standalone/README.md
@@ -95,6 +95,29 @@ Standalone entrega o overlay GitOps; os charts acima são gap pré-existente do 
 
 Standalone entrega GitOps + provisioning + bootstrap K8s completos. A matriz de validação end-to-end (Postgres, Kafka, MinIO no data-host) só fecha 100% após o Epic `data/*` aterrissar — gap pré-existente, tratado como Epic separado (ADR-008, seção "Decisões de design já tomadas").
 
+## Matriz observada de reconciliação ArgoCD
+
+Resultado da validação executada em 2026-05-05 contra o cluster `uniplus-standalone` (issue #86), aplicando `argocd/project.yaml` + `argocd/applicationset.yaml` após registrar o cluster com labels `uniplus.io/managed=true` + `environment=standalone`. Esta seção é o "estado da arte" que o standalone entrega hoje — fixa a expectativa de quem registra um novo cluster e impede falsos positivos em futuras sessões de validação.
+
+| Application | Sync | Health | Diagnóstico |
+|---|---|---|---|
+| `platform-storage-uniplus-standalone` | Synced | Healthy | StorageClass `standalone-local-nvme` criada e em uso pelos PVCs do Vault. |
+| `platform-vault-uniplus-standalone` | Synced | Progressing | Recursos aterrissam (StatefulSet, Services, RBAC, NetworkPolicy, Webhook). PVCs Bound. Pod-0 fica em `CreateContainerConfigError` com `Error: secret "vault-ocikms-config" not found` — comportamento esperado até que **#64** (Vault init + auto-unseal OCI KMS) sintetize o Secret via External Secrets. |
+| `platform-vault-transit-uniplus-standalone` | Synced | Healthy | `vaultTransit.enabled: false` no overlay → render vazio. Correto: standalone usa OCI KMS, não Transit em PA1. |
+| `platform-cert-manager-uniplus-standalone` | Unknown | Healthy | Chart placeholder sem `Chart.yaml` (gap pré-existente — issue #15). `ComparisonError`: `no such file or directory ... platform/cert-manager/Chart.yaml`. |
+| `platform-traefik-uniplus-standalone` | Unknown | Healthy | Idem placeholder. |
+| `platform-external-secrets-uniplus-standalone` | Unknown | Healthy | Idem placeholder — bloqueia #64 (sem ESO não há como sintetizar `vault-ocikms-config`). |
+| `platform-cloudflared-uniplus-standalone` | Unknown | Healthy | Idem placeholder. |
+| `platform-observability-{prometheus,grafana,loki,tempo,otel-collector}-uniplus-standalone` | Unknown | Healthy | Idem placeholder. |
+| `uniplus-web-uniplus-standalone` | Synced | Healthy | Chart sem templates → render vazio. "Healthy" reflete zero recursos, não app rodando. |
+| `uniplus-api-{portal,selecao,ingresso}-uniplus-standalone` | Synced | Healthy | Idem render vazio. Endpoints de Postgres/Redis/Kafka/MinIO chegariam via External Secrets a partir do data-host quando o Epic `data/*` aterrissar. |
+| `clamav-scanner-uniplus-standalone` | Synced | Healthy | Idem render vazio. |
+| `keycloak-replica-uniplus-standalone` | Synced | Healthy | Idem render vazio. |
+
+**Ajustes de values descobertos:** nenhum específico ao overlay standalone. O `values.yaml` deste diretório cobre os charts reais (`platform/storage`, `platform/vault`, `platform/vault-transit`) sem necessidade de override adicional.
+
+**Bug corrigido na validação:** os dois ApplicationSets em `argocd/applicationset.yaml` precisavam de `spec.goTemplate: true` + `goTemplateOptions: [missingkey=error]` — sem isso o controller renderizava `{{.app}}`, `{{.metadata.labels.environment}}` e `{{.component | replace "/" "-"}}` literalmente, todos os Applications colidiam no mesmo nome e o AppSet falhava em `ApplicationValidationError`. O fix está no manifesto principal e não é específico do standalone (afeta qualquer ambiente).
+
 ## Documentos relacionados
 
 - [ADR-008 — Topologia standalone](../../docs/adrs/ADR-008-topologia-standalone.md) — decisão e premissas


### PR DESCRIPTION
## Sumário

Fecha #86 — validação da reconciliação ArgoCD de `apps/` e `platform/` contra o cluster `uniplus-standalone`.

A validação revelou um bug bloqueante (corrigido) e produziu uma matriz Sync/Health que vira referência para futuras validações.

## Mudanças

**1. `fix(argocd)` — `goTemplate: true` nos dois ApplicationSets**

Sem `spec.goTemplate: true`, o controller cai em fasttemplate e renderiza `{{.app}}`, `{{.metadata.labels.environment}}` e a função Sprig `replace` literalmente. Resultado observado antes do fix:

```
ApplicationSet uniplus-platform contains applications with duplicate name:
  platform-{{.component | replace "/" "-"}}-{{.name}} (and 11 more)
Reason: ApplicationValidationError
```

Adicionado `goTemplateOptions: [missingkey=error]` para falhar cedo se um campo de parâmetro sumir, em vez de gerar nomes vazios silenciosamente. Nota também adicionada em `argocd/README.md` para evitar regressão.

**2. `docs(standalone)` — matriz observada de reconciliação**

Nova seção em `environments/standalone/README.md` registrando o que cada Application produz hoje no cluster real, separando charts reais (`storage`, `vault`, `vault-transit`) dos placeholders pré-existentes (`cert-manager`, `traefik`, `external-secrets`, `cloudflared`, `observability/*`) e dos esqueletos sem templates (`apps/*`).

## Achados principais

- **18 Applications geradas** após o fix (6 apps + 12 platform).
- **`platform/storage`**: StorageClass `standalone-local-nvme` aplicada e em uso pelos PVCs do Vault.
- **`platform/vault`**: recursos aterrissam corretamente (StatefulSet, Services, RBAC, NetworkPolicy, Webhook). PVCs Bound. Pod-0 em `CreateContainerConfigError` por `secret "vault-ocikms-config" not found` — esperado até #64.
- **`platform/vault-transit`**: render vazio com `enabled: false` (correto, standalone usa OCI KMS).
- **Placeholders sem `Chart.yaml`** geram `ComparisonError` mas não bloqueiam a reconciliação dos charts reais. Gap pré-existente, não específico do standalone.
- **`apps/*` esqueletos** mostram Synced/Healthy mas deployam zero recursos — "Healthy" enganoso, documentado.
- **Nenhum ajuste de values específico do standalone** descoberto além do já presente.

## Validação executada

- Cluster: `uniplus-standalone` (OCI sa-saopaulo-1, k8s-host)
- Registrado via Secret `cluster-standalone-incluster` com labels `uniplus.io/managed=true` + `environment=standalone`
- `kubectl apply -f argocd/project.yaml -f argocd/applicationset.yaml`
- `kubectl get applications -n argocd` → 18 Applications, status conferido linha a linha
- `kubectl describe pod platform-vault-uniplus-standalone-0` → confirma dependência em `vault-ocikms-config`
- `yamllint -c .yamllint.yaml argocd/ environments/standalone/` → 0 issues
- `markdownlint-cli2 argocd/README.md environments/standalone/README.md` → 0 errors

## Test plan

- [ ] Após merge, ArgoCD do standalone reaplica o ApplicationSet (auto-sync) e mantém os 18 Apps gerados
- [ ] Quando #64 mergear e sintetizar `vault-ocikms-config`, o Pod-0 do Vault sai de `CreateContainerConfigError` e a Application transita para Synced/Healthy

## Issues relacionadas

Closes #86. Sub-issue da Story #63 (única task da Story).

Dependência observada: #64 (Vault auto-unseal) — já planejada, esta validação só evidenciou o ponto de espera.

Charts placeholder pré-existentes (issue #15 + outros) — não são bloqueio desta task.