### PR TITLE
feat(observability/grafana): chart wrapper grafana 10.5.15 + datasources

### DIFF
--- a/environments/lab-pa1/values.yaml
+++ b/environments/lab-pa1/values.yaml
@@ -44,6 +44,12 @@ vault:
 kubePrometheusStack:
   enabled: false
 
+# Grafana (chart platform/observability/grafana/) NÃO roda em PA1 também.
+# PA1 hospeda agregação separada; o Grafana de visualização vive nos
+# clusters SP1/SP2 que servem a UI institucional.
+grafana:
+  enabled: false
+
 # Vault Transit — chart platform/vault-transit/.
 # 1 réplica em lab/sanidade (recursos reduzidos); 3 réplicas Raft em hml/prod.
 vaultTransit:

--- a/environments/lab-sp1/values.yaml
+++ b/environments/lab-sp1/values.yaml
@@ -98,6 +98,25 @@ kubePrometheusStack:
           spec:
             storageClassName: lab-local-nvme
 
+# Wiring real do chart platform/observability/grafana/ — força tier
+# `lab-local-nvme` no PVC e datasource Prometheus apontando para o
+# Service real do release deste cluster.
+grafana:
+  persistence:
+    storageClassName: lab-local-nvme
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          uid: prometheus
+          access: proxy
+          url: http://platform-observability-prometheus-lab-sp1-prometheus.observability-prometheus.svc.cluster.local:9090
+          isDefault: true
+          jsonData:
+            timeInterval: 30s
+
 # Cluster identification
 cluster:
   name: lab-sp1

--- a/environments/lab-sp2/values.yaml
+++ b/environments/lab-sp2/values.yaml
@@ -93,6 +93,24 @@ kubePrometheusStack:
           spec:
             storageClassName: lab-local-nvme
 
+# Wiring real do chart platform/observability/grafana/ — tier lab-local-nvme
+# e datasource Prometheus do release deste cluster.
+grafana:
+  persistence:
+    storageClassName: lab-local-nvme
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          uid: prometheus
+          access: proxy
+          url: http://platform-observability-prometheus-lab-sp2-prometheus.observability-prometheus.svc.cluster.local:9090
+          isDefault: true
+          jsonData:
+            timeInterval: 30s
+
 cluster:
   name: lab-sp2
   region: lab

--- a/environments/prod-pa1/values.yaml
+++ b/environments/prod-pa1/values.yaml
@@ -44,6 +44,11 @@ vault:
 kubePrometheusStack:
   enabled: false
 
+# Grafana (chart platform/observability/grafana/) NÃO roda em PA1.
+# UI institucional vive nos clusters SP1/SP2.
+grafana:
+  enabled: false
+
 # Vault Transit em HA Raft (3 réplicas) em prod.
 vaultTransit:
   enabled: false  # ligar quando dependências estiverem prontas

--- a/environments/prod-sp1/values.yaml
+++ b/environments/prod-sp1/values.yaml
@@ -87,6 +87,25 @@ kubePrometheusStack:
           spec:
             storageClassName: prod-local-nvme
 
+# Wiring real do chart platform/observability/grafana/ — tier prod-local-nvme,
+# 2 réplicas para HA, datasource Prometheus do release deste cluster.
+grafana:
+  replicas: 2
+  persistence:
+    storageClassName: prod-local-nvme
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          uid: prometheus
+          access: proxy
+          url: http://platform-observability-prometheus-prod-sp1-prometheus.observability-prometheus.svc.cluster.local:9090
+          isDefault: true
+          jsonData:
+            timeInterval: 30s
+
 cluster:
   name: prod-sp1
   region: prod

--- a/environments/prod-sp2/values.yaml
+++ b/environments/prod-sp2/values.yaml
@@ -82,6 +82,26 @@ kubePrometheusStack:
           spec:
             storageClassName: prod-local-nvme
 
+# Wiring real do chart platform/observability/grafana/ — tier prod-local-nvme,
+# 2 réplicas para HA, datasource Prometheus do release deste cluster
+# (espelha prod-sp1).
+grafana:
+  replicas: 2
+  persistence:
+    storageClassName: prod-local-nvme
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          uid: prometheus
+          access: proxy
+          url: http://platform-observability-prometheus-prod-sp2-prometheus.observability-prometheus.svc.cluster.local:9090
+          isDefault: true
+          jsonData:
+            timeInterval: 30s
+
 cluster:
   name: prod-sp2
   region: prod

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -110,6 +110,29 @@ kubePrometheusStack:
           spec:
             storageClassName: standalone-local-nvme
 
