### PR TITLE
feat(observability/prometheus): chart wrapper kube-prometheus-stack 84.5.0

### DIFF
--- a/environments/lab-pa1/values.yaml
+++ b/environments/lab-pa1/values.yaml
@@ -36,6 +36,14 @@ storage:
 vault:
   enabled: false
 
+# Stack Prometheus (chart platform/observability/prometheus/) NÃO roda em PA1.
+# PA1 hospeda agregação de longa retenção via mecanismo separado (Thanos ou
+# remote_write para um Prometheus dedicado de retenção longa) — fora do escopo
+# do chart wrapper único. Sem este override, o ApplicationSet deployaria o
+# stack completo aqui também, duplicando coleta com SP1/SP2.
+kubePrometheusStack:
+  enabled: false
+
 # Vault Transit — chart platform/vault-transit/.
 # 1 réplica em lab/sanidade (recursos reduzidos); 3 réplicas Raft em hml/prod.
 vaultTransit:

--- a/environments/lab-sp1/values.yaml
+++ b/environments/lab-sp1/values.yaml
@@ -57,7 +57,12 @@ replicas:
   keycloak: 1
   redis: 1
 
-# Observabilidade com retenção curta
+# Observabilidade com retenção curta.
+#
+# NOTA: o bloco `observability:` é DOCUMENTAÇÃO de intenção (alinha com a
+# Tabela 10.1 do ARCHITECTURE.md) e NÃO é consumido por nenhum chart. Os
+# wrappers (`platform/observability/{prometheus,loki,...}`) consomem suas
+# próprias values (ex.: `kubePrometheusStack.*`). Wiring real abaixo.
 observability:
   prometheus:
     retention: 7d  # vs 15d em prod
@@ -65,6 +70,30 @@ observability:
   loki:
     retention: 7d
     storage: 30Gi
+
+# Wiring real do chart platform/observability/prometheus/ — força StorageClass
+# `lab-local-nvme` (default-class do K3s seria `local-path`), retenção 7d
+# (alinhada com observability.prometheus.retention) e storage 20Gi.
+kubePrometheusStack:
+  prometheus:
+    prometheusSpec:
+      retention: 7d
+      retentionSize: 16GiB  # storage 20Gi com folga pra WAL
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: lab-local-nvme
+            resources:
+              requests:
+                storage: 20Gi
+      externalLabels:
+        cluster: lab-sp1
+  alertmanager:
+    alertmanagerSpec:
+      storage:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: lab-local-nvme
   tempo:
     retention: 3d
     storage: 10Gi

--- a/environments/lab-sp1/values.yaml
+++ b/environments/lab-sp1/values.yaml
@@ -70,6 +70,9 @@ observability:
   loki:
     retention: 7d
     storage: 30Gi
+  tempo:
+    retention: 3d
+    storage: 10Gi
 
 # Wiring real do chart platform/observability/prometheus/ — força StorageClass
 # `lab-local-nvme` (default-class do K3s seria `local-path`), retenção 7d
@@ -94,9 +97,6 @@ kubePrometheusStack:
         volumeClaimTemplate:
           spec:
             storageClassName: lab-local-nvme
-  tempo:
-    retention: 3d
-    storage: 10Gi
 
 # Cluster identification
 cluster:

--- a/environments/lab-sp2/values.yaml
+++ b/environments/lab-sp2/values.yaml
@@ -66,6 +66,9 @@ observability:
   loki:
     retention: 3d
     storage: 15Gi
+  tempo:
+    retention: 1d
+    storage: 5Gi
 
 # Wiring real do chart platform/observability/prometheus/ — retenção 3d
 # (i7 com menos RAM/disco) e storage 10Gi.
@@ -89,9 +92,6 @@ kubePrometheusStack:
         volumeClaimTemplate:
           spec:
             storageClassName: lab-local-nvme
-  tempo:
-    retention: 1d
-    storage: 5Gi
 
 cluster:
   name: lab-sp2

--- a/environments/lab-sp2/values.yaml
+++ b/environments/lab-sp2/values.yaml
@@ -55,7 +55,10 @@ replicas:
   keycloak: 1
   redis: 1
 
-# Observabilidade reduzida (i7 tem menos RAM)
+# Observabilidade reduzida (i7 tem menos RAM).
+#
+# NOTA: bloco `observability:` é DOCUMENTAÇÃO; charts consomem suas
+# próprias values. Wiring real abaixo.
 observability:
   prometheus:
     retention: 3d  # menor que SP1
@@ -63,6 +66,29 @@ observability:
   loki:
     retention: 3d
     storage: 15Gi
