### PR TITLE
feat(cert-manager): chart wrapper v1.20.2 + ClusterIssuers Let's Encrypt (HTTP-01)

### DIFF
--- a/environments/standalone/README.md
+++ b/environments/standalone/README.md
@@ -84,7 +84,7 @@ Procedimento detalhado: `docs/RUNBOOKS.md` §8 (Bootstrap e Teardown — Ambient
 
 Charts referenciados pelo overlay que ainda são placeholders (sem `Chart.yaml`/templates) e precisam aterrissar antes do bootstrap funcionar end-to-end:
 
-- `platform/cert-manager/` — `ingress.tls.issuer: letsencrypt` neste overlay assume `cert-manager` instalado e um `ClusterIssuer` chamado `letsencrypt` configurado para HTTP-01 (issue #15).
+- `platform/cert-manager/` — `ingress.tls.issuer: letsencrypt-prod` neste overlay assume `cert-manager` instalado e o `ClusterIssuer` `letsencrypt-prod` configurado para HTTP-01 (issue #15; chart cria também `letsencrypt-staging`).
 - `platform/traefik/` — terminação TLS e roteamento por path no FQDN único de standalone.
 - `platform/external-secrets/` — sintetiza o Secret `vault-ocikms-config` consumido pelo Vault (issue #64).
 - `platform/cloudflared/`, `platform/observability/*` — completam o stack de borda e observabilidade.

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -24,7 +24,7 @@ ingress:
   host: standalone.example
   tls:
     enabled: true
-    issuer: letsencrypt  # cert-manager emite via HTTP-01 (single-host simplifica DNS-01)
+    issuer: letsencrypt-prod  # cert-manager emite via HTTP-01 (single-host simplifica DNS-01); chart cria letsencrypt-{staging,prod}
 
 # Postgres single-primary por banco — sem replica (data-host é único).
 # Patroni é dispensado nesta topologia; chart consumidor deve interpretar

--- a/platform/cert-manager/Chart.lock
+++ b/platform/cert-manager/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: cert-manager
+  repository: https://charts.jetstack.io
+  version: v1.20.2
+digest: sha256:141fadb572c29e1104fbfef298cd02b7d985d46f4d47fc2ccae48defc1b76200
+generated: "2026-05-05T00:14:09.371143582-03:00"

--- a/platform/cert-manager/Chart.yaml
+++ b/platform/cert-manager/Chart.yaml
@@ -1,0 +1,40 @@
+apiVersion: v2
+name: cert-manager
+description: |
+  cert-manager — emissão e renovação automática de certificados X.509 no
+  cluster. Empacotado como chart wrapper sobre jetstack/cert-manager
+  com ClusterIssuers Let's Encrypt (staging + prod) via HTTP-01 + Traefik.
+type: application
+
+# Versão do chart wrapper Uni+.
+version: 0.1.0
+
+# Versão do cert-manager upstream empacotado.
+appVersion: "v1.20.2"
+
+home: https://github.com/unifesspa-edu-br/uniplus-infra
+sources:
+  - https://github.com/unifesspa-edu-br/uniplus-infra
+  - https://github.com/cert-manager/cert-manager
+
+maintainers:
+  - name: CTIC Unifesspa
+    url: https://github.com/unifesspa-edu-br
+
+keywords:
+  - cert-manager
+  - tls
+  - letsencrypt
+  - acme
+  - uniplus
+
+# Dependência do chart upstream oficial.
+# `alias: certManager` mantém consistência com o padrão do platform/external-secrets/
+# (alias camelCase para acessar valores via `.Values.certManager.*` em Go templates).
+dependencies:
+  - name: cert-manager
+    alias: certManager
+    version: v1.20.2
+    repository: https://charts.jetstack.io
+    # Permite desligar o subchart por environment se necessário.
+    condition: certManager.enabled

--- a/platform/cert-manager/README.md
+++ b/platform/cert-manager/README.md
@@ -68,16 +68,31 @@ Após o ApplicationSet sincronizar:
 
 ## Como emitir um certificado
 
-Anotar um IngressRoute (Traefik CRD) ou Service para emissão automática:
+Importante: o `ingress-shim` do cert-manager só auto-gera `Certificate` a partir de `Ingress` (networking.k8s.io/v1) ou Gateway API — **não** de `IngressRoute` (CRD do Traefik). A annotation `cert-manager.io/cluster-issuer` é ignorada em IngressRoutes. Há duas opções:
+
+**Opção A — Certificate explícito + IngressRoute referenciando o Secret** (recomendado quando o stack usa Traefik IngressRoute):
 
 ```yaml
+# 1. Certificate explícito — cert-manager solicita e renova
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: portal-tls
+  namespace: uniplus
+spec:
+  secretName: portal-tls           # Secret que cert-manager cria/atualiza
+  issuerRef:
+    name: letsencrypt-prod         # ou letsencrypt-staging para validação
+    kind: ClusterIssuer
+  dnsNames:
+    - standalone.portaluni.com.br
+---
+# 2. IngressRoute consome o Secret pronto
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: portal
   namespace: uniplus
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod  # ou letsencrypt-staging para teste
 spec:
   entryPoints: [websecure]
   routes:
@@ -87,10 +102,37 @@ spec:
         - name: uniplus-web
           port: 80
   tls:
-    secretName: portal-tls  # cert-manager preenche
+    secretName: portal-tls         # mesmo nome do Certificate.spec.secretName
 ```
 
-Para ambiente de testes, sempre começar com `letsencrypt-staging` (cert não confiável mas sem rate limit).
+**Opção B — Ingress nativo + ingress-shim** (caminho automático):
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: portal
+  namespace: uniplus
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [standalone.portaluni.com.br]
+      secretName: portal-tls
+  rules:
+    - host: standalone.portaluni.com.br
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: uniplus-web
+                port: { number: 80 }
+```
+
+Para validação inicial, sempre começar com `letsencrypt-staging` (cert não confiável pelo browser mas sem rate limit). Após confirmar o fluxo, trocar para `letsencrypt-prod`.
 
 ## Renovação
 

--- a/platform/cert-manager/README.md
+++ b/platform/cert-manager/README.md
@@ -1,30 +1,138 @@
 # cert-manager
 
-Provisionamento automático de certificados TLS (Let's Encrypt)
-
-> ⚠️ **Status:** placeholder inicial.
+Provisionamento automático de certificados TLS via Let's Encrypt (HTTP-01 + Traefik).
 
 ## Visão geral
 
-Componente de plataforma do cluster Kubernetes do Uni+.
+Wrapper do chart oficial [jetstack/cert-manager](https://github.com/cert-manager/cert-manager). Roda em cada cluster (lab-{sp1,sp2}, prod-{sp1,sp2}, standalone). Em PA1 pode permanecer desligado — não há ingress público lá.
 
 **Upstream:** https://github.com/cert-manager/cert-manager
+**Versão upstream empacotada:** v1.20.2 (ver `Chart.yaml`)
 
-## Estratégia de deploy
+## Estratégia de emissão
 
-Recomenda-se usar o **chart upstream oficial** quando disponível, ao invés de manter chart próprio. Esta pasta deve conter:
+- **HTTP-01 via Traefik** para hosts simples (cobertura desta PR)
+- **DNS-01 wildcard** fora de escopo até decisão DIRSI sobre borda externa (ADR-004) — separado para evitar acoplar Cloudflare DNS API ao Uni+ antes da decisão
 
-- `Chart.yaml` — chart umbrella ou referência ao chart upstream
-- `values.yaml` — valores customizados para o ambiente Uni+
-- `README.md` — este arquivo
+Standalone usa apenas HTTP-01 (FQDN único `standalone.portaluni.com.br`). 3-DC poderá adicionar DNS-01 quando decisão de borda for tomada.
 
-## Implementação pendente
+## Estrutura
 
-- [ ] Chart.yaml com dependência do chart upstream
-- [ ] values.yaml com configuração base
-- [ ] Documentação de configurações específicas
-- [ ] ApplicationSet ArgoCD
+```
+platform/cert-manager/
+├── Chart.yaml                                          # subchart upstream (alias=certManager)
+├── values.yaml                                         # defaults Uni+
+├── values.schema.json                                  # validação dos overrides
+├── README.md                                           # este arquivo
+└── templates/
+    ├── clusterissuer-letsencrypt-staging.yaml          # ACME staging (gated)
+    ├── clusterissuer-letsencrypt-prod.yaml             # ACME production (gated)
+    └── networkpolicy.yaml                              # egress controlado
+```
 
-## Contribuindo
+ServiceMonitor vem do subchart upstream (gateado por `certManager.prometheus.servicemonitor.enabled`). Wrapper não emite SM próprio.
 
-PRs em [unifesspa-edu-br/uniplus-infra](https://github.com/unifesspa-edu-br/uniplus-infra).
+## Bootstrap
+
+Após o ApplicationSet sincronizar:
+
+1. Pods do controller, webhook e cainjector sobem (3 Deployments)
+2. CRDs `certificates.cert-manager.io`, `clusterissuers.cert-manager.io`, etc. são instaladas
+3. ClusterIssuers permanecem desligados até `clusterIssuers.enabled: true` em algum environment
+4. Habilitar requer **Traefik (#14) Synced/Healthy** — sem IngressClass `traefik`, HTTP-01 challenges falham
+5. Habilitar via override:
+
+   ```yaml
+   # environments/standalone/values.yaml
+   clusterIssuers:
+     enabled: true
+   ```
+
+6. ArgoCD reconcilia, ClusterIssuers ficam `Ready=True` após primeira interação ACME
+
+## Variáveis principais
+
+| Variável | Default | Notas |
+|---|---|---|
+| `certManager.enabled` | `true` | Liga o subchart |
+| `certManager.crds.enabled` | `true` | Instala CRDs (Certificate, Issuer, etc.) |
+| `certManager.crds.keep` | `true` | Não remove CRDs em uninstall |
+| `certManager.replicaCount` | `1` | 1 em lab/standalone, 2+ em prod |
+| `certManager.prometheus.servicemonitor.enabled` | `false` | Ligar quando #26 (Prometheus chart) estiver pronto |
+| `clusterIssuers.enabled` | `false` | Habilitar APÓS Traefik (#14) estar pronto |
+| `clusterIssuers.email` | `ctic@unifesspa.edu.br` | Registro ACME — recebe avisos de expiração |
+| `clusterIssuers.ingressClass` | `traefik` | IngressClass que resolve HTTP-01 |
+| `clusterIssuers.staging.enabled` | `true` | ACME staging (sem rate limit relevante) |
+| `clusterIssuers.production.enabled` | `true` | ACME production (rate limit 50 certs/domain/week) |
+| `networkPolicy.enabled` | `true` | Egress restrito a internet:443, kube-dns, K8s API |
+
+## Como emitir um certificado
+
+Anotar um IngressRoute (Traefik CRD) ou Service para emissão automática:
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: portal
+  namespace: uniplus
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod  # ou letsencrypt-staging para teste
+spec:
+  entryPoints: [websecure]
+  routes:
+    - match: Host(`standalone.portaluni.com.br`)
+      kind: Rule
+      services:
+        - name: uniplus-web
+          port: 80
+  tls:
+    secretName: portal-tls  # cert-manager preenche
+```
+
+Para ambiente de testes, sempre começar com `letsencrypt-staging` (cert não confiável mas sem rate limit).
+
+## Renovação
+
+Renovação automática 30 dias antes da expiração (default do cert-manager). Forçar renovação manual:
+
+```bash
+kubectl cmctl renew portal -n uniplus
+# ou via annotation:
+kubectl annotate certificate portal -n uniplus cert-manager.io/issue-temporary-certificate-
+```
+
+## Observabilidade
+
+cert-manager expõe métricas Prometheus na porta `9402` (default upstream). O ServiceMonitor é gerado pelo próprio subchart quando `certManager.prometheus.servicemonitor.enabled: true` — manter desligado até o stack Prometheus (#26) estar no ar. Wrapper não emite SM próprio para evitar scrape duplicado.
+
+Métricas chave:
+- `certmanager_certificate_expiration_timestamp_seconds` — quando cada cert vai expirar
+- `certmanager_http_acme_client_request_count` — chamadas ao ACME server
+- `certmanager_certificate_ready_status` — gauge de saúde dos certs
+
+## Network
+
+NetworkPolicy do chart restringe egress dos Pods do operator a:
+- Internet pública na porta 443 (ACME endpoints — não há IP estável para Let's Encrypt)
+- kube-dns (UDP/TCP 53)
+- Kubernetes API (TCP 6443/443) restrito ao service CIDR
+
+Egress para internet exclui CIDRs RFC 1918 (já cobertos por outras regras).
+
+Sem ingress (controller não recebe tráfego direto — webhook é gerenciado pelo subchart).
+
+## Segurança
+
+- ACME private keys ficam em Secrets gerenciados pelo cert-manager (`letsencrypt-{staging,prod}-account-key`)
+- Email registrado no ACME é endereço institucional CTIC — alertas de expiração chegam ao canal correto
+- Egress limitado por NetworkPolicy
+- CRDs com `keep: true` evitam perda de Certificates/Orders se o chart for desinstalado por engano
+
+## Referências
+
+- [#3](https://github.com/unifesspa-edu-br/uniplus-infra/issues/3) — umbrella platform charts
+- [#15](https://github.com/unifesspa-edu-br/uniplus-infra/issues/15) — esta task
+- [#14](https://github.com/unifesspa-edu-br/uniplus-infra/issues/14) — Traefik (pré-requisito do HTTP-01)
+- ADR-004 (borda externa — DNS-01 fica para depois)
+- ADR-008 (topologia standalone)

--- a/platform/cert-manager/templates/clusterissuer-letsencrypt-prod.yaml
+++ b/platform/cert-manager/templates/clusterissuer-letsencrypt-prod.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterIssuers.enabled .Values.clusterIssuers.production.enabled }}
+{{- if and .Values.certManager.enabled .Values.clusterIssuers.enabled .Values.clusterIssuers.production.enabled }}
 {{- if not .Values.clusterIssuers.email -}}
 {{- fail "clusterIssuers.enabled=true exige clusterIssuers.email não vazio (registro ACME)." -}}
 {{- end }}

--- a/platform/cert-manager/templates/clusterissuer-letsencrypt-prod.yaml
+++ b/platform/cert-manager/templates/clusterissuer-letsencrypt-prod.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: uniplus
     app.kubernetes.io/component: cert-manager
@@ -23,7 +24,10 @@ spec:
     privateKeySecretRef:
       name: {{ .Values.clusterIssuers.production.privateKeySecretRef | quote }}
     solvers:
+      # ingressClassName é o caminho moderno (campo nativo do Ingress v1).
+      # `class` (legacy) controla a annotation kubernetes.io/ingress.class
+      # do v1beta1 — Traefik v3 lê ingressClassName.
       - http01:
           ingress:
-            class: {{ .Values.clusterIssuers.ingressClass | quote }}
+            ingressClassName: {{ .Values.clusterIssuers.ingressClass | quote }}
 {{- end }}

--- a/platform/cert-manager/templates/clusterissuer-letsencrypt-prod.yaml
+++ b/platform/cert-manager/templates/clusterissuer-letsencrypt-prod.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.clusterIssuers.enabled .Values.clusterIssuers.production.enabled }}
+{{- if not .Values.clusterIssuers.email -}}
+{{- fail "clusterIssuers.enabled=true exige clusterIssuers.email não vazio (registro ACME)." -}}
+{{- end }}
+# ClusterIssuer Let's Encrypt PRODUCTION — HTTP-01 via Traefik.
+# ATENÇÃO: rate limit de 50 certs/domain/week. Sempre validar primeiro com
+# o `letsencrypt-staging`. Para emitir um certificado, anotar o IngressRoute
+# (ou Certificate manual) com `cert-manager.io/cluster-issuer: letsencrypt-prod`.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+  labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: uniplus
+    app.kubernetes.io/component: cert-manager
+spec:
+  acme:
+    email: {{ .Values.clusterIssuers.email | quote }}
+    server: {{ .Values.clusterIssuers.production.server | quote }}
+    privateKeySecretRef:
+      name: {{ .Values.clusterIssuers.production.privateKeySecretRef | quote }}
+    solvers:
+      - http01:
+          ingress:
+            class: {{ .Values.clusterIssuers.ingressClass | quote }}
+{{- end }}

--- a/platform/cert-manager/templates/clusterissuer-letsencrypt-staging.yaml
+++ b/platform/cert-manager/templates/clusterissuer-letsencrypt-staging.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.clusterIssuers.enabled .Values.clusterIssuers.staging.enabled }}
+{{- if not .Values.clusterIssuers.email -}}
+{{- fail "clusterIssuers.enabled=true exige clusterIssuers.email não vazio (registro ACME)." -}}
+{{- end }}
+# ClusterIssuer Let's Encrypt STAGING — HTTP-01 via Traefik.
+# Servidor de testes (sem rate limit relevante; certificados não confiáveis
+# por browsers). Use para validar o caminho de emissão antes de promover ao
+# `letsencrypt-prod` (rate limit 50 certs/domain/week).
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+  labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: uniplus
+    app.kubernetes.io/component: cert-manager
+spec:
+  acme:
+    email: {{ .Values.clusterIssuers.email | quote }}
+    server: {{ .Values.clusterIssuers.staging.server | quote }}
+    privateKeySecretRef:
+      name: {{ .Values.clusterIssuers.staging.privateKeySecretRef | quote }}
+    solvers:
+      - http01:
+          ingress:
+            class: {{ .Values.clusterIssuers.ingressClass | quote }}
+{{- end }}

--- a/platform/cert-manager/templates/clusterissuer-letsencrypt-staging.yaml
+++ b/platform/cert-manager/templates/clusterissuer-letsencrypt-staging.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: uniplus
     app.kubernetes.io/component: cert-manager
@@ -23,7 +24,10 @@ spec:
     privateKeySecretRef:
       name: {{ .Values.clusterIssuers.staging.privateKeySecretRef | quote }}
     solvers:
+      # ingressClassName é o caminho moderno (campo nativo do Ingress v1).
+      # `class` (legacy) controla a annotation kubernetes.io/ingress.class
+      # do v1beta1 — Traefik v3 lê ingressClassName.
       - http01:
           ingress:
-            class: {{ .Values.clusterIssuers.ingressClass | quote }}
+            ingressClassName: {{ .Values.clusterIssuers.ingressClass | quote }}
 {{- end }}

--- a/platform/cert-manager/templates/clusterissuer-letsencrypt-staging.yaml
+++ b/platform/cert-manager/templates/clusterissuer-letsencrypt-staging.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterIssuers.enabled .Values.clusterIssuers.staging.enabled }}
+{{- if and .Values.certManager.enabled .Values.clusterIssuers.enabled .Values.clusterIssuers.staging.enabled }}
 {{- if not .Values.clusterIssuers.email -}}
 {{- fail "clusterIssuers.enabled=true exige clusterIssuers.email não vazio (registro ACME)." -}}
 {{- end }}

--- a/platform/cert-manager/templates/networkpolicy.yaml
+++ b/platform/cert-manager/templates/networkpolicy.yaml
@@ -6,19 +6,36 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: uniplus
 spec:
-  # Subchart upstream cria 3 Deployments com app.kubernetes.io/name distintos
-  # (`cert-manager`, `webhook`, `cainjector`). Selecionar por `name` exigiria
-  # listar os 3 nomes. `app.kubernetes.io/component: cert-manager` (de
-  # `global.commonLabels` em values.yaml) está nos 3 e é mais específico que
-  # os nomes genéricos `webhook`/`cainjector` (que poderiam colidir com outros
-  # charts). Combinado com instance, isola exatamente este release.
+  # Subchart upstream cria 3 Deployments + 1 startup Job com nomes distintos:
+  #   - cert-manager     (controller)
+  #   - webhook          (validating webhook)
+  #   - cainjector       (CA bundle injector)
+  #   - startupapicheck  (post-install Job, hook helm.sh/hook=post-install)
+  #
+  # `commonLabels` NÃO pode adicionar `app.kubernetes.io/component` porque
+  # o subchart hardcoda esse label nos selectors das Deployments com valores
+  # diferentes (`controller`/`webhook`/`cainjector`); sobrescrever quebra a
+  # API admission. Selecionamos os 3 Pods longos por `name` + `instance`.
+  # startupapicheck é Job de execução curta (post-install) e fica fora —
+  # se for bloqueado pela default-deny do CNI, falha o helm hook mas não
+  # impede o controller de rodar (workaround: adicionar `startupapicheck`
+  # ao In: caso CNI default-deny seja restritivo).
   podSelector:
-    matchLabels:
-      app.kubernetes.io/component: cert-manager
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - cert-manager
+          - webhook
+          - cainjector
+      - key: app.kubernetes.io/instance
+        operator: In
+        values:
+          - {{ .Release.Name }}
   policyTypes:
     - Egress
   egress:

--- a/platform/cert-manager/templates/networkpolicy.yaml
+++ b/platform/cert-manager/templates/networkpolicy.yaml
@@ -39,10 +39,12 @@ spec:
   policyTypes:
     - Egress
   egress:
-    # ACME server (Let's Encrypt) — HTTPS na internet pública.
-    # Não há como restringir por IP estável (Let's Encrypt usa CDN/anycast),
-    # então o controle é por porta 443 + DNS only. Aceitável: cert-manager
-    # só fala com endpoints ACME (RFC 8555) na porta 443.
+    # ACME server (Let's Encrypt) na porta 443 + self-check HTTP-01 na 80.
+    # Não há como restringir por IP estável (Let's Encrypt usa CDN/anycast).
+    # cert-manager faz GET http://<host>/.well-known/acme-challenge/<token>
+    # ANTES de pedir validação ao Let's Encrypt — sem 80 liberado, a
+    # autovalidação trava em CNIs com egress default-deny e o certificado
+    # nunca sai do estado pending.
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
@@ -54,6 +56,8 @@ spec:
       ports:
         - protocol: TCP
           port: 443
+        - protocol: TCP
+          port: 80
     # DNS (kube-dns).
     - to:
         - namespaceSelector:

--- a/platform/cert-manager/templates/networkpolicy.yaml
+++ b/platform/cert-manager/templates/networkpolicy.yaml
@@ -1,0 +1,63 @@
+{{- if and .Values.networkPolicy.enabled .Values.certManager.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-cert-manager
+  labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: uniplus
+spec:
+  # Subchart upstream cria 3 Deployments com app.kubernetes.io/name distintos
+  # (`cert-manager`, `webhook`, `cainjector`). Selecionar por `name` exigiria
+  # listar os 3 nomes. `app.kubernetes.io/component: cert-manager` (de
+  # `global.commonLabels` em values.yaml) está nos 3 e é mais específico que
+  # os nomes genéricos `webhook`/`cainjector` (que poderiam colidir com outros
+  # charts). Combinado com instance, isola exatamente este release.
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: cert-manager
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Egress
+  egress:
+    # ACME server (Let's Encrypt) — HTTPS na internet pública.
+    # Não há como restringir por IP estável (Let's Encrypt usa CDN/anycast),
+    # então o controle é por porta 443 + DNS only. Aceitável: cert-manager
+    # só fala com endpoints ACME (RFC 8555) na porta 443.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              # Bloquear egress para CIDRs internos (já cobertos por outras regras).
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+    # DNS (kube-dns).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Kubernetes API (CRD operations, SAR/TokenReview, ingress lookup).
+    {{- with .Values.networkPolicy.kubeApiCidrs }}
+    - to:
+        {{- range . }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 6443
+        - protocol: TCP
+          port: 443
+    {{- end }}
+{{- end }}

--- a/platform/cert-manager/values.schema.json
+++ b/platform/cert-manager/values.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/unifesspa-edu-br/uniplus-infra/platform/cert-manager/values.schema.json",
+  "title": "cert-manager chart values",
+  "description": "Schema dos values do chart platform/cert-manager/. Subchart jetstack/cert-manager tem seu próprio schema — additionalProperties=true permite passar overrides que serão validados pelo upstream.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "certManager": {
+      "type": "object",
+      "description": "Bloco do subchart jetstack/cert-manager (alias certManager).",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Liga/desliga o subchart. False em PA1 (não há ingress público)."
+        },
+        "nameOverride": {
+          "type": "string",
+          "description": "Força o subchart a usar este nome (kebab-case Uni+) em labels e nomes de recursos, restaurando convenção apesar do alias camelCase."
+        },
+        "crds": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "keep": { "type": "boolean" }
+          }
+        },
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "resources": { "$ref": "#/$defs/k8sResources" },
+        "webhook": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "replicaCount": { "type": "integer", "minimum": 1 },
+            "resources": { "$ref": "#/$defs/k8sResources" }
+          }
+        },
+        "cainjector": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "replicaCount": { "type": "integer", "minimum": 1 },
+            "resources": { "$ref": "#/$defs/k8sResources" }
+          }
+        },
+        "prometheus": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "servicemonitor": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "ServiceMonitor do subchart upstream. Wrapper não emite SM próprio. Default false até #26."
+                }
+              }
+            }
+          }
+        },
+        "global": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "commonLabels": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "clusterIssuers": {
+      "type": "object",
+      "description": "ClusterIssuers Let's Encrypt — HTTP-01 via Traefik.",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Habilitar apenas após Traefik (#14) estar Synced/Healthy."
+        },
+        "email": {
+          "type": "string",
+          "format": "email",
+          "description": "Email para registro ACME — recebe avisos de expiração."
+        },
+        "ingressClass": {
+          "type": "string",
+          "description": "IngressClass que resolve HTTP-01 challenges (default: traefik)."
+        },
+        "staging": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "server": { "type": "string", "format": "uri" },
+            "privateKeySecretRef": { "type": "string" }
+          }
+        },
+        "production": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "server": { "type": "string", "format": "uri" },
+            "privateKeySecretRef": { "type": "string" }
+          }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "kubeApiCidrs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+          },
+          "description": "CIDRs autorizados para egress ao Kubernetes API server."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "k8sResources": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "cpu": { "type": "string", "pattern": "^[0-9]+(m|)?$" },
+            "memory": { "type": "string", "pattern": "^[0-9]+(Mi|Gi)$" }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "cpu": { "type": "string", "pattern": "^[0-9]+(m|)?$" },
+            "memory": { "type": "string", "pattern": "^[0-9]+(Mi|Gi)$" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/platform/cert-manager/values.yaml
+++ b/platform/cert-manager/values.yaml
@@ -1,0 +1,118 @@
+# Defaults para o cert-manager no cluster Uni+.
+#
+# Topologia: cert-manager roda em cada cluster (lab-{sp1,sp2}, prod-{sp1,sp2},
+# standalone). Em PA1 pode permanecer desligado (não há ingress público em PA1).
+#
+# Estratégia de emissão (ADR-008 + #15):
+# - HTTP-01 via Traefik (chart platform/traefik/) para hosts simples
+# - DNS-01 wildcard fica fora de escopo até decisão DIRSI sobre borda (ADR-004)
+#
+# IMPORTANTE: o ClusterIssuer letsencrypt-prod usa o servidor real do
+# Let's Encrypt — sujeito a rate limits (50 certs/domain/week). Para testes
+# usar letsencrypt-staging (sem rate limit relevante; certs não confiáveis).
+
+certManager:
+  enabled: true
+
+  # `nameOverride: cert-manager` força o subchart a usar kebab-case nos
+  # labels e nomes de recursos, restaurando a convenção apesar do alias
+  # camelCase no Chart.yaml. Mesmo padrão de platform/external-secrets/.
+  nameOverride: cert-manager
+
+  # Instalar CRDs automaticamente. ArgoCD reconhece e sincroniza.
+  # Em prod pode-se mover para gerenciamento separado, mas no Uni+ optamos
+  # por consolidar no chart (menos pontos móveis).
+  crds:
+    enabled: true
+    keep: true  # Não remover CRDs em uninstall — preserva CertificateRequests/Orders existentes.
+
+  # Controller principal. Recursos modestos — cert-manager é leve.
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+  # Webhook (validating admission). Necessário para validar Issuer/Certificate.
+  webhook:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+
+  # Cainjector (injeta CA bundles em webhooks/APIServices anotados).
+  cainjector:
+    enabled: true
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
+  # Métricas Prometheus do controller. Subchart tem sua própria definição
+  # de ServiceMonitor — gateado por `serviceMonitor.enabled` + helper
+  # interno (skipIfMissing default). Wrapper NÃO emite SM próprio para
+  # evitar scrape duplicado (mesmo padrão de platform/external-secrets/).
+  prometheus:
+    enabled: false  # Ligar quando #26 (Prometheus chart) estiver pronto.
+    servicemonitor:
+      enabled: false
+
+  # Labels padrão Uni+ aplicados em todos os recursos do subchart.
+  # No cert-manager v1.20+, `commonLabels` vive sob `global` (não no root
+  # como em external-secrets). Schema upstream rejeita root.commonLabels.
+  global:
+    commonLabels:
+      app.kubernetes.io/part-of: uniplus
+      app.kubernetes.io/component: cert-manager
+
+# ============================================================================
+# ClusterIssuers Let's Encrypt — HTTP-01 via Traefik.
+# Requer chart platform/traefik/ instalado e IngressClass `traefik` disponível.
+# Habilitar apenas após Traefik estar Synced/Healthy.
+# ============================================================================
+clusterIssuers:
+  enabled: false  # Habilitar via override em environments/<env>/values.yaml
+
+  # Email para registro ACME (notificações de expiração e termos de uso).
+  # Padrão: canal oficial CTIC. Override por environment se desejado.
+  email: ctic@unifesspa.edu.br
+
+  # IngressClass que resolve os HTTP-01 challenges. Coincide com Traefik
+  # (chart platform/traefik/). Override se outro ingress controller for usado.
+  ingressClass: traefik
+
+  staging:
+    enabled: true
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef: letsencrypt-staging-account-key
+
+  production:
+    enabled: true
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef: letsencrypt-prod-account-key
+
+# ============================================================================
+# NetworkPolicy — egress controlado.
+# cert-manager precisa alcançar:
+#   - ACME servers (Let's Encrypt) via HTTPS na internet
+#   - Kubernetes API (CRD operations, SAR/TokenReview)
+#   - DNS (kube-dns)
+# ============================================================================
+networkPolicy:
+  enabled: true
+
+  # CIDRs restritos para egress ao Kubernetes API server.
+  # Padrão: service CIDR do K3s (10.43.0.0/16).
+  kubeApiCidrs:
+    - 10.43.0.0/16

--- a/platform/cert-manager/values.yaml
+++ b/platform/cert-manager/values.yaml
@@ -71,10 +71,17 @@ certManager:
   # Labels padrão Uni+ aplicados em todos os recursos do subchart.
   # No cert-manager v1.20+, `commonLabels` vive sob `global` (não no root
   # como em external-secrets). Schema upstream rejeita root.commonLabels.
+  #
+  # NÃO incluir `app.kubernetes.io/component` aqui — o chart upstream
+  # hardcoda esse label nos pod templates de cada Deployment como
+  # `controller`/`webhook`/`cainjector`, mas as Deployment selectors
+  # mantêm o valor hardcoded. Sobrescrever via commonLabels causa
+  # selector/template label mismatch e a API rejeita as Deployments.
+  # Manter só `part-of: uniplus` que é seguro porque o subchart não tem
+  # `part-of` em selectors.
   global:
     commonLabels:
       app.kubernetes.io/part-of: uniplus
-      app.kubernetes.io/component: cert-manager
 
 # ============================================================================
 # ClusterIssuers Let's Encrypt — HTTP-01 via Traefik.


### PR DESCRIPTION
## Sumário

Fecha #15 — `platform/cert-manager/` deixa de ser placeholder e vira chart wrapper completo do upstream `jetstack/cert-manager` v1.20.2, com ClusterIssuers Let's Encrypt (staging + prod) via HTTP-01 + Traefik.

Faz parte da Fase 2 do plano standalone (paralelo ao caminho crítico do Vault). Sem cert-manager, não há TLS válido em `standalone.portaluni.com.br` para o smoke test de login.

## Mudanças

**Chart wrapper:**
- `Chart.yaml` v2 com dependência pinada `jetstack/cert-manager@v1.20.2`, `alias: certManager` (camelCase pra valores)
- `values.yaml` com defaults enxutos (1 réplica de cada Deployment), `global.commonLabels` para `part-of: uniplus`, CRDs `keep: true`
- `values.schema.json` com `additionalProperties: true` em blocos compartilhados — alinhado a platform/external-secrets/
- `Chart.lock` commitado

**Templates Uni+:**
- `clusterissuer-letsencrypt-staging.yaml`: ACME staging (sem rate limit relevante; certs não confiáveis)
- `clusterissuer-letsencrypt-prod.yaml`: ACME production (rate limit 50/domain/week)
- Ambos via HTTP-01 + Traefik IngressClass; gateados por `clusterIssuers.enabled` (default false — habilitar APÓS #14 Traefik)
- fail-fast se `enabled=true` sem `email` configurado
- `networkpolicy.yaml`: egress restrito a internet:443 (ACME endpoints, sem IP estável), kube-dns, K8s API

**Decisões de design:**
- `nameOverride: cert-manager` força kebab-case nos labels apesar do alias camelCase (mesmo padrão de external-secrets)
- `global.commonLabels` (não root.commonLabels — schema upstream rejeita root)
- PodSelector da NetworkPolicy usa `app.kubernetes.io/component: cert-manager` (vindo de commonLabels) — cobre os 3 Deployments (controller, webhook, cainjector) sem listar nomes genéricos
- Wrapper NÃO emite ServiceMonitor próprio — upstream já emite; gateado por `certManager.prometheus.servicemonitor.enabled` (default false até #26)
- DNS-01 wildcard fica fora de escopo (decisão DIRSI sobre borda — ADR-004); standalone usa só HTTP-01 (FQDN único)

## Pré-requisitos para usar

1. PR mergeado, ApplicationSet sincroniza, controller + webhook + cainjector sobem
2. Traefik chart (#14) instalado e IngressClass `traefik` disponível
3. DNS A record do FQDN apontando para o cluster
4. Override em `environments/<env>/values.yaml`:
   ```yaml
   clusterIssuers:
     enabled: true
   ```
5. Anotar IngressRoute com `cert-manager.io/cluster-issuer: letsencrypt-staging` (validar) → `letsencrypt-prod`

## Validação

- `helm lint --strict` ✅
- `helm dep update` resolve `jetstack/cert-manager@v1.20.2` corretamente
- `helm template` (com CSS habilitado) renderiza CRDs + 3 Deployments + RBAC + Webhook + 2 ClusterIssuers + NetworkPolicy
- yamllint OK, markdownlint 0 errors
- Pods labels confirmados: `app.kubernetes.io/part-of: uniplus` propaga via `global.commonLabels`

## Test plan

- [ ] CI verde
- [ ] Após merge, ArgoCD sincroniza Application `platform-cert-manager-uniplus-standalone` para Synced/Healthy (controller + webhook + cainjector rodando, CRDs registradas)
- [ ] Quando Traefik (#14) chegar, habilitar `clusterIssuers.enabled: true` em `environments/standalone/values.yaml` e validar emissão de cert para `standalone.portaluni.com.br` via `letsencrypt-staging`

## Issues relacionadas

Closes #15. Sub-task de #3 (umbrella platform charts). Pré-requisito do smoke test (#99) e da Fase 6 do plano standalone.