+# Wiring real do chart platform/observability/grafana/ — força StorageClass
+# `standalone-local-nvme` no PVC (sem isso fica no `local-path` default do
+# K3s) e sobrescreve a URL do Prometheus datasource com o nome real do
+# Service (release name dinâmico do ApplicationSet).
+grafana:
+  persistence:
+    storageClassName: standalone-local-nvme
+  grafana.ini:
+    server:
+      root_url: https://standalone.portaluni.com.br/grafana/
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          uid: prometheus
+          access: proxy
+          url: http://platform-observability-prometheus-uniplus-standalone-prometheus.observability-prometheus.svc.cluster.local:9090
+          isDefault: true
+          jsonData:
+            timeInterval: 30s
+
 # ============================================================================
 # StorageClass do tier standalone (#74, ADR-008).
 # rancher.io/local-path mapeado para /var/lib/uniplus/* no NVMe local da VM.

--- a/platform/observability/grafana/Chart.lock
+++ b/platform/observability/grafana/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: grafana
+  repository: https://grafana.github.io/helm-charts
+  version: 10.5.15
+digest: sha256:b3cb95e553f7a46143ca66dda33a61479c41146a7fa50a67ac4cf775934d9a28
+generated: "2026-05-05T02:58:50.619294584-03:00"

--- a/platform/observability/grafana/Chart.yaml
+++ b/platform/observability/grafana/Chart.yaml
@@ -1,0 +1,37 @@
+apiVersion: v2
+name: grafana
+description: |
+  Grafana — UI para visualização de métricas (Prometheus), logs (Loki) e
+  traces (Tempo). Empacotado como chart wrapper sobre grafana/grafana com
+  datasources pré-configurados.
+type: application
+
+# Versão do chart wrapper Uni+.
+version: 0.1.0
+
+# Versão do Grafana upstream empacotado.
+appVersion: "12.3.1"
+
+home: https://github.com/unifesspa-edu-br/uniplus-infra
+sources:
+  - https://github.com/unifesspa-edu-br/uniplus-infra
+  - https://github.com/grafana/helm-charts
+
+maintainers:
+  - name: CTIC Unifesspa
+    url: https://github.com/unifesspa-edu-br
+
+keywords:
+  - grafana
+  - observability
+  - dashboards
+  - uniplus
+
+# Dependência do chart upstream oficial.
+# Sem alias — `grafana` é nome válido como Go identifier, valores acessíveis
+# via .Values.grafana.x diretamente.
+dependencies:
+  - name: grafana
+    version: 10.5.15
+    repository: https://grafana.github.io/helm-charts
+    condition: grafana.enabled

--- a/platform/observability/grafana/README.md
+++ b/platform/observability/grafana/README.md
@@ -1,30 +1,156 @@
-# observability/grafana
+# grafana
 
-Dashboards e visualização
-
-> ⚠️ **Status:** placeholder inicial.
+UI para visualização de métricas (Prometheus), logs (Loki) e traces (Tempo).
 
 ## Visão geral
 