+
+# Wiring real do chart platform/observability/prometheus/ — retenção 3d
+# (i7 com menos RAM/disco) e storage 10Gi.
+kubePrometheusStack:
+  prometheus:
+    prometheusSpec:
+      retention: 3d
+      retentionSize: 8GiB
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: lab-local-nvme
+            resources:
+              requests:
+                storage: 10Gi
+      externalLabels:
+        cluster: lab-sp2
+  alertmanager:
+    alertmanagerSpec:
+      storage:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: lab-local-nvme
   tempo:
     retention: 1d
     storage: 5Gi

--- a/environments/prod-pa1/values.yaml
+++ b/environments/prod-pa1/values.yaml
@@ -36,6 +36,14 @@ storage:
 vault:
   enabled: false
 
+# Stack Prometheus (chart platform/observability/prometheus/) NÃO roda em PA1.
+# PA1 hospeda agregação de longa retenção via mecanismo separado (Thanos ou
+# remote_write para um Prometheus dedicado de retenção longa) — fora do escopo
+# do chart wrapper único. Sem este override, o ApplicationSet deployaria o
+# stack completo aqui também, duplicando coleta com SP1/SP2.
+kubePrometheusStack:
+  enabled: false
+
 # Vault Transit em HA Raft (3 réplicas) em prod.
 vaultTransit:
   enabled: false  # ligar quando dependências estiverem prontas

--- a/environments/prod-sp1/values.yaml
+++ b/environments/prod-sp1/values.yaml
@@ -54,6 +54,9 @@ observability:
   loki:
     retention: 30d
     storage: 100Gi
+  tempo:
+    retention: 7d
+    storage: 50Gi
 
 # NOTA: bloco `observability:` acima é DOCUMENTAÇÃO de intenção; os charts
 # wrapper consomem suas próprias values. Wiring real abaixo.
@@ -83,9 +86,6 @@ kubePrometheusStack:
         volumeClaimTemplate:
           spec:
             storageClassName: prod-local-nvme
-  tempo:
-    retention: 7d
-    storage: 50Gi
 
 cluster:
   name: prod-sp1

--- a/environments/prod-sp1/values.yaml
+++ b/environments/prod-sp1/values.yaml
@@ -54,6 +54,35 @@ observability:
   loki:
     retention: 30d
     storage: 100Gi
+
+# NOTA: bloco `observability:` acima é DOCUMENTAÇÃO de intenção; os charts
+# wrapper consomem suas próprias values. Wiring real abaixo.
+#
+# Prometheus em prod-sp1: retenção 15d (Tabela 10.1), storage 50Gi. Stack
+# elevado para 2 réplicas para HA; pesquisa cross-cluster fica via Thanos
+# em PA1 (chart separado, fora deste wrapper).
+kubePrometheusStack:
+  prometheus:
+    prometheusSpec:
+      replicas: 2
+      retention: 15d
+      retentionSize: 40GiB
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: prod-local-nvme
+            resources:
+              requests:
+                storage: 50Gi
+      externalLabels:
+        cluster: prod-sp1
+  alertmanager:
+    alertmanagerSpec:
+      replicas: 2
+      storage:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: prod-local-nvme
   tempo:
     retention: 7d
     storage: 50Gi

--- a/environments/prod-sp2/values.yaml
+++ b/environments/prod-sp2/values.yaml
@@ -53,6 +53,9 @@ observability:
   loki:
     retention: 30d
     storage: 100Gi
+  tempo:
+    retention: 7d
+    storage: 50Gi
 
 # NOTA: bloco `observability:` acima é DOCUMENTAÇÃO; charts consomem
 # suas próprias values. Wiring real abaixo (espelha prod-sp1).
@@ -78,9 +81,6 @@ kubePrometheusStack:
         volumeClaimTemplate:
           spec:
             storageClassName: prod-local-nvme
-  tempo:
-    retention: 7d
-    storage: 50Gi
 
 cluster:
   name: prod-sp2

--- a/environments/prod-sp2/values.yaml
+++ b/environments/prod-sp2/values.yaml
@@ -53,6 +53,31 @@ observability:
   loki:
     retention: 30d
     storage: 100Gi
+
+# NOTA: bloco `observability:` acima é DOCUMENTAÇÃO; charts consomem
+# suas próprias values. Wiring real abaixo (espelha prod-sp1).
+kubePrometheusStack:
+  prometheus:
+    prometheusSpec:
+      replicas: 2
+      retention: 15d
+      retentionSize: 40GiB
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: prod-local-nvme
+            resources:
+              requests:
+                storage: 50Gi
+      externalLabels:
+        cluster: prod-sp2
+  alertmanager:
+    alertmanagerSpec:
+      replicas: 2
+      storage:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: prod-local-nvme
   tempo:
     retention: 7d
     storage: 50Gi

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -72,6 +72,12 @@ replicas:
 
 # Observabilidade single-stack com retenção curta — standalone não substitui
 # a observabilidade do lab/prod 3-DC, serve apenas para validação local.
