### PR TITLE
feat(traefik): chart wrapper v3.6.15 + middlewares + IngressClass traefik

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -206,6 +206,22 @@ clusterSecretStore:
   vaultServer: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
 
 # ----------------------------------------------------------------------------
+# Traefik (chart platform/traefik/) — exposição externa em standalone.
+# Single-host com IP público bindando hostPort 80/443 direto na VM,
+# evitando dependência de NodePort range > 30000 e LoadBalancer (provider
+# OCI cobraria por LB). NodePort dá fallback de descoberta interna.
+# Em prod 3-DC, override seria service.type: LoadBalancer + remover hostPort.
+# ----------------------------------------------------------------------------
+traefik:
+  service:
+    type: NodePort
+  ports:
+    web:
+      hostPort: 80
+    websecure:
+      hostPort: 443
+
+# ----------------------------------------------------------------------------
 # Keycloak local (apps/keycloak-replica) — sem federação Gov.br no MVP.
 # 1 réplica, valida apenas o contrato OIDC/JWT entre frontends e APIs.
 # Federação Gov.br fica fora do escopo standalone (depende de cadastro

--- a/platform/traefik/Chart.lock
+++ b/platform/traefik/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: traefik
+  repository: https://traefik.github.io/charts
+  version: 39.0.9
+digest: sha256:bcc84ee265f8004d41d3d6e22966852ac672ad2d5e9ab36139be6cb2ff3d9f3a
+generated: "2026-05-05T01:03:31.699412984-03:00"

--- a/platform/traefik/Chart.yaml
+++ b/platform/traefik/Chart.yaml
@@ -1,0 +1,37 @@
+apiVersion: v2
+name: traefik
+description: |
+  Traefik IngressController v3 — entrypoints HTTP/HTTPS, IngressRoute CRDs,
+  middlewares (redirect-https, security headers). Empacotado como chart
+  wrapper sobre traefik/traefik.
+type: application
+
+# Versão do chart wrapper Uni+.
+version: 0.1.0
+
+# Versão do Traefik upstream empacotado.
+appVersion: "v3.6.15"
+
+home: https://github.com/unifesspa-edu-br/uniplus-infra
+sources:
+  - https://github.com/unifesspa-edu-br/uniplus-infra
+  - https://github.com/traefik/traefik-helm-chart
+
+maintainers:
+  - name: CTIC Unifesspa
+    url: https://github.com/unifesspa-edu-br
+
+keywords:
+  - traefik
+  - ingress
+  - reverse-proxy
+  - uniplus
+
+# Dependência do chart upstream oficial.
+# alias=traefik mantém o nome natural do subchart (não há colisão).
+dependencies:
+  - name: traefik
+    version: 39.0.9
+    repository: https://traefik.github.io/charts
+    # Permite desligar o subchart por environment se necessário.
+    condition: traefik.enabled

--- a/platform/traefik/README.md
+++ b/platform/traefik/README.md
@@ -1,30 +1,134 @@
 # traefik
 
-API Gateway + Ingress Controller (já incluso no K3s)
-
-> ⚠️ **Status:** placeholder inicial.
+Traefik IngressController v3 — entrypoints HTTP/HTTPS, IngressRoute CRDs, middlewares (security headers, compress).
 
 ## Visão geral
 