-Componente de plataforma do cluster Kubernetes do Uni+.
+Wrapper do chart oficial [grafana/grafana](https://github.com/grafana/helm-charts/tree/main/charts/grafana). Roda em cada cluster (lab-{sp1,sp2}, prod-{sp1,sp2}, standalone). Em PA1 fica desligado por default — PA1 hospeda agregação separada.
+
+Vem como chart separado (não bundled no `kube-prometheus-stack`) para facilitar versionamento independente e desligar Grafana em envs sem UI (PA1, ou qualquer cluster onde apenas a coleta importe).
 
 **Upstream:** https://github.com/grafana/helm-charts
+**Versão upstream empacotada:** grafana 10.5.15 (Grafana v12.3.1)
 
-## Estratégia de deploy
+## Estrutura
 
-Recomenda-se usar o **chart upstream oficial** quando disponível, ao invés de manter chart próprio. Esta pasta deve conter:
+```
+platform/observability/grafana/
+├── Chart.yaml                              # subchart upstream (sem alias)
+├── values.yaml                             # defaults Uni+ + datasources
+├── values.schema.json                      # validação dos overrides
+├── README.md                               # este arquivo
+└── templates/                              # delegado ao subchart (placeholder)
+```
 
-- `Chart.yaml` — chart umbrella ou referência ao chart upstream
-- `values.yaml` — valores customizados para o ambiente Uni+
-- `README.md` — este arquivo
+## Bootstrap
 
-## Implementação pendente
+Após o ApplicationSet sincronizar:
 
-- [ ] Chart.yaml com dependência do chart upstream
-- [ ] values.yaml com configuração base
-- [ ] Documentação de configurações específicas
-- [ ] ApplicationSet ArgoCD
+1. Pod do Grafana sobe (1 réplica em standalone/lab; 2+ em prod via override)
+2. PVC `grafana` (5Gi default) é provisionado para o sqlite interno
+3. Datasource Prometheus pré-configurado via ConfigMap (sidecar carrega no boot)
+4. Loki/Tempo datasources gateados — habilitar em env quando charts (#28/#29) aterrissarem
+5. Sidecar `grafana_dashboard=1` carrega dashboards de qualquer ConfigMap labelado dessa forma em qualquer namespace (search-namespace=ALL)
+6. Login default `admin` / `uniplus` (PLACEHOLDER) — sobrescrever via ESO + Vault em prod/standalone
 
-## Contribuindo
+## Variáveis principais
 
-PRs em [unifesspa-edu-br/uniplus-infra](https://github.com/unifesspa-edu-br/uniplus-infra).
+| Variável | Default | Notas |
+|---|---|---|
+| `grafana.enabled` | `true` | Liga o subchart |
+| `grafana.replicas` | `1` | 1 em standalone/lab, 2+ em prod (override) |
+| `grafana.persistence.size` | `5Gi` | PVC para o sqlite interno |
+| `grafana.adminPassword` | `uniplus` | PLACEHOLDER — sobrescrever via ESO + Vault em prod/standalone |
+| `grafana.serviceMonitor.enabled` | `false` | Ligar quando Prometheus (#26) consumidor estiver pronto e Grafana scrapeado |
+| `grafana.ingress.enabled` | `false` | Wrapper usa IngressRoute do Traefik (futuro template gated) |
+| `grafana.sidecar.dashboards.enabled` | `true` | Auto-carrega dashboards de ConfigMaps labelados |
+| `networkPolicy.enabled` | `false` | Subchart tem NPs próprias — habilitar em env se necessário |
+
+## Datasource Prometheus — URL por environment
+
+O default em `values.yaml` usa um placeholder `CLUSTER` no FQDN do Service Prometheus:
+
+```yaml
+url: http://platform-observability-prometheus-CLUSTER-prometheus.observability-prometheus.svc.cluster.local:9090
+```
+
+Isso porque o ApplicationSet usa o cluster name no release (`{{.name}}` em `argocd/applicationset.yaml`) e o Service do Prometheus leva esse nome. Cada environment DEVE sobrescrever:
+
+```yaml
+# environments/standalone/values.yaml
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          uid: prometheus
+          access: proxy
+          url: http://platform-observability-prometheus-uniplus-standalone-prometheus.observability-prometheus.svc.cluster.local:9090
+          isDefault: true
+          jsonData:
+            timeInterval: 30s
+```
+
+Pattern por env:
+- standalone: `platform-observability-prometheus-uniplus-standalone-prometheus.observability-prometheus.svc...`
+- lab-sp1: `platform-observability-prometheus-lab-sp1-prometheus.observability-prometheus.svc...`
+- lab-sp2: `platform-observability-prometheus-lab-sp2-prometheus.observability-prometheus.svc...`
+- prod-sp1/sp2: `platform-observability-prometheus-prod-{sp1,sp2}-prometheus.observability-prometheus.svc...`
+
+(Quando `platform/observability/prometheus/` ganhar `fullnameOverride`, esse pattern simplifica — issue separada se valer a pena.)
+
+## Provisionar dashboards Uni+
+
+Dashboards customizados são empacotados como ConfigMaps com label `grafana_dashboard=1`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: portal-dashboard
+  labels:
+    grafana_dashboard: "1"   # sidecar do Grafana auto-carrega
+data:
+  portal.json: |
+    { "dashboard": { ... JSON do dashboard ... } }
+```
+
+Os ConfigMaps podem viver em qualquer namespace (sidecar usa `searchNamespace: ALL`). Dashboards iniciais (cluster, K8s, node-exporter, kube-state-metrics) são carregados automaticamente do upstream `kube-prometheus-stack`.
+
+## SSO via OIDC (Keycloak)
+
+`grafana.ini` traz placeholder para integração OIDC (ADR-003). Quando `apps/keycloak-replica` tiver o realm `uniplus` com client `grafana` configurado, sobrescrever em env values:
+
+```yaml
+grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.standalone.portaluni.com.br
+    auth.generic_oauth:
+      enabled: true
+      name: Keycloak
+      allow_sign_up: true
+      client_id: grafana
+      client_secret: $__file{/etc/secrets/oidc-client-secret}  # via ESO
+      scopes: openid email profile
+      auth_url: https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/auth
+      token_url: http://platform-keycloak-replica-uniplus-standalone-keycloakx-http.keycloak.svc.cluster.local:8080/realms/uniplus/protocol/openid-connect/token
+      api_url: http://platform-keycloak-replica-uniplus-standalone-keycloakx-http.keycloak.svc.cluster.local:8080/realms/uniplus/protocol/openid-connect/userinfo
+```
+
+(URLs exatas dependem do chart Keycloak quando aterrissar.)
+
+## Storage
+
+PVC default 5Gi (sqlite interno do Grafana). Em standalone, `storageClassName` herda da `standalone-local-nvme` quando configurado em env values:
+
+```yaml
+# environments/standalone/values.yaml
+grafana:
+  persistence:
+    storageClassName: standalone-local-nvme
+```
+
+Mesmo override para os demais envs (lab/prod-local-nvme).
+
+## Network
+
+O subchart upstream tem NetworkPolicies próprias (gateadas por `grafana.networkPolicy.enabled`). Wrapper Uni+ não duplica — habilitar via env values quando necessário.
+
+## Segurança
+
+- Pod roda como non-root (UID 472, default upstream)
+- `adminPassword: uniplus` é PLACEHOLDER — JAMAIS commitar senha real; sobrescrever via ESO apontando para `secret/grafana/admin` no Vault
+- IngressRoute desligada por default — habilitar atrás de OIDC (depois que Keycloak chart aterrissar)
+- `analytics.reporting_enabled: false` (não envia telemetria pra Grafana Labs)
+
+## Referências
+
+- [#3](https://github.com/unifesspa-edu-br/uniplus-infra/issues/3) — umbrella platform charts
+- [#27](https://github.com/unifesspa-edu-br/uniplus-infra/issues/27) — esta task
+- [#26](https://github.com/unifesspa-edu-br/uniplus-infra/issues/26) — Prometheus (datasource principal — mergeado)
+- [#28](https://github.com/unifesspa-edu-br/uniplus-infra/issues/28) — Loki (datasource futuro)
+- [#29](https://github.com/unifesspa-edu-br/uniplus-infra/issues/29) — Tempo (datasource futuro)
+- ADR-003 (OIDC federado Gov.br via Keycloak)

--- a/platform/observability/grafana/templates/.gitkeep
+++ b/platform/observability/grafana/templates/.gitkeep
@@ -1,0 +1,4 @@
+# Templates Uni+ específicos do wrapper (NetworkPolicy custom, IngressRoutes
+# OIDC-gated, dashboards provisionados via ConfigMap, etc.) ficam aqui.
+# Atualmente o chart delega tudo para o subchart upstream grafana/grafana
+# — este .gitkeep só mantém o diretório `templates/` rastreado pelo git.

--- a/platform/observability/grafana/values.schema.json
+++ b/platform/observability/grafana/values.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/unifesspa-edu-br/uniplus-infra/platform/observability/grafana/values.schema.json",
+  "title": "grafana chart values",
+  "description": "Schema mínimo dos values do chart wrapper. Subchart grafana/grafana tem seu próprio schema; additionalProperties=true em todos os blocos permite passar overrides validados pelo upstream.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "grafana": {
+      "type": "object",
+      "description": "Bloco do subchart grafana/grafana.",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Liga/desliga o subchart. False em PA1 (que hospeda agregação separada)."
+        },
+        "replicas": { "type": "integer", "minimum": 1 },
+        "adminUser": { "type": "string" },
+        "adminPassword": {
+          "type": "string",
+          "description": "PLACEHOLDER no chart. Sobrescrever via ESO em prod/standalone."
+        },
+        "commonLabels": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/platform/observability/grafana/values.yaml
+++ b/platform/observability/grafana/values.yaml
@@ -1,0 +1,139 @@
+# Defaults para o Grafana no cluster Uni+.
+#
+# Topologia: roda em cada cluster (lab-{sp1,sp2}, prod-{sp1,sp2}, standalone).
+# Em PA1 fica desligado por default (PA1 hospeda agregação separada).
+#
+# Datasources:
+# - Prometheus: pré-configurado, aponta pro Service do chart
+#   `platform/observability/prometheus/` (release name no namespace
+#   `observability-prometheus` per ApplicationSet pattern).
+# - Loki: gateado por `datasources.loki.enabled` (false até #28 mergear).
+# - Tempo: gateado por `datasources.tempo.enabled` (false até #29 mergear).
+#
+# Admin password: placeholder no chart wrapper (default `admin/uniplus`).
+# Em prod/standalone, sobrescrever via External Secret (#24 ESO já mergeado;
+# requer Vault inicializado #64). Não commitar senha real no values.
+
+grafana:
+  enabled: true
+
+  # Padrão Uni+: kebab-case no Chart.Name (sem alias necessário, mas
+  # explicito por consistência com outros wrappers).
+  commonLabels:
+    app.kubernetes.io/part-of: uniplus
+
+  # 1 réplica em standalone/lab; prod-{sp1,sp2} elevam para 2.
+  replicas: 1
+
+  # Recursos lab — Tabela 10.1 (Grafana é leve em uso normal).
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  # Imagem upstream — versão pinada via appVersion do Chart.yaml.
+  image:
+    tag: "12.3.1"
+
+  # Persistence: 5Gi PVC para o sqlite (sessions + dashboards modificados
+  # via UI, embora o pattern preferido seja provisionar via ConfigMap).
+  # StorageClass nomeada pelo environment.
+  persistence:
+    enabled: true
+    type: pvc
+    accessModes: ["ReadWriteOnce"]
+    size: 5Gi
+    # storageClassName: <definido por environment>
+
+  # Admin: senha placeholder. Em prod/standalone sobrescrever via ESO
+  # apontando para Secret no Vault (path secret/grafana/admin).
+  admin:
+    existingSecret: ""              # default vazio — usa adminPassword abaixo
+    userKey: admin-user
+    passwordKey: admin-password
+  adminUser: admin
+  adminPassword: uniplus            # PLACEHOLDER — sobrescrever por env+ESO
+
+  # Service: ClusterIP (acesso via IngressRoute do Traefik).
+  service:
+    type: ClusterIP
+    port: 80
+
+  # Ingress upstream desligado — usamos IngressRoute do Traefik via
+  # template separado quando configurado (default off).
+  ingress:
+    enabled: false
+
+  # Métricas Prometheus do próprio Grafana. ServiceMonitor vem do upstream
+  # (gateado por `serviceMonitor.enabled`); wrapper não emite SM próprio.
+  serviceMonitor:
+    enabled: false  # ligar quando Prometheus (#26) consumidor estiver pronto
+
+  # Datasources provisionados via ConfigMap. Prometheus pré-configurado;
+  # Loki/Tempo gateados até as charts (#28/#29) aterrissarem.
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          uid: prometheus
+          access: proxy
+          # URL do Service do Prometheus em outro namespace. ApplicationSet
+          # cria release `platform-observability-prometheus-<cluster>` no
+          # namespace `observability-prometheus`. O Service do Prometheus
+          # leva o release name + sufixo do subchart kube-prometheus-stack.
+          # Override por environment (cluster name varia).
+          url: http://platform-observability-prometheus-CLUSTER-prometheus.observability-prometheus.svc.cluster.local:9090
+          isDefault: true
+          jsonData:
+            timeInterval: 30s
+
+  # Dashboards iniciais — carregados via sidecar do upstream chart se
+  # `sidecar.dashboards.enabled: true`. Default off no wrapper para ficar
+  # leve; ligar quando dashboards Uni+ específicos forem provisionados.
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      labelValue: "1"
+      folder: /tmp/dashboards
+      searchNamespace: ALL
+    datasources:
+      enabled: true
+      label: grafana_datasource
+      labelValue: "1"
+      searchNamespace: ALL
+
+  # SSO via OIDC (Keycloak — ADR-003) — placeholder. Habilitar em env values
+  # apontando pro realm Uni+ depois que Keycloak (apps/keycloak-replica)
+  # tiver o client `grafana` configurado.
+  grafana.ini:
+    server:
+      root_url: ""  # override por env (ex.: https://grafana.standalone.portaluni.com.br)
+    analytics:
+      reporting_enabled: false
+      check_for_updates: false
+    auth:
+      disable_login_form: false
+    auth.anonymous:
+      enabled: false
+    log:
+      mode: console
+      level: info
+
+  # Pod security — non-root (Grafana já roda como UID 472 por default).
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 472
+    fsGroup: 472
+
+# ============================================================================
+# NetworkPolicy custom Uni+. Subchart upstream tem suas próprias NPs;
+# wrapper deixa pra subchart. Override por env se precisar.
+# ============================================================================
+networkPolicy:
+  enabled: false

--- a/platform/observability/grafana/values.yaml
+++ b/platform/observability/grafana/values.yaml
@@ -17,9 +17,11 @@
 grafana:
   enabled: true
 
-  # Padrão Uni+: kebab-case no Chart.Name (sem alias necessário, mas
-  # explicito por consistência com outros wrappers).
-  commonLabels:
+  # Labels Uni+ aplicados aos resources do subchart. ATENÇÃO: o chart
+  # grafana/grafana usa `extraLabels` (NÃO `commonLabels` como prometheus
+  # ou external-secrets). Setar `commonLabels` aqui seria silenciosamente
+  # ignorado e `app.kubernetes.io/part-of: uniplus` não propagaria.
+  extraLabels:
     app.kubernetes.io/part-of: uniplus
 
   # 1 réplica em standalone/lab; prod-{sp1,sp2} elevam para 2.


### PR DESCRIPTION
## Sumário

Fecha #27 — `platform/observability/grafana/` deixa de ser placeholder e vira chart wrapper completo do upstream `grafana/grafana` 10.5.15 (Grafana v12.3.1).

Complementa o `platform/observability/prometheus/` (PR #103, mergeado) — Grafana fica em chart separado para versionamento independente e flexibilidade (PA1 desliga ambos; envs sem UI desligam só o Grafana).

## Mudanças

**Chart wrapper:**
- `Chart.yaml` v2 com dependência pinada `grafana/grafana@10.5.15` (sem alias — `grafana` é Go identifier válido)
- `values.yaml` com defaults: 1 réplica, persistência 5Gi, datasource Prometheus pré-configurado, sidecar de dashboards/datasources habilitado
- `values.schema.json` minimal com `additionalProperties: true`
- `Chart.lock` commitado

**Configurações:**
- Datasource Prometheus pré-configurado via ConfigMap (URL com placeholder `CLUSTER` — env values sobrescreve com nome real do Service)
- Loki/Tempo datasources documentados no README (habilitar quando #28/#29 mergearem)
- Sidecar `grafana_dashboard=1` carrega dashboards de qualquer ConfigMap labelado em qualquer namespace
- Senha admin PLACEHOLDER `uniplus` — sobrescrever via ESO + Vault em prod/standalone (path `secret/grafana/admin`)
- IngressRoute desligado por default (habilitar atrás de OIDC depois que Keycloak chart aterrissar)
- SSO via OIDC (Keycloak) documentado no README como template para envs sobrescreverem
- Pod non-root (UID 472, default upstream)
- Analytics/telemetria desligados

**Decisões de design:**
- Sem alias na dep (Go identifier válido)
- commonLabels só com `part-of: uniplus` (lição da cert-manager #101)
- ServiceMonitor vem do upstream gateado; wrapper não emite SM próprio
- NetworkPolicy do wrapper desligada (subchart tem as próprias)

## Pré-requisitos

- `platform/observability/prometheus/` (#26, mergeado) — datasource principal
- `platform/traefik/` (#14, mergeado) + `platform/cert-manager/` (#15, mergeado) — quando IngressRoute do Grafana for habilitado

## Test plan

- [ ] CI verde
- [ ] Após merge, ArgoCD sincroniza Application `platform-observability-grafana-uniplus-standalone` para Synced/Healthy
- [ ] Em env values, sobrescrever a URL do Prometheus datasource com o nome real do Service por env (pattern documentado no README)
- [ ] Em env values, sobrescrever `storageClassName` para a tier correta (standalone-local-nvme, lab-local-nvme, prod-local-nvme)
- [ ] `kubectl port-forward svc/grafana 3000:80 -n observability-grafana` → login com `admin` / `uniplus` → dashboards do kube-prometheus-stack devem estar disponíveis (carregados pelo sidecar)

## Issues relacionadas

Closes #27. Sub-task de #3. Foundation Fase 7 continua avançando — restam #28 (Loki), #29 (Tempo), #30 (OTel Collector).