+#
+# NOTA: o bloco `observability:` abaixo é DOCUMENTAÇÃO de intenção (alinha
+# com ADR-008) e NÃO é consumido por nenhum chart. Os charts wrapper
+# (`platform/observability/prometheus/`, `loki/`, `tempo/`) consomem suas
+# values próprias (ex.: `kubePrometheusStack.*`). Os defaults dos wrappers
+# já refletem esses números — overrides reais ficam nos blocos abaixo.
 observability:
   prometheus:
     retention: 7d
@@ -82,6 +88,27 @@ observability:
   tempo:
     retention: 3d
     storage: 5Gi
+
+# Wiring real do chart platform/observability/prometheus/ — força a
+# StorageClass standalone-local-nvme nos PVCs do Prometheus + Alertmanager
+# (default-class do cluster é local-path do K3s, não a tier do projeto)
+# e adiciona o cluster name no external_labels para identificação em
+# alertas e federation.
+kubePrometheusStack:
+  prometheus:
+    prometheusSpec:
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: standalone-local-nvme
+      externalLabels:
+        cluster: standalone
+  alertmanager:
+    alertmanagerSpec:
+      storage:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: standalone-local-nvme
 
 # ============================================================================
 # StorageClass do tier standalone (#74, ADR-008).

--- a/platform/observability/prometheus/Chart.lock
+++ b/platform/observability/prometheus/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 84.5.0
+digest: sha256:acff9581bce4ac430b38da50931eea2d8a2defae127b5cc350df7b4077178061
+generated: "2026-05-05T01:49:27.155941479-03:00"

--- a/platform/observability/prometheus/Chart.yaml
+++ b/platform/observability/prometheus/Chart.yaml
@@ -1,0 +1,39 @@
+apiVersion: v2
+name: prometheus
+description: |
+  Prometheus + Prometheus Operator (CRDs ServiceMonitor/PodMonitor),
+  Alertmanager placeholder, node-exporter e kube-state-metrics. Empacotado
+  como chart wrapper sobre prometheus-community/kube-prometheus-stack.
+  Grafana fica fora deste chart (chart separado em platform/observability/grafana/).
+type: application
+
+# Versão do chart wrapper Uni+.
+version: 0.1.0
+
+# Versão upstream empacotada (kube-prometheus-stack).
+appVersion: "v0.90.1"
+
+home: https://github.com/unifesspa-edu-br/uniplus-infra
+sources:
+  - https://github.com/unifesspa-edu-br/uniplus-infra
+  - https://github.com/prometheus-community/helm-charts
+
+maintainers:
+  - name: CTIC Unifesspa
+    url: https://github.com/unifesspa-edu-br
+
+keywords:
+  - prometheus
+  - alertmanager
+  - observability
+  - uniplus
+
+# Dependência do chart upstream oficial (umbrella kube-prometheus-stack).
+# alias=kubePrometheusStack para acessar valores via .Values.kubePrometheusStack.*
+# (sem alias o nome com hífens não funcionaria em Go templates).
+dependencies:
+  - name: kube-prometheus-stack
+    alias: kubePrometheusStack
+    version: 84.5.0
+    repository: https://prometheus-community.github.io/helm-charts
+    condition: kubePrometheusStack.enabled

--- a/platform/observability/prometheus/README.md
+++ b/platform/observability/prometheus/README.md
@@ -1,30 +1,121 @@
-# observability/prometheus
+# prometheus
 
-Coleta e armazenamento de métricas
-
-> ⚠️ **Status:** placeholder inicial.
+Stack Prometheus + Operator (CRDs ServiceMonitor/PodMonitor) + Alertmanager + node-exporter + kube-state-metrics.
 
 ## Visão geral
 
