### PR TITLE
fix(argocd): ApplicationSet multi-source com $values ref (corrige path relativo)

### DIFF
--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -47,14 +47,23 @@ spec:
         environment: '{{.metadata.labels.environment}}'
     spec:
       project: uniplus
-      source:
-        repoURL: https://github.com/unifesspa-edu-br/uniplus-infra
-        targetRevision: main
-        path: 'apps/{{.app}}'
-        helm:
-          valueFiles:
-            - values.yaml
-            - '../../environments/{{.metadata.labels.environment}}/values.yaml'
+      # Multi-source apps (ArgoCD ≥ 2.6) — usar `$values` para referenciar
+      # arquivos de valores via path absoluto a partir do repo root,
+      # eliminando a fragilidade de `../../` relativo (que quebra para
+      # paths de profundidade variável). Todos os apps usam apps/<app>
+      # (2 segmentos), mas mantemos o pattern consistente com o
+      # uniplus-platform AppSet para evitar drift.
+      sources:
+        - repoURL: https://github.com/unifesspa-edu-br/uniplus-infra
+          targetRevision: main
+          path: 'apps/{{.app}}'
+          helm:
+            valueFiles:
+              - values.yaml
+              - '$values/environments/{{.metadata.labels.environment}}/values.yaml'
+        - repoURL: https://github.com/unifesspa-edu-br/uniplus-infra
+          targetRevision: main
+          ref: values
       destination:
         server: '{{.server}}'
         namespace: uniplus
@@ -115,14 +124,23 @@ spec:
         environment: '{{.metadata.labels.environment}}'
     spec:
       project: uniplus
-      source:
-        repoURL: https://github.com/unifesspa-edu-br/uniplus-infra
-        targetRevision: main
-        path: 'platform/{{.component}}'
-        helm:
-          valueFiles:
-            - values.yaml
-            - '../../environments/{{.metadata.labels.environment}}/values.yaml'
+      # Multi-source apps — `$values` usa path absoluto a partir do repo
+      # root, evitando o bug de `../../` relativo que renderizava
+      # `platform/environments/...` para components com profundidade 3
+      # (observability/prometheus, observability/grafana, etc.). Components
+      # de profundidade 2 (storage, traefik, ...) também passam a usar
+      # path absoluto pra consistência.
+      sources:
+        - repoURL: https://github.com/unifesspa-edu-br/uniplus-infra
+          targetRevision: main
+          path: 'platform/{{.component}}'
+          helm:
+            valueFiles:
+              - values.yaml
+              - '$values/environments/{{.metadata.labels.environment}}/values.yaml'
+        - repoURL: https://github.com/unifesspa-edu-br/uniplus-infra
+          targetRevision: main
+          ref: values
       destination:
         server: '{{.server}}'
         namespace: '{{.component | replace "/" "-"}}'


### PR DESCRIPTION
## Sumário

Bug encontrado durante validação contra o cluster `uniplus-standalone` real após restart das VMs (5 PRs já merged tinham aterrissado mas o cluster estava off). ApplicationSet renderizava o valueFile relativo `../../environments/<env>/values.yaml` errado para componentes com profundidade > 2 segmentos.

## Análise

Para path `platform/observability/prometheus` (3 segmentos), `../../environments/...` resolvia para `platform/environments/standalone/values.yaml` — caminho que não existe. ArgoCD falhava com:

```
ComparisonError: open <path>/platform/environments/standalone/values.yaml: no such file or directory
```

Confirmado no cluster: `platform-cert-manager-uniplus-standalone` (2 segmentos) com o mesmo valueFile relativo funciona; `platform-observability-prometheus-uniplus-standalone` (3 segmentos) falhava em `Unknown/Healthy` desde sync inicial.

## Fix

Converter ambos os ApplicationSets (`uniplus-apps` e `uniplus-platform`) do pattern single-source com path relativo → multi-source apps (ArgoCD ≥ 2.6) com `$values` ref:

```yaml
sources:
  - repoURL: https://github.com/unifesspa-edu-br/uniplus-infra
    targetRevision: main
    path: 'platform/{{.component}}'
    helm:
      valueFiles:
        - values.yaml
        - $values/environments/{{.metadata.labels.environment}}/values.yaml
  - repoURL: https://github.com/unifesspa-edu-br/uniplus-infra
    targetRevision: main
    ref: values
```

`$values/environments/...` usa path **absoluto** a partir do repo root — funciona para qualquer profundidade de path da source principal.

## Validação

Aplicado direto no cluster antes do PR para validar:

```
ANTES (path relativo):
platform-observability-prometheus-uniplus-standalone   Unknown   Healthy
platform-observability-grafana-uniplus-standalone      Unknown   Healthy

DEPOIS (multi-source $values):
platform-observability-prometheus-uniplus-standalone   OutOfSync   Missing  → auto-sync rodando
platform-observability-grafana-uniplus-standalone      Synced    Progressing
```

Auto-sync do AppSet pega os OutOfSync e converge para Synced/Healthy nos próximos minutos.

## Test plan

- [ ] CI verde
- [ ] Após merge, ArgoCD reaplicará o ApplicationSet no cluster (já manualmente aplicado para destravar a validação noturna)
- [ ] Todas as 18 Applications convergem para Synced (com Healthy/Progressing aceitável; Unknown aceitável apenas para placeholders #25/#28/#29/#30 e cloudflared)

## Issues relacionadas

Bug detectado durante validação que se tornaria visível também em prod 3-DC quando algum environment tentasse usar componentes em `observability/*`. Fix preventivo crítico.