-Componente de plataforma do cluster Kubernetes do Uni+.
+Wrapper do chart oficial [traefik/traefik-helm-chart](https://github.com/traefik/traefik-helm-chart). Roda em cada cluster (lab-{sp1,sp2}, prod-{sp1,sp2}, standalone). Em PA1 pode ficar desligado — não há ingress público lá.
 
 **Upstream:** https://github.com/traefik/traefik-helm-chart
+**Versão upstream empacotada:** v3.6.15 (chart 39.0.9)
 
-## Estratégia de deploy
+K3s vem com Traefik pré-instalado por default; o `bootstrap-standalone.sh` desabilita esse Traefik default (`--disable=traefik`) para que este chart wrapper seja a única instância no cluster (sem conflito de IngressClass).
 
-Recomenda-se usar o **chart upstream oficial** quando disponível, ao invés de manter chart próprio. Esta pasta deve conter:
+## Estrutura
 
-- `Chart.yaml` — chart umbrella ou referência ao chart upstream
-- `values.yaml` — valores customizados para o ambiente Uni+
-- `README.md` — este arquivo
+```
+platform/traefik/
+├── Chart.yaml                                  # subchart upstream (sem alias)
+├── values.yaml                                 # defaults Uni+
+├── values.schema.json                          # validação dos overrides
+├── README.md                                   # este arquivo
+└── templates/
+    ├── middleware-headers-security.yaml        # HSTS, X-Frame, etc. (gated)
+    ├── middleware-compress.yaml                # gzip/br (gated)
+    └── networkpolicy.yaml                      # ingress 80/443 + egress controlado
+```
 
-## Implementação pendente
+ServiceMonitor + dashboard IngressRoute vêm do subchart upstream (gateados por `traefik.metrics.prometheus.serviceMonitor.enabled` e `traefik.ingressRoute.dashboard.enabled`). Wrapper não emite SM próprio.
 
-- [ ] Chart.yaml com dependência do chart upstream
-- [ ] values.yaml com configuração base
-- [ ] Documentação de configurações específicas
-- [ ] ApplicationSet ArgoCD
+## Bootstrap
 
-## Contribuindo
+Após o ApplicationSet sincronizar:
 
-PRs em [unifesspa-edu-br/uniplus-infra](https://github.com/unifesspa-edu-br/uniplus-infra).
+1. Pod do Traefik sobe (1 réplica em standalone/lab; 2+ em prod via override)
+2. CRDs `ingressroutes.traefik.io`, `middlewares.traefik.io`, `serverstransports.traefik.io`, etc. são instaladas
+3. IngressClass `traefik` (default do cluster) fica disponível
+4. 2 Middlewares Uni+ ficam prontos (headers-security, compress)
+5. Em standalone, hostPort binda 0.0.0.0:80 e 0.0.0.0:443 direto na VM com IP público
+6. Em prod, Service `LoadBalancer` provisiona um LB do provider (override por env)
+
+## Variáveis principais
+
+| Variável | Default | Notas |
+|---|---|---|
+| `traefik.enabled` | `true` | Liga o subchart |
+| `traefik.deployment.replicas` | `1` | 1 em lab/standalone, 2+ em prod (override) |
+| `traefik.service.type` | `NodePort` | `LoadBalancer` em prod (override) |
+| `traefik.ports.web.hostPort` | `80` | Bind direto na VM (standalone) |
+| `traefik.ports.websecure.hostPort` | `443` | Bind direto na VM (standalone) |
+| `traefik.ingressClass.name` | `traefik` | Referenciado pelo cert-manager (#15) |
+| `traefik.ingressRoute.dashboard.enabled` | `false` | Habilitar atrás de OIDC + IP allowlist |
+| `traefik.metrics.prometheus.serviceMonitor.enabled` | `false` | Ligar quando #26 (Prometheus) chegar |
+| `middlewares.headersSecurity.enabled` | `true` | HSTS, frameDeny, nosniff, referrer-policy |
+| `middlewares.compress.enabled` | `true` | gzip/br nas respostas |
+| `networkPolicy.enabled` | `true` | Ingress 80/443 + egress aos namespaces das apps |
+| `networkPolicy.appNamespaces` | `[uniplus, vault, keycloak]` | Namespaces dos backends — ajustar por env |
+
+## Como criar uma IngressRoute em apps Uni+
+
+Padrão de IngressRoute (Traefik CRD) consumindo os middlewares Uni+:
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: portal
+  namespace: uniplus
+spec:
+  entryPoints: [websecure]
+  routes:
+    - match: Host(`standalone.portaluni.com.br`)
+      kind: Rule
+      middlewares:
+        - name: <release-name>-headers-security  # ex.: traefik-headers-security
+          namespace: traefik
+        - name: <release-name>-compress
+          namespace: traefik
+      services:
+        - name: uniplus-web
+          port: 80
+  tls:
+    secretName: portal-tls  # preenchido por cert-manager (ver platform/cert-manager/README.md)
+```
+
+Os middlewares vivem no namespace do release do Traefik (geralmente `traefik`). Substituir `<release-name>` pelo nome do release (em standalone: `platform-traefik-uniplus-standalone`).
+
+## Pathing standalone
+
+FQDN único `standalone.portaluni.com.br` com pathing controlado pelo Traefik:
+
+| Path | Backend |
+|---|---|
+| `/` | `apps/uniplus-web` (portal Angular) |
+| `/auth/*` | `apps/keycloak-replica` |
+| `/api/portal/*` | `apps/uniplus-api-portal` |
+| `/api/ingresso/*` | `apps/uniplus-api-ingresso` |
+| `/api/selecao/*` | `apps/uniplus-api-selecao` |
+
+IngressRoutes específicas serão adicionadas pelos charts de cada app (sub-issues da Story #99 de validação integrada).
+
+## Observabilidade
+
+Métricas Prometheus na porta 9100 (default upstream), formato Prometheus. ServiceMonitor vem do próprio subchart quando `traefik.metrics.prometheus.serviceMonitor.enabled: true` — manter desligado até o stack Prometheus (#26) estar no ar.
+
+Logs em **JSON** (general + access) — pronto para coleta por Loki (#28) sem parser intermediário.
+
+Métricas chave:
+- `traefik_entrypoint_requests_total` — total de requests por entrypoint
+- `traefik_entrypoint_request_duration_seconds` — histograma de latência
+- `traefik_router_requests_total{code}` — código de status por rota
+- `traefik_service_open_connections` — conexões abertas por backend
+
+## Network
+
+NetworkPolicy do chart:
+
+- **Ingress**: 8000 (web) e 8443 (websecure) abertos a qualquer origem (firewall externo controla a borda); 9100 (métricas) aberto a qualquer namespace para Prometheus.
+- **Egress**: namespaces das apps (`uniplus`, `vault`, `keycloak` por default — ajustar por env), namespace `cert-manager` (challenge solver Pods do HTTP-01), kube-dns, Kubernetes API.
+
+## Segurança
+
+- Pod roda como non-root (UID 65532), `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]` + `add: [NET_BIND_SERVICE]` para abrir portas privilegiadas via hostPort
+- Headers de segurança aplicados via Middleware (HSTS 1 ano, X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy strict-origin-when-cross-origin)
+- `X-Powered-By` e `Server` removidos das respostas (não revela stack)
+- Dashboard interno desligado por default — habilitar atrás de OIDC + IP allowlist
+- HSTS preload `false` por default; ligar só após confirmação institucional de inclusão na lista do Chrome
+
+## Referências
+
+- [#3](https://github.com/unifesspa-edu-br/uniplus-infra/issues/3) — umbrella platform charts
+- [#14](https://github.com/unifesspa-edu-br/uniplus-infra/issues/14) — esta task
+- [#15](https://github.com/unifesspa-edu-br/uniplus-infra/issues/15) — cert-manager (consome a IngressClass `traefik`)
+- ADR-004 (borda externa)
+- ADR-008 (topologia standalone)

--- a/platform/traefik/README.md
+++ b/platform/traefik/README.md
@@ -9,7 +9,7 @@ Wrapper do chart oficial [traefik/traefik-helm-chart](https://github.com/traefik
 **Upstream:** https://github.com/traefik/traefik-helm-chart
 **Versão upstream empacotada:** v3.6.15 (chart 39.0.9)
 
-K3s vem com Traefik pré-instalado por default; o `bootstrap-standalone.sh` desabilita esse Traefik default (`--disable=traefik`) para que este chart wrapper seja a única instância no cluster (sem conflito de IngressClass).
+K3s vem com Traefik pré-instalado por default. O `scripts/bootstrap-standalone.sh` desabilita explicitamente esse Traefik default (`--disable traefik`) para que este chart wrapper seja a única instância no cluster — sem conflito de IngressClass nem de bind 80/443. Re-executar o bootstrap após mudanças nesse script aplica o reset (K3s recria os manifests de bundled apps em cada start sem `--disable`).
 
 ## Estrutura
 
@@ -68,12 +68,12 @@ metadata:
 spec:
   entryPoints: [websecure]
   routes:
-    - match: Host(`standalone.portaluni.com.br`)
+    - match: Host(`<env-fqdn>`)              # ex.: standalone.portaluni.com.br
       kind: Rule
       middlewares:
-        - name: <release-name>-headers-security  # ex.: traefik-headers-security
+        - name: uniplus-headers-security     # nome FIXO do middleware Uni+
           namespace: traefik
-        - name: <release-name>-compress
+        - name: uniplus-compress
           namespace: traefik
       services:
         - name: uniplus-web
@@ -82,7 +82,7 @@ spec:
     secretName: portal-tls  # preenchido por cert-manager (ver platform/cert-manager/README.md)
 ```
 
-Os middlewares vivem no namespace do release do Traefik (geralmente `traefik`). Substituir `<release-name>` pelo nome do release (em standalone: `platform-traefik-uniplus-standalone`).
+Os middlewares têm **nomes fixos** (`uniplus-headers-security`, `uniplus-compress`) e vivem no namespace onde o Traefik está instalado (geralmente `traefik`) — independente do release name dinâmico do ApplicationSet. Substituir `<env-fqdn>` pelo FQDN do environment (definido em `environments/<env>/values.yaml` sob `ingress.host`).
 
 ## Pathing standalone
 

--- a/platform/traefik/templates/middleware-compress.yaml
+++ b/platform/traefik/templates/middleware-compress.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.middlewares.enabled .Values.middlewares.compress.enabled .Values.traefik.enabled }}
+# Middleware Uni+ — compressão automática (gzip/br) de respostas HTTP.
+# Aplicar nos IngressRoutes via:
+#   middlewares:
+#     - name: {{ .Release.Name }}-compress
+#       namespace: {{ .Release.Namespace }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ .Release.Name }}-compress
+  labels:
+    app.kubernetes.io/name: traefik
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: uniplus
+    app.kubernetes.io/component: traefik
+spec:
+  compress: {}
+{{- end }}

--- a/platform/traefik/templates/middleware-compress.yaml
+++ b/platform/traefik/templates/middleware-compress.yaml
@@ -1,13 +1,14 @@
 {{- if and .Values.middlewares.enabled .Values.middlewares.compress.enabled .Values.traefik.enabled }}
 # Middleware Uni+ — compressão automática (gzip/br) de respostas HTTP.
-# Aplicar nos IngressRoutes via:
+# Nome FIXO `uniplus-compress` (sem prefixo de release) para referência
+# estável a partir de IngressRoutes em outros namespaces. Aplicar via:
 #   middlewares:
-#     - name: {{ .Release.Name }}-compress
+#     - name: uniplus-compress
 #       namespace: {{ .Release.Namespace }}
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ .Release.Name }}-compress
+  name: uniplus-compress
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/platform/traefik/templates/middleware-headers-security.yaml
+++ b/platform/traefik/templates/middleware-headers-security.yaml
@@ -1,13 +1,16 @@
 {{- if and .Values.middlewares.enabled .Values.middlewares.headersSecurity.enabled .Values.traefik.enabled }}
 # Middleware Uni+ — headers de segurança HTTP padrão.
-# Aplicar nos IngressRoutes via:
+# Nome FIXO `uniplus-headers-security` (sem prefixo de release) para que
+# IngressRoutes em outros namespaces possam referenciar diretamente sem
+# precisar conhecer o release name dinâmico do ApplicationSet
+# (`platform-traefik-<cluster>`). Aplicar nos IngressRoutes via:
 #   middlewares:
-#     - name: {{ .Release.Name }}-headers-security
+#     - name: uniplus-headers-security
 #       namespace: {{ .Release.Namespace }}
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ .Release.Name }}-headers-security
+  name: uniplus-headers-security
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -18,7 +21,10 @@ metadata:
 spec:
   headers:
     {{- if .Values.middlewares.headersSecurity.hsts.enabled }}
-    stsSeconds: {{ .Values.middlewares.headersSecurity.hsts.seconds }}
+    # `| int` força inteiro — sem ele Helm renderiza valores grandes em
+    # notação científica (ex.: 31536000 → 3.1536e+07) que a CRD do Traefik
+    # rejeita por esperar integer puro.
+    stsSeconds: {{ .Values.middlewares.headersSecurity.hsts.seconds | int }}
     stsIncludeSubdomains: {{ .Values.middlewares.headersSecurity.hsts.includeSubdomains }}
     stsPreload: {{ .Values.middlewares.headersSecurity.hsts.preload }}
     forceSTSHeader: true
@@ -26,7 +32,7 @@ spec:
     frameDeny: {{ .Values.middlewares.headersSecurity.frameDeny }}
     contentTypeNosniff: {{ .Values.middlewares.headersSecurity.contentTypeNosniff }}
     referrerPolicy: {{ .Values.middlewares.headersSecurity.referrerPolicy | quote }}
-    # X-Powered-By removido por segurança (não revela stack).
+    # X-Powered-By e Server removidos por segurança (não revelam stack).
     customResponseHeaders:
       X-Powered-By: ""
       Server: ""

--- a/platform/traefik/templates/middleware-headers-security.yaml
+++ b/platform/traefik/templates/middleware-headers-security.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.middlewares.enabled .Values.middlewares.headersSecurity.enabled .Values.traefik.enabled }}
+# Middleware Uni+ — headers de segurança HTTP padrão.
+# Aplicar nos IngressRoutes via:
+#   middlewares:
+#     - name: {{ .Release.Name }}-headers-security
+#       namespace: {{ .Release.Namespace }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ .Release.Name }}-headers-security
+  labels:
+    app.kubernetes.io/name: traefik
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: uniplus
+    app.kubernetes.io/component: traefik
+spec:
+  headers:
+    {{- if .Values.middlewares.headersSecurity.hsts.enabled }}
+    stsSeconds: {{ .Values.middlewares.headersSecurity.hsts.seconds }}
+    stsIncludeSubdomains: {{ .Values.middlewares.headersSecurity.hsts.includeSubdomains }}
+    stsPreload: {{ .Values.middlewares.headersSecurity.hsts.preload }}
+    forceSTSHeader: true
+    {{- end }}
+    frameDeny: {{ .Values.middlewares.headersSecurity.frameDeny }}
+    contentTypeNosniff: {{ .Values.middlewares.headersSecurity.contentTypeNosniff }}
+    referrerPolicy: {{ .Values.middlewares.headersSecurity.referrerPolicy | quote }}
+    # X-Powered-By removido por segurança (não revela stack).
+    customResponseHeaders:
+      X-Powered-By: ""
+      Server: ""
+{{- end }}

--- a/platform/traefik/templates/networkpolicy.yaml
+++ b/platform/traefik/templates/networkpolicy.yaml
@@ -1,0 +1,76 @@
+{{- if and .Values.networkPolicy.enabled .Values.traefik.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-traefik
+  labels:
+    app.kubernetes.io/name: traefik
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: uniplus
+spec:
+  # Subchart upstream emite Pods com app.kubernetes.io/name: traefik
+  # e instance == release name. commonLabels adiciona part-of e component.
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Tráfego externo entra via NodePort/LoadBalancer (depende do environment).
+    # Sem from selector — qualquer origem pode bater nas portas 8000/8443
+    # do Pod (firewall/NodePort range já controla acesso na borda do cluster).
+    - ports:
+        - protocol: TCP
+          port: 8000  # web (HTTP) — entryPoint redireciona para HTTPS
+        - protocol: TCP
+          port: 8443  # websecure (HTTPS)
+    # Métricas Prometheus (quando habilitado).
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 9100
+  egress:
+    # Tráfego para os Services dos backends nos namespaces das apps.
+    {{- with .Values.networkPolicy.appNamespaces }}
+    - to:
+        {{- range . }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+        {{- end }}
+    {{- end }}
+    # cert-manager solver Pods (HTTP-01 challenge) — namespace cert-manager
+    # pode hospedar challenge solver pods com label específico.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cert-manager
+    # DNS (kube-dns).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Kubernetes API (descoberta de Services e Endpoints, leitura de CRDs).
+    {{- with .Values.networkPolicy.kubeApiCidrs }}
+    - to:
+        {{- range . }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 6443
+        - protocol: TCP
+          port: 443
+    {{- end }}
+{{- end }}

--- a/platform/traefik/templates/networkpolicy.yaml
+++ b/platform/traefik/templates/networkpolicy.yaml
@@ -10,12 +10,15 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: uniplus
 spec:
-  # Subchart upstream emite Pods com app.kubernetes.io/name: traefik
-  # e instance == release name. commonLabels adiciona part-of e component.
+  # Subchart upstream emite Pods com `app.kubernetes.io/name: traefik` e
+  # `app.kubernetes.io/instance: <release>-traefik` (subchart fullname,
+  # NÃO o release name puro). commonLabels adiciona `part-of: uniplus`.
+  # Selecionamos por name+part-of (estáveis e únicos por instalação Uni+),
+  # evitando depender do template fullname do upstream.
   podSelector:
     matchLabels:
       app.kubernetes.io/name: traefik
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/part-of: uniplus
   policyTypes:
     - Ingress
     - Egress

--- a/platform/traefik/values.schema.json
+++ b/platform/traefik/values.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/unifesspa-edu-br/uniplus-infra/platform/traefik/values.schema.json",
+  "title": "traefik chart values",
+  "description": "Schema dos values do chart platform/traefik/. Subchart traefik/traefik tem seu próprio schema — additionalProperties=true permite passar overrides que serão validados pelo upstream.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "traefik": {
+      "type": "object",
+      "description": "Bloco do subchart traefik/traefik.",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Liga/desliga o subchart. False em PA1."
+        },
+        "deployment": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "replicas": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "resources": { "$ref": "#/$defs/k8sResources" },
+        "ingressClass": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "isDefaultClass": { "type": "boolean" },
+            "name": { "type": "string" }
+          }
+        },
+        "service": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["LoadBalancer", "NodePort", "ClusterIP"]
+            }
+          }
+        },
+        "commonLabels": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "middlewares": {
+      "type": "object",
+      "description": "Middlewares globais Uni+ (headers de segurança, compress).",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "headersSecurity": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "hsts": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "seconds": { "type": "integer", "minimum": 0 },
+                "includeSubdomains": { "type": "boolean" },
+                "preload": { "type": "boolean" }
+              }
+            },
+            "frameDeny": { "type": "boolean" },
+            "contentTypeNosniff": { "type": "boolean" },
+            "referrerPolicy": { "type": "string" }
+          }
+        },
+        "compress": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "appNamespaces": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "kubeApiCidrs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "k8sResources": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "cpu": { "type": "string", "pattern": "^[0-9]+(m|)?$" },
+            "memory": { "type": "string", "pattern": "^[0-9]+(Mi|Gi)$" }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "cpu": { "type": "string", "pattern": "^[0-9]+(m|)?$" },
+            "memory": { "type": "string", "pattern": "^[0-9]+(Mi|Gi)$" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/platform/traefik/values.yaml
+++ b/platform/traefik/values.yaml
@@ -51,6 +51,12 @@ traefik:
         enabled: true
     kubernetesCRD:
       enabled: true
+      # Sem `allowCrossNamespace: true`, IngressRoutes em ns das apps
+      # (uniplus, vault, keycloak) NÃO podem referenciar Middlewares no
+      # ns do Traefik — e os middlewares Uni+ (`uniplus-headers-security`,
+      # `uniplus-compress`) vivem aqui no `traefik` ns. Sem isso o
+      # exemplo do README falha silenciosamente.
+      allowCrossNamespace: true
 
   # Logs em JSON para integração com Loki (#28).
   logs:

--- a/platform/traefik/values.yaml
+++ b/platform/traefik/values.yaml
@@ -13,10 +13,12 @@
 traefik:
   enabled: true
 
-  # Padrão Uni+: kebab-case nos labels do subchart.
+  # Labels padrão Uni+. NÃO incluir `app.kubernetes.io/component` aqui —
+  # mesma lição da cert-manager: subcharts hardcodam component nos
+  # selectors das Deployments e sobrescrever via commonLabels pode quebrar
+  # a admission. Manter só `part-of: uniplus`.
   commonLabels:
     app.kubernetes.io/part-of: uniplus
-    app.kubernetes.io/component: traefik
 
   # 1 réplica em standalone/lab; prod-{sp1,sp2} elevam para 2+ via
   # environments/prod-*/values.yaml conforme Tabela 10.1.
@@ -59,23 +61,25 @@ traefik:
       enabled: true
       format: json
 
-  # Service: standalone usa NodePort (single-host com IP público); prod
-  # eleva para LoadBalancer via environments/prod-*/values.yaml.
+  # Service: defaults seguros (ClusterIP, sem hostPort). Cada environment
+  # sobrescreve para o que faz sentido na sua topologia:
+  #  - standalone (single-host com IP público): NodePort + hostPort 80/443
+  #    (binda direto na VM, sem precisar NodePort range > 30000)
+  #  - prod 3-DC: LoadBalancer + annotations do provider (OCI shape, etc.)
   service:
-    type: NodePort
+    type: ClusterIP
     annotations: {}
 
   # Ports: 80 (HTTP, redireciona para HTTPS) + 443 (HTTPS).
-  # hostPort: bind 0.0.0.0:80/443 direto na VM com IP público (standalone
-  # single-host) — sem precisar NodePort range > 30000. Em prod 3-DC,
-  # `service.type: LoadBalancer` recebe o tráfego e proxy para o Pod.
+  # hostPort fica null por default — environments adicionam quando precisam
+  # bindar diretamente na VM (caso standalone) ou deixam vazio quando o
+  # tráfego entra via LoadBalancer (caso prod 3-DC).
   ports:
     web:
       port: 8000
       expose:
         default: true
       exposedPort: 80
-      hostPort: 80
       http:
         redirections:
           entryPoint:
@@ -87,7 +91,6 @@ traefik:
       expose:
         default: true
       exposedPort: 443
-      hostPort: 443
       http:
         tls:
           enabled: true

--- a/platform/traefik/values.yaml
+++ b/platform/traefik/values.yaml
@@ -1,0 +1,165 @@
+# Defaults para o Traefik IngressController no cluster Uni+.
+#
+# Topologia: roda em cada cluster (lab-{sp1,sp2}, prod-{sp1,sp2}, standalone).
+# Em PA1 pode ficar desligado (sem ingress público lá). Em standalone usa
+# NodePort 80/443 no único host com IP público; em prod 3-DC usa
+# LoadBalancer (típico dos providers OCI/EKS/etc.) — override por
+# environments/<env>/values.yaml.
+#
+# IngressClass: `traefik` — referenciado pelos ClusterIssuers do
+# platform/cert-manager/ no `solvers.http01.ingress.ingressClassName` e
+# pelas IngressRoutes/Ingress dos apps Uni+.
+
+traefik:
+  enabled: true
+
+  # Padrão Uni+: kebab-case nos labels do subchart.
+  commonLabels:
+    app.kubernetes.io/part-of: uniplus
+    app.kubernetes.io/component: traefik
+
+  # 1 réplica em standalone/lab; prod-{sp1,sp2} elevam para 2+ via
+  # environments/prod-*/values.yaml conforme Tabela 10.1.
+  deployment:
+    replicas: 1
+
+  # Recursos lab — Tabela 10.1 (200m→1000m / 256MB→512MB).
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+
+  # IngressClass `traefik` instalado e marcado como default. ClusterIssuer
+  # do cert-manager referencia esse nome literalmente.
+  ingressClass:
+    enabled: true
+    isDefaultClass: true
+    name: traefik
+
+  # CRDs IngressRoute, Middleware, etc. — gerenciadas pelo subchart.
+  # `ServersTransport`, `ServersTransportTCP`, `TLSStore`, `TraefikService`
+  # também ficam disponíveis.
+  providers:
+    kubernetesIngress:
+      enabled: true
+      publishedService:
+        enabled: true
+    kubernetesCRD:
+      enabled: true
+
+  # Logs em JSON para integração com Loki (#28).
+  logs:
+    general:
+      format: json
+      level: INFO
+    access:
+      enabled: true
+      format: json
+
+  # Service: standalone usa NodePort (single-host com IP público); prod
+  # eleva para LoadBalancer via environments/prod-*/values.yaml.
+  service:
+    type: NodePort
+    annotations: {}
+
+  # Ports: 80 (HTTP, redireciona para HTTPS) + 443 (HTTPS).
+  # hostPort: bind 0.0.0.0:80/443 direto na VM com IP público (standalone
+  # single-host) — sem precisar NodePort range > 30000. Em prod 3-DC,
+  # `service.type: LoadBalancer` recebe o tráfego e proxy para o Pod.
+  ports:
+    web:
+      port: 8000
+      expose:
+        default: true
+      exposedPort: 80
+      hostPort: 80
+      http:
+        redirections:
+          entryPoint:
+            to: websecure
+            scheme: https
+            permanent: true
+    websecure:
+      port: 8443
+      expose:
+        default: true
+      exposedPort: 443
+      hostPort: 443
+      http:
+        tls:
+          enabled: true
+
+  # Métricas Prometheus do Traefik. ServiceMonitor vem do subchart
+  # quando habilitado — wrapper não emite SM próprio (mesmo padrão dos
+  # outros wrappers do projeto). Ligar quando #26 (Prometheus) chegar.
+  metrics:
+    prometheus:
+      service:
+        enabled: false
+      serviceMonitor:
+        enabled: false
+
+  # Dashboard interno do Traefik. Default DESLIGADO — quando ligado deve
+  # ficar atrás de OIDC (Keycloak) + IP allowlist UNIFESSPA. Configurar
+  # via IngressRoute separada com middlewares de auth.
+  ingressRoute:
+    dashboard:
+      enabled: false
+
+  # Segurança: rodar como non-root + readOnlyRootFilesystem (já default
+  # do chart upstream em versões recentes — explicitar).
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    fsGroup: 65532
+  securityContext:
+    capabilities:
+      drop: [ALL]
+      add: [NET_BIND_SERVICE]
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+
+# ============================================================================
+# Middlewares globais — distribuídos como Middleware CRDs no namespace do
+# Traefik. Apps consomem via `traefik.ingress.kubernetes.io/router.middlewares:
+# traefik-headers-security@kubernetescrd`.
+# ============================================================================
+middlewares:
+  enabled: true
+
+  # HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy.
+  # Defaults conservadores; apps podem desligar por anotação se precisarem.
+  headersSecurity:
+    enabled: true
+    hsts:
+      enabled: true
+      seconds: 31536000  # 1 ano
+      includeSubdomains: true
+      preload: false  # Ligar só quando institucional confirmar inclusão
+    frameDeny: true
+    contentTypeNosniff: true
+    referrerPolicy: strict-origin-when-cross-origin
+
+  # Compress respostas HTTP automaticamente (gzip/br).
+  compress:
+    enabled: true
+
+# ============================================================================
+# NetworkPolicy — ingress de 80/443 da internet (NodePort/LoadBalancer);
+# egress para os namespaces das apps (uniplus, vault, etc.).
+# ============================================================================
+networkPolicy:
+  enabled: true
+
+  # Namespaces de destino dos backends. Ajustar por environment.
+  appNamespaces:
+    - uniplus
+    - vault
+    - keycloak
+
+  # CIDRs autorizados para egress ao Kubernetes API server.
+  kubeApiCidrs:
+    - 10.43.0.0/16

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -188,6 +188,12 @@ step_install_k3s() {
 
         log_info "Instalando K3s $K3S_VERSION (node: $node_name, IP: $node_ip)..."
 
+        # --disable traefik: o chart platform/traefik/ instala o IngressController
+        # do projeto (v3.6.15 com middlewares Uni+ e IngressClass `traefik`).
+        # Sem --disable, o Traefik bundled do K3s competiria pelo bind 80/443
+        # e pela IngressClass de mesmo nome.
+        # --disable servicelb: usamos NodePort+hostPort em standalone (single
+        # host com IP público) — ServiceLB do K3s não acrescenta nada aqui.
         run "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=$K3S_VERSION sh -s - \
             --node-name $node_name \
             --cluster-init \
@@ -196,6 +202,7 @@ step_install_k3s() {
             --tls-san $K8S_PUBLIC_IP \
             --tls-san $K8S_DOMAIN \
             --disable servicelb \
+            --disable traefik \
             --write-kubeconfig-mode 644"
     fi
 


### PR DESCRIPTION
## Sumário

Fecha #14 — `platform/traefik/` deixa de ser placeholder e vira chart wrapper completo do upstream `traefik/traefik` (chart 39.0.9, app v3.6.15), com middlewares Uni+ (security headers + compress) e IngressClass `traefik` referenciada pelos ClusterIssuers do `platform/cert-manager/` (PR #101 mergeado).

Completa a Fase 2 do plano standalone (borda: TLS + ingress). Pré-requisito do smoke test (#99) — sem Traefik, ClusterIssuers do cert-manager não conseguem resolver HTTP-01 challenges.

## Mudanças

**Chart wrapper:**
- `Chart.yaml` v2 com dependência pinada `traefik/traefik@39.0.9` (sem alias — sem colisão de nome)
- `values.yaml`: 1 réplica em standalone/lab; recursos Tabela 10.1 (200m→1000m / 256MB→512MB); IngressClass `traefik` default; logs JSON (general + access); pod non-root + readOnlyRootFilesystem
- `values.schema.json` com `additionalProperties: true` em blocos compartilhados
- `Chart.lock` commitado

**Templates Uni+:**
- `middleware-headers-security.yaml`: HSTS 1 ano (includeSubdomains), frameDeny, contentTypeNosniff, referrer-policy strict-origin-when-cross-origin, remove X-Powered-By/Server
- `middleware-compress.yaml`: gzip/br nas respostas
- `networkpolicy.yaml`: ingress 8000/8443 aberto; egress aos namespaces das apps + cert-manager (challenge solver) + kube-dns + K8s API

**Decisões de design:**
- Service: NodePort em standalone (single-host com IP público; hostPort 80/443 binda direto na VM); LoadBalancer em prod 3-DC via override
- HostPort 80/443 + capabilities NET_BIND_SERVICE — sem precisar NodePort range > 30000
- Dashboard interno DESLIGADO por default — habilitar atrás de OIDC + IP allowlist
- ServiceMonitor + dashboard IngressRoute vêm do upstream (gateados); wrapper não emite SM próprio
- HSTS preload `false` por default — ligar só após confirmação institucional

## Pré-requisitos para usar

1. PR mergeado, ApplicationSet sincroniza, Pod do Traefik sobe
2. K3s instalado SEM o Traefik default (`--disable=traefik` em `bootstrap-standalone.sh`) — evita colisão
3. Após Traefik Synced/Healthy, habilitar `clusterIssuers.enabled: true` em `environments/standalone/values.yaml` (do platform/cert-manager) para ativar os ClusterIssuers Let's Encrypt
4. Apps publicam via IngressRoute consumindo middlewares pelo nome (ex.: `traefik-headers-security` em `traefik` namespace)

## Validação

- `helm lint --strict` ✅
- `helm dep update` resolve `traefik/traefik@39.0.9`
- `helm template` renderiza Deployment + Service + IngressClass + ServiceAccount + ClusterRole/Binding + 2 Middlewares Uni+ + NetworkPolicy
- yamllint OK, markdownlint 0 errors

## Test plan

- [ ] CI verde
- [ ] Após merge, ArgoCD sincroniza Application `platform-traefik-uniplus-standalone` para Synced/Healthy
- [ ] Habilitar `clusterIssuers.enabled: true` em `environments/standalone/values.yaml` (platform/cert-manager) — ClusterIssuers letsencrypt-prod/letsencrypt-staging ficam Ready
- [ ] Criar Certificate de teste, validar emissão Let's Encrypt staging
- [ ] curl -I no FQDN com cert válido + headers de segurança presentes (HSTS, X-Frame-Options, X-Content-Type-Options)

## Issues relacionadas

Closes #14. Sub-task de #3 (umbrella platform charts). Junto com PR #101 (cert-manager) completa a Fase 2 do plano standalone.