-Componente de plataforma do cluster Kubernetes do Uni+.
+Wrapper do chart oficial [prometheus-community/kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack). Roda em cada cluster (lab-{sp1,sp2}, prod-{sp1,sp2}, standalone). Em PA1 fica desligado por default — PA1 hospeda agregação separada com retenção longa.
+
+Grafana NÃO faz parte deste chart (vai para `platform/observability/grafana/`, sub-issue #27). O subchart upstream vem com Grafana habilitado por default — desligamos explicitamente aqui.
 
 **Upstream:** https://github.com/prometheus-community/helm-charts
+**Versão upstream empacotada:** kube-prometheus-stack 84.5.0 (Operator v0.90.1)
 
-## Estratégia de deploy
+## Estrutura
 
-Recomenda-se usar o **chart upstream oficial** quando disponível, ao invés de manter chart próprio. Esta pasta deve conter:
+```
+platform/observability/prometheus/
+├── Chart.yaml                              # subchart umbrella (alias=kubePrometheusStack)
+├── values.yaml                             # defaults Uni+
+├── values.schema.json                      # validação dos overrides
+├── README.md                               # este arquivo
+└── templates/                              # delegado ao subchart (placeholder)
+```
 
-- `Chart.yaml` — chart umbrella ou referência ao chart upstream
-- `values.yaml` — valores customizados para o ambiente Uni+
-- `README.md` — este arquivo
+## Bootstrap
 
-## Implementação pendente
+Após o ApplicationSet sincronizar:
 
-- [ ] Chart.yaml com dependência do chart upstream
-- [ ] values.yaml com configuração base
-- [ ] Documentação de configurações específicas
-- [ ] ApplicationSet ArgoCD
+1. Pods sobem: prometheus-operator, prometheus-server, alertmanager, node-exporter (DaemonSet), kube-state-metrics
+2. CRDs `servicemonitors.monitoring.coreos.com`, `podmonitors`, `prometheusrules`, `alertmanagers`, etc. são instaladas
+3. Charts `platform/external-secrets/`, `platform/cert-manager/`, `platform/traefik/`, `platform/vault/` podem habilitar `serviceMonitor.enabled: true` em seus values — Prometheus passa a scrape automaticamente (selector aceita TODOS os SMs do cluster, ver `serviceMonitorSelectorNilUsesHelmValues: false` em values.yaml)
+4. Alertmanager fica ativo mas sem receivers reais (apenas registra no log) — receivers serão adicionados em sub-issue separada
 
-## Contribuindo
+## Variáveis principais
 
-PRs em [unifesspa-edu-br/uniplus-infra](https://github.com/unifesspa-edu-br/uniplus-infra).
+| Variável | Default | Notas |
+|---|---|---|
+| `kubePrometheusStack.enabled` | `true` | Liga o subchart |
+| `kubePrometheusStack.grafana.enabled` | `false` | Grafana fica em chart separado (#27) |
+| `kubePrometheusStack.prometheus.prometheusSpec.replicas` | `1` | 1 em standalone/lab, 2+ em prod (override) |
+| `kubePrometheusStack.prometheus.prometheusSpec.retention` | `7d` | Standalone alinha com `environments/standalone/values.yaml` |
+| `kubePrometheusStack.prometheus.prometheusSpec.retentionSize` | `8GiB` | Storage 10Gi com folga pra WAL |
+| `kubePrometheusStack.prometheus.ingress.enabled` | `false` | Habilitar atrás de OIDC + IP allowlist |
+| `kubePrometheusStack.alertmanager.enabled` | `true` | Receiver placeholder "null" (apenas log) |
+| `kubePrometheusStack.crds.enabled` | `true` | Instala ServiceMonitor/PodMonitor/etc. |
+| `kubePrometheusStack.crds.upgradeJob.enabled` | `false` | ArgoCD gerencia upgrades |
+| `kubePrometheusStack.kubeControllerManager.enabled` | `false` | K3s embute no kubelet |
+| `kubePrometheusStack.kubeScheduler.enabled` | `false` | Idem |
+| `kubePrometheusStack.kubeProxy.enabled` | `false` | K3s usa flannel sem kube-proxy |
+| `kubePrometheusStack.kubeEtcd.enabled` | `false` | K3s embarca etcd sem endpoint scrape |
+
+## Como expor métricas de outros charts
+
+Após este chart estar Synced/Healthy, outros charts da plataforma podem habilitar seus ServiceMonitors via override no environment:
+
+```yaml
+# environments/standalone/values.yaml
+externalSecrets:
+  serviceMonitor:
+    enabled: true       # ESO scrapeado pelo Prometheus
+
+certManager:
+  prometheus:
+    servicemonitor:
+      enabled: true     # cert-manager scrapeado
+
+traefik:
+  metrics:
+    prometheus:
+      service:
+        enabled: true
+      serviceMonitor:
+        enabled: true   # Traefik scrapeado
+
+vault:
+  serviceMonitor:
+    enabled: true       # Vault scrapeado
+```
+
+A flag `serviceMonitorSelectorNilUsesHelmValues: false` no `prometheusSpec` faz o Prometheus aceitar SMs de qualquer release/namespace — não há necessidade de label sync entre charts.
+
+## Storage
+
+O stack precisa de PVCs para Prometheus (10Gi default) e Alertmanager (2Gi). Em standalone, `storageClassName` herda da `standalone-local-nvme` (chart `platform/storage/`). Cada environment pode override via:
+
+```yaml
+# environments/<env>/values.yaml
+kubePrometheusStack:
+  prometheus:
+    prometheusSpec:
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: <env-specific-sc>
+```
+
+## Componentes K3s
+
+Por default o subchart upstream tenta scrape kube-controller-manager, kube-scheduler, kube-proxy e etcd. Em K3s todos rodam embutidos no `kubelet` (ou, no caso do flannel, sem kube-proxy), sem endpoints HTTP separados — desligamos esses ServiceMonitors no chart wrapper para evitar alertas falsos `*Down` desde a primeira sincronização.
+
+## Network
+
+O subchart upstream tem suas próprias NetworkPolicies (gateadas por `kubePrometheusStack.prometheus.networkPolicy.enabled` etc.). O wrapper Uni+ não duplica — habilitar via env values quando necessário.
+
+Em standalone (single-host, default-allow no K3s sem CNI mais restritivo), as NPs do subchart podem ficar desligadas. Em prod 3-DC (Calico ou Cilium com default-deny), habilitar no env override.
+
+## Segurança
+
+- Pod security: defaults do upstream (non-root, runAsUser 65534 para Prometheus)
+- IngressRoute desligado por default — habilitar atrás de OIDC + IP allowlist
+- Receivers do Alertmanager começam como placeholder "null" — adicionar receivers reais em sub-issue separada
+
+## Referências
+
+- [#3](https://github.com/unifesspa-edu-br/uniplus-infra/issues/3) — umbrella platform charts
+- [#26](https://github.com/unifesspa-edu-br/uniplus-infra/issues/26) — esta task
+- [#27](https://github.com/unifesspa-edu-br/uniplus-infra/issues/27) — Grafana (chart separado)
+- [#28](https://github.com/unifesspa-edu-br/uniplus-infra/issues/28) — Loki (logs)
+- [#29](https://github.com/unifesspa-edu-br/uniplus-infra/issues/29) — Tempo (traces)
+- [#30](https://github.com/unifesspa-edu-br/uniplus-infra/issues/30) — OpenTelemetry Collector (pipeline)
+- ADR-008 (topologia standalone) — retenção curta justificada

--- a/platform/observability/prometheus/README.md
+++ b/platform/observability/prometheus/README.md
@@ -46,8 +46,8 @@ Após o ApplicationSet sincronizar:
 | `kubePrometheusStack.crds.upgradeJob.enabled` | `false` | ArgoCD gerencia upgrades |
 | `kubePrometheusStack.kubeControllerManager.enabled` | `false` | K3s embute no kubelet |
 | `kubePrometheusStack.kubeScheduler.enabled` | `false` | Idem |
-| `kubePrometheusStack.kubeProxy.enabled` | `false` | K3s usa flannel sem kube-proxy |
-| `kubePrometheusStack.kubeEtcd.enabled` | `false` | K3s embarca etcd sem endpoint scrape |
+| `kubePrometheusStack.kubeProxy.enabled` | `false` | K3s roda kube-proxy mas binda métricas em 127.0.0.1 — SM padrão não scrapeia |
+| `kubePrometheusStack.kubeEtcd.enabled` | `false` | K3s embarca etcd sem endpoint client-cert separado |
 
 ## Como expor métricas de outros charts
 
@@ -96,7 +96,7 @@ kubePrometheusStack:
 
 ## Componentes K3s
 
-Por default o subchart upstream tenta scrape kube-controller-manager, kube-scheduler, kube-proxy e etcd. Em K3s todos rodam embutidos no `kubelet` (ou, no caso do flannel, sem kube-proxy), sem endpoints HTTP separados — desligamos esses ServiceMonitors no chart wrapper para evitar alertas falsos `*Down` desde a primeira sincronização.
+Por default o subchart upstream tenta scrape kube-controller-manager, kube-scheduler, kube-proxy e etcd. Em K3s controller-manager e scheduler rodam dentro do binário único do K3s (sem endpoint HTTP separado), kube-proxy roda mas binda as métricas em `127.0.0.1` por default (SM padrão não consegue scrape sem mudar `metricsBindAddress: 0.0.0.0`), e etcd está embarcado sem endpoint client-cert separado. Desligamos esses 4 ServiceMonitors no chart wrapper para evitar alertas falsos `*Down` desde a primeira sincronização. Em distribuições K8s upstream (não-K3s) reabilitar via env override.
 
 ## Network
 

--- a/platform/observability/prometheus/templates/.gitkeep
+++ b/platform/observability/prometheus/templates/.gitkeep
@@ -1,0 +1,4 @@
+# Templates Uni+ específicos do wrapper (NetworkPolicy custom, IngressRoutes
+# OIDC-gated, etc.) ficam aqui. Atualmente o chart delega tudo para o
+# subchart upstream kube-prometheus-stack — este .gitkeep só mantém o
+# diretório `templates/` rastreado pelo git.

--- a/platform/observability/prometheus/templates/.uniplus-placeholder
+++ b/platform/observability/prometheus/templates/.uniplus-placeholder
@@ -1,0 +1,5 @@
+# Templates Uni+ específicos do wrapper (NetworkPolicy custom, IngressRoutes
+# OIDC-gated, etc.) ficam aqui. Atualmente o chart delega tudo para o
+# subchart upstream kube-prometheus-stack, então este diretório fica vazio
+# mas precisa existir para que helm lint --strict aceite o chart como
+# completo.

--- a/platform/observability/prometheus/templates/.uniplus-placeholder
+++ b/platform/observability/prometheus/templates/.uniplus-placeholder
@@ -1,5 +1,0 @@
-# Templates Uni+ específicos do wrapper (NetworkPolicy custom, IngressRoutes
-# OIDC-gated, etc.) ficam aqui. Atualmente o chart delega tudo para o
-# subchart upstream kube-prometheus-stack, então este diretório fica vazio
-# mas precisa existir para que helm lint --strict aceite o chart como
-# completo.

--- a/platform/observability/prometheus/values.schema.json
+++ b/platform/observability/prometheus/values.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/unifesspa-edu-br/uniplus-infra/platform/observability/prometheus/values.schema.json",
+  "title": "prometheus chart values",
+  "description": "Schema mínimo dos values do chart wrapper. Subchart kube-prometheus-stack tem seu próprio schema (extenso); additionalProperties=true em todos os blocos permite passar overrides que serão validados pelo upstream.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "kubePrometheusStack": {
+      "type": "object",
+      "description": "Bloco do subchart prometheus-community/kube-prometheus-stack (alias).",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Liga/desliga o subchart. False em PA1 (que hospeda agregação separada)."
+        },
+        "nameOverride": {
+          "type": "string",
+          "description": "Força kebab-case no Chart.Name (alias=kubePrometheusStack vira camelCase nos labels sem este override)."
+        },
+        "commonLabels": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Labels Uni+ aplicados em todos recursos. NÃO incluir component (vide platform/cert-manager para a lição)."
+        },
+        "crds": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "grafana": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Default false aqui — Grafana vai pro chart platform/observability/grafana/ (#27)."
+            }
+          }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/platform/observability/prometheus/values.yaml
+++ b/platform/observability/prometheus/values.yaml
@@ -26,8 +26,8 @@ kubePrometheusStack:
     app.kubernetes.io/part-of: uniplus
 
   # Instalar CRDs (ServiceMonitor, PodMonitor, PrometheusRule, etc.)
-  # ArgoCD reconcilia. KEEP em uninstall pra preservar configurações
-  # de monitoring de outros charts.
+  # ArgoCD reconcilia. O subchart upstream já aplica `helm.sh/resource-policy:
+  # keep` nas CRDs, então uninstall preserva — não precisa flag adicional.
   crds:
     enabled: true
     upgradeJob:
@@ -166,13 +166,13 @@ kubePrometheusStack:
   kubelet:
     enabled: true
   kubeControllerManager:
-    enabled: false  # K3s embute no kubelet
+    enabled: false  # K3s roda controller-manager via processo único do K3s, sem endpoint HTTP separado
   kubeScheduler:
-    enabled: false  # K3s embute no kubelet
+    enabled: false  # idem (mesmo binário K3s)
   kubeProxy:
-    enabled: false  # K3s usa flannel sem kube-proxy
+    enabled: false  # K3s roda kube-proxy mas binda métricas em 127.0.0.1 por default — SM padrão não scrapeia
   kubeEtcd:
-    enabled: false  # K3s embarca etcd sem endpoint scrape
+    enabled: false  # K3s embarca etcd sem endpoint client-cert separado pra scrape
 
 # ============================================================================
 # NetworkPolicy custom Uni+. O subchart upstream tem suas próprias NPs

--- a/platform/observability/prometheus/values.yaml
+++ b/platform/observability/prometheus/values.yaml
@@ -1,0 +1,185 @@
+# Defaults para o stack Prometheus no cluster Uni+.
+#
+# Topologia (ADR-007 + ADR-008):
+# - lab/prod-{sp1,sp2}: Prometheus local com retenção curta (7-15d);
+#   PA1 agrega retenção longa (separado, fora deste chart)
+# - standalone: Prometheus single-replica, retenção 7d (suficiente pra
+#   validação, alinhado a `environments/standalone/values.yaml:77-79`)
+# - PA1: stack desligado por default (PA1 hospeda agregação separada)
+#
+# IMPORTANTE: este chart wrapper NÃO inclui Grafana (vai pro chart
+# platform/observability/grafana/, sub-issue #27). O subchart upstream
+# kube-prometheus-stack vem com Grafana habilitado por default — desliga
+# explicitamente aqui.
+
+kubePrometheusStack:
+  enabled: true
+
+  # `nameOverride` força kebab-case no Chart.Name (alias=kubePrometheusStack
+  # iria virar `kubePrometheusStack` nos labels). Mesma lição da
+  # platform/external-secrets/ e platform/cert-manager/.
+  nameOverride: kube-prometheus-stack
+
+  # Labels padrão Uni+ aplicados em todos os recursos do subchart.
+  # NÃO incluir `app.kubernetes.io/component` aqui (pode quebrar selectors).
+  commonLabels:
+    app.kubernetes.io/part-of: uniplus
+
+  # Instalar CRDs (ServiceMonitor, PodMonitor, PrometheusRule, etc.)
+  # ArgoCD reconcilia. KEEP em uninstall pra preservar configurações
+  # de monitoring de outros charts.
+  crds:
+    enabled: true
+    upgradeJob:
+      enabled: false  # ArgoCD gerencia upgrades via sync
+
+  # ============================================================================
+  # Grafana — DESLIGADO neste chart (vai pro platform/observability/grafana/).
+  # ============================================================================
+  grafana:
+    enabled: false
+
+  # ============================================================================
+  # Prometheus Operator (rola os CRDs ServiceMonitor/PodMonitor/etc.).
+  # ============================================================================
+  prometheusOperator:
+    enabled: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  # ============================================================================
+  # Prometheus server (TSDB + scrape) + IngressRoute para a UI.
+  # ============================================================================
+  prometheus:
+    enabled: true
+    # IngressRoute (Traefik) para a UI do Prometheus.
+    # DESLIGADO por default — habilitar atrás de OIDC + IP allowlist via
+    # IngressRoute separada (sub-issue futura, similar ao Vault UI).
+    ingress:
+      enabled: false
+    prometheusSpec:
+      # 1 réplica em standalone/lab; prod-{sp1,sp2} elevam para 2 via env.
+      replicas: 1
+
+      # Retenção 7d (alinha com environments/standalone/values.yaml:77-79).
+      # Prod elevará para 15d via override; PA1 hospeda retenção longa.
+      retention: 7d
+      retentionSize: 8GiB  # storage 10Gi com folga pra WAL
+
+      # Recursos lab — Tabela 10.1.
+      resources:
+        requests:
+          cpu: 200m
+          memory: 512Mi
+        limits:
+          cpu: 1000m
+          memory: 2Gi
+
+      # Storage PVC. StorageClass nomeada pelo environment.
+      # standalone-local-nvme em standalone (override por env).
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            # storageClassName: <definido por environment>
+            resources:
+              requests:
+                storage: 10Gi
+
+      # Selecionar TODOS os ServiceMonitors do cluster, não só os com
+      # release matching. Permite que charts independentes (vault,
+      # external-secrets, cert-manager, traefik) tenham seus SMs scrapeados
+      # sem precisar sincronizar release labels.
+      serviceMonitorSelectorNilUsesHelmValues: false
+      podMonitorSelectorNilUsesHelmValues: false
+      probeSelectorNilUsesHelmValues: false
+      ruleSelectorNilUsesHelmValues: false
+
+      # Identificação institucional nos external_labels (carregadas em
+      # alertas e federation). Override por env (cluster name).
+      externalLabels:
+        institution: unifesspa
+        platform: uniplus
+        # cluster: <definido por environment>
+
+  # ============================================================================
+  # Alertmanager — placeholder (sem receivers reais).
+  # Receivers de email/Slack/etc. serão adicionados em sub-issue separada.
+  # ============================================================================
+  alertmanager:
+    enabled: true
+    alertmanagerSpec:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+      retention: 120h
+      storage:
+        volumeClaimTemplate:
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: 2Gi
+
+    # Configuração inicial: receiver "null" que descarta os alertas (apenas
+    # registra no log do Alertmanager). Substituir quando a integração de
+    # notificações for definida.
+    config:
+      global:
+        resolve_timeout: 5m
+      route:
+        group_by: [alertname, cluster, service]
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 12h
+        receiver: "null"
+      receivers:
+        - name: "null"
+      inhibit_rules: []
+
+  # ============================================================================
+  # Node exporter (DaemonSet — métricas de host) e kube-state-metrics.
+  # ============================================================================
+  nodeExporter:
+    enabled: true
+
+  kube-state-metrics:
+    enabled: true
+
+  # ============================================================================
+  # Componentes opcionais — desligar ServiceMonitors duplicados em K3s.
+  # Em K3s control-plane components rodam como processos no host (não como
+  # Pods K8s separados), então os SMs default não conseguem scrape.
+  # ============================================================================
+  kubeApiServer:
+    enabled: true
+  kubelet:
+    enabled: true
+  kubeControllerManager:
+    enabled: false  # K3s embute no kubelet
+  kubeScheduler:
+    enabled: false  # K3s embute no kubelet
+  kubeProxy:
+    enabled: false  # K3s usa flannel sem kube-proxy
+  kubeEtcd:
+    enabled: false  # K3s embarca etcd sem endpoint scrape
+
+# ============================================================================
+# NetworkPolicy custom Uni+. O subchart upstream tem suas próprias NPs
+# (gateadas por `prometheus.networkPolicy.enabled`); nosso chart não duplica.
+# Override por env caso seja necessário ajustar.
+# ============================================================================
+networkPolicy:
+  # Wrapper deixa pro subchart gerenciar NetworkPolicies. Habilitar via
+  # `kubePrometheusStack.prometheus.networkPolicy.enabled: true` em env values.
+  enabled: false


### PR DESCRIPTION
## Sumário

Fecha #26 — `platform/observability/prometheus/` deixa de ser placeholder e vira chart wrapper completo do upstream `prometheus-community/kube-prometheus-stack` 84.5.0 (Operator v0.90.1).

Primeira peça da Fase 7 do plano standalone (observabilidade — paralela ao caminho crítico). Destrava ServiceMonitors em `platform/external-secrets/`, `platform/cert-manager/`, `platform/traefik/` e `platform/vault/` (já mergeados) — basta habilitar o flag em cada env values quando este chart estiver Synced/Healthy.

## Mudanças

**Stack incluído:**
- Prometheus Operator (rola CRDs ServiceMonitor/PodMonitor/PrometheusRule/AlertmanagerConfig/etc.)
- Prometheus server (1 réplica, retenção 7d alinhada com `environments/standalone/values.yaml:77`)
- Alertmanager (1 réplica, receiver placeholder `null` — apenas log; receivers reais ficam para sub-issue)
- node-exporter (DaemonSet) + kube-state-metrics

**Componentes excluídos:**
- Grafana — chart separado em #27
- ServiceMonitors de kube-controller-manager/scheduler/proxy/etcd — K3s embute esses no kubelet ou usa flannel sem kube-proxy, evitando alertas falsos `*Down`

**Decisões de design:**
- `alias: kubePrometheusStack` + `nameOverride: kube-prometheus-stack` (kebab-case nos labels — mesma lição de external-secrets/cert-manager)
- `commonLabels.app.kubernetes.io/part-of: uniplus` apenas (NÃO `component` — lição da cert-manager #101)
- `serviceMonitorSelectorNilUsesHelmValues: false` — Prometheus aceita SMs de qualquer release/namespace
- `crds.upgradeJob.enabled: false` — ArgoCD gerencia upgrades das CRDs
- IngressRoute desligado por default (habilitar atrás de OIDC + IP allowlist)
- NetworkPolicy do wrapper desligada (subchart tem as próprias)

**Render produzido:** 10 CRDs + 30 PrometheusRules default + 8 SMs internos + Operator + Prometheus + Alertmanager + node-exporter + kube-state-metrics + RBAC + webhooks.

## Pré-requisitos

Nenhum (chart independente). Para uso com TLS via IngressRoute, precisa de `platform/traefik/` (#14, mergeado) + `platform/cert-manager/` (#15, mergeado).

## Como destravar SMs nos charts já mergeados

Após este PR mergear e ApplicationSet sincronizar:

```yaml
# environments/standalone/values.yaml
externalSecrets:
  serviceMonitor:
    enabled: true
certManager:
  prometheus:
    servicemonitor:
      enabled: true
traefik:
  metrics:
    prometheus:
      service:
        enabled: true
      serviceMonitor:
        enabled: true
vault:
  serviceMonitor:
    enabled: true
```

A flag `serviceMonitorSelectorNilUsesHelmValues: false` faz o Prometheus aceitar SMs sem precisar de label sync entre charts.

## Validação

- `helm lint --strict` ✅
- `helm dep update` resolve `kube-prometheus-stack@84.5.0`
- `helm template` renderiza ~70 manifests (CRDs + Operator + Prometheus + Alertmanager + observability tooling)
- yamllint OK, markdownlint 0 errors

## Test plan

- [ ] CI verde
- [ ] Após merge, ArgoCD sincroniza Application `platform-observability-prometheus-uniplus-standalone` para Synced/Healthy
- [ ] CRDs `servicemonitors.monitoring.coreos.com`, `podmonitors`, `prometheusrules` aparecem no cluster
- [ ] Habilitar SMs em algum dos charts já mergeados (ESO/cert-manager/Traefik/Vault) — Prometheus passa a scrape automaticamente
- [ ] Próximo PR (#27 Grafana) consome os datasources Prometheus expostos por este chart

## Issues relacionadas

Closes #26. Sub-task de #3 (umbrella platform charts). Foundation para #27 (Grafana), #28 (Loki), #29 (Tempo), #30 (OTel Collector).