### PR TITLE
fix(charts): remover alias de external-secrets e cert-manager (container name RFC 1123)

### DIFF
--- a/platform/cert-manager/Chart.lock
+++ b/platform/cert-manager/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.20.2
-digest: sha256:141fadb572c29e1104fbfef298cd02b7d985d46f4d47fc2ccae48defc1b76200
-generated: "2026-05-05T00:14:09.371143582-03:00"
+digest: sha256:a06fef64f0b92cdcaae388ba7386da6b9eb1766821245e6cbbaecff3cffec4b1
+generated: "2026-05-05T09:41:15.025788458-03:00"

--- a/platform/cert-manager/Chart.yaml
+++ b/platform/cert-manager/Chart.yaml
@@ -29,12 +29,19 @@ keywords:
   - uniplus
 
 # Dependência do chart upstream oficial.
-# `alias: certManager` mantém consistência com o padrão do platform/external-secrets/
-# (alias camelCase para acessar valores via `.Values.certManager.*` em Go templates).
+# SEM ALIAS: o template `templates/deployment.yaml` do upstream usa
+# `{{ .Chart.Name }}` (e similares) literalmente como nome do container.
+# Com `alias: certManager` os containers ficavam `certManager-controller/
+# webhook/cainjector` (camelCase) — K8s API rejeita por RFC 1123. Sem alias,
+# Chart.Name=`cert-manager` (kebab-case) e os containers validam.
+#
+# Custo: values acessados por `(index .Values "cert-manager" ...)` em Go
+# templates (hífen quebra dot syntax). Restrito ao único campo que o wrapper
+# consulta: `enabled` em ClusterIssuers + networkpolicy.yaml.
 dependencies:
   - name: cert-manager
-    alias: certManager
     version: v1.20.2
     repository: https://charts.jetstack.io
     # Permite desligar o subchart por environment se necessário.
-    condition: certManager.enabled
+    # Helm aceita key com hífen na string de condition.
+    condition: cert-manager.enabled

--- a/platform/cert-manager/templates/clusterissuer-letsencrypt-prod.yaml
+++ b/platform/cert-manager/templates/clusterissuer-letsencrypt-prod.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.certManager.enabled .Values.clusterIssuers.enabled .Values.clusterIssuers.production.enabled }}
+{{- $cm := index .Values "cert-manager" -}}
+{{- if and $cm.enabled .Values.clusterIssuers.enabled .Values.clusterIssuers.production.enabled }}
 {{- if not .Values.clusterIssuers.email -}}
 {{- fail "clusterIssuers.enabled=true exige clusterIssuers.email não vazio (registro ACME)." -}}
 {{- end }}

--- a/platform/cert-manager/templates/clusterissuer-letsencrypt-staging.yaml
+++ b/platform/cert-manager/templates/clusterissuer-letsencrypt-staging.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.certManager.enabled .Values.clusterIssuers.enabled .Values.clusterIssuers.staging.enabled }}
+{{- $cm := index .Values "cert-manager" -}}
+{{- if and $cm.enabled .Values.clusterIssuers.enabled .Values.clusterIssuers.staging.enabled }}
 {{- if not .Values.clusterIssuers.email -}}
 {{- fail "clusterIssuers.enabled=true exige clusterIssuers.email não vazio (registro ACME)." -}}
 {{- end }}

--- a/platform/cert-manager/templates/networkpolicy.yaml
+++ b/platform/cert-manager/templates/networkpolicy.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.networkPolicy.enabled .Values.certManager.enabled }}
+{{- $cm := index .Values "cert-manager" -}}
+{{- if and .Values.networkPolicy.enabled $cm.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/platform/cert-manager/values.schema.json
+++ b/platform/cert-manager/values.schema.json
@@ -6,9 +6,9 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
-    "certManager": {
+    "cert-manager": {
       "type": "object",
-      "description": "Bloco do subchart jetstack/cert-manager (alias certManager).",
+      "description": "Bloco do subchart jetstack/cert-manager (sem alias — Chart.Name=cert-manager pra K8s container name validar RFC 1123).",
       "additionalProperties": true,
       "properties": {
         "enabled": {

--- a/platform/cert-manager/values.yaml
+++ b/platform/cert-manager/values.yaml
@@ -11,13 +11,12 @@
 # Let's Encrypt — sujeito a rate limits (50 certs/domain/week). Para testes
 # usar letsencrypt-staging (sem rate limit relevante; certs não confiáveis).
 
-certManager:
+# Sem alias no Chart.yaml — key tem que ser literal `cert-manager`
+# (com hífen). Acesso em templates Go via `(index .Values "cert-manager" "x")`.
+# Sem alias o `nameOverride` também é desnecessário: Chart.Name = nome da dep =
+# `cert-manager` (kebab-case) → container name e labels ficam corretos.
+cert-manager:
   enabled: true
-
-  # `nameOverride: cert-manager` força o subchart a usar kebab-case nos
-  # labels e nomes de recursos, restaurando a convenção apesar do alias
-  # camelCase no Chart.yaml. Mesmo padrão de platform/external-secrets/.
-  nameOverride: cert-manager
 
   # Instalar CRDs automaticamente. ArgoCD reconhece e sincroniza.
   # Em prod pode-se mover para gerenciamento separado, mas no Uni+ optamos

--- a/platform/external-secrets/Chart.lock
+++ b/platform/external-secrets/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: external-secrets
   repository: https://charts.external-secrets.io
   version: 2.4.1
-digest: sha256:d67c31aa17bab7e67e2a548d938460a33792f3843cc2d0f2fe1171b0ac85192a
-generated: "2026-05-04T22:51:07.564423948-03:00"
+digest: sha256:a06abaf30a9a95a4061ddb3d112477ef045efe7f890ce589e3b0e045898831bd
+generated: "2026-05-05T09:39:58.083685946-03:00"

--- a/platform/external-secrets/Chart.yaml
+++ b/platform/external-secrets/Chart.yaml
@@ -28,15 +28,20 @@ keywords:
   - uniplus
 
 # Dependência do chart upstream oficial.
-# `alias: externalSecrets` é necessário: sem ele, Helm só forwarda valores
-# da key `external-secrets:` (com hífen) — incompatível com a sintaxe
-# `.Values.externalSecrets.x` em Go templates. O alias renomeia o scope
-# de valores para `externalSecrets:` (camelCase), permitindo override
-# limpo de replicas, resources, commonLabels, serviceAccount.name etc.
+# SEM ALIAS: o template `templates/deployment.yaml` do upstream usa
+# `{{ .Chart.Name }}` literalmente como nome do container (linha
+# `containers: - name: {{ .Chart.Name }}`). Com `alias: externalSecrets`
+# o container ficava `externalSecrets` (camelCase) — K8s API rejeita
+# por RFC 1123 (lowercase + dash apenas). Sem alias, Chart.Name fica
+# `external-secrets` (kebab-case) e o container valida.
+#
+# Custo: values acessados por `(index .Values "external-secrets" ...)`
+# em Go templates (hífen quebra dot syntax). Restrito ao único campo
+# que o wrapper consulta: `enabled` em networkpolicy.yaml + servicemonitor.yaml.
 dependencies:
   - name: external-secrets
-    alias: externalSecrets
     version: 2.4.1
     repository: https://charts.external-secrets.io
     # Permite desligar o subchart por environment se necessário.
-    condition: externalSecrets.enabled
+    # Helm aceita o key com hífen na string de condition.
+    condition: external-secrets.enabled

--- a/platform/external-secrets/templates/networkpolicy.yaml
+++ b/platform/external-secrets/templates/networkpolicy.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.networkPolicy.enabled .Values.externalSecrets.enabled }}
+{{- $eso := index .Values "external-secrets" -}}
+{{- if and .Values.networkPolicy.enabled $eso.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/platform/external-secrets/values.schema.json
+++ b/platform/external-secrets/values.schema.json
@@ -6,9 +6,9 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
-    "externalSecrets": {
+    "external-secrets": {
       "type": "object",
-      "description": "Bloco do subchart external-secrets/external-secrets.",
+      "description": "Bloco do subchart external-secrets/external-secrets (sem alias — Chart.Name=external-secrets pra K8s container name validar RFC 1123).",
       "additionalProperties": true,
       "properties": {
         "enabled": {

--- a/platform/external-secrets/values.yaml
+++ b/platform/external-secrets/values.yaml
@@ -10,15 +10,12 @@
 # de ligar o store. Habilitar via override em environments/<env>/values.yaml
 # após Vault init (issue #64) e provisionamento da policy + role.
 
-externalSecrets:
+# Sem alias no Chart.yaml — key tem que ser literal `external-secrets`
+# (com hífen). Acesso em templates Go via `(index .Values "external-secrets" "x")`.
+# Sem alias o `nameOverride` também é desnecessário: Chart.Name = nome da dep =
+# `external-secrets` (kebab-case) → container name e labels ficam corretos.
+external-secrets:
   enabled: true
-
-  # `alias: externalSecrets` no Chart.yaml faz o subchart enxergar
-  # `Chart.Name == "externalSecrets"` (camelCase). Sem nameOverride os
-  # labels ficam `app.kubernetes.io/name: externalSecrets` (camelCase),
-  # quebrando o podSelector da NetworkPolicy (que usa kebab-case) e a
-  # convenção do projeto (CLAUDE.md: kebab-case em todos os nomes).
-  nameOverride: external-secrets
 
   # Operator core. Mantido enxuto — em prod elevar conforme Tabela 10.1.
   replicaCount: 1


### PR DESCRIPTION
## Sumário

Bug crítico encontrado durante validação contra o cluster `uniplus-standalone` real (após restart das VMs OCI). Ambos os charts `platform/external-secrets/` (PR #100, mergeado) e `platform/cert-manager/` (PR #101, mergeado) falham em sync no ArgoCD com:

```
Deployment ... is invalid: spec.template.spec.containers[0].name: Invalid value:
"externalSecrets": a lowercase RFC 1123 label must consist of lower case
alphanumeric characters or '-'...
```

## Causa raiz

O template `templates/deployment.yaml` upstream usa `{{ .Chart.Name }}` literalmente como nome do container. Com `alias: externalSecrets` (PR #100) e `alias: certManager` (PR #101), Chart.Name ficou camelCase — K8s API rejeita.

Verificado via `helm template`:

| Chart | Antes | Depois |
|---|---|---|
| ESO | container `externalSecrets` (BAD) | container `external-secrets` (OK) |
| cert-manager | `certManager-cainjector/controller/webhook` (BAD) | `cert-manager-cainjector/controller/webhook` (OK) |

## Histórico

Codex pediu o alias na PR #100 ("Add an alias before using externalSecrets overrides") porque key com hífen quebra dot syntax `.Values.externalSecrets.x` em Go templates. Mas a solução tinha custo invisível: o alias virou Chart.Name e o container herdou o camelCase. **A solução correta é NÃO usar alias e acessar values via `(index .Values "external-secrets" "x")`.**

## Fix

Para cada chart (ESO + cert-manager):

1. `Chart.yaml`: remove `alias`. `condition` passa a usar key com hífen (`external-secrets.enabled`, `cert-manager.enabled`) — Helm aceita.
2. `values.yaml`: rename top-level key (`externalSecrets:` → `external-secrets:`, `certManager:` → `cert-manager:`). Remove `nameOverride` (agora redundante — Chart.Name = nome da dep = kebab-case).
3. `templates/*.yaml`: substitui `.Values.externalSecrets.enabled` por `(index .Values "external-secrets" "enabled")` (e equivalente em cert-manager). Apenas as templates do wrapper que checam `enabled` foram tocadas — o resto delega ao subchart.
4. `values.schema.json`: rename property.

Outros charts (Traefik, Prometheus, Grafana, Vault, vault-transit, storage) NÃO afetados — Traefik/Grafana/storage não tinham alias; Prometheus tem alias `kubePrometheusStack` mas o subchart usa helper templates (não `Chart.Name` direto), então funciona; Vault/vault-transit usam mesmo chart upstream com diferenciação só por release name.

## Validação

- `helm lint --strict` ✅ em ambos
- `helm template` confirma container names kebab-case em todos os Deployments
- `helm dep update` resolve corretamente sem o alias
- yamllint OK

## Test plan

- [ ] CI verde
- [ ] Após merge, ArgoCD reaplica os 2 charts no cluster — `platform-external-secrets-uniplus-standalone` e `platform-cert-manager-uniplus-standalone` saem de OutOfSync/Missing-Degraded para Synced/Healthy.

## Issues relacionadas

Bug regressivo dos PRs #100 e #101. Foi detectado tarde porque depende do K8s admission rejeitar — `helm lint` e `helm template` não validam K8s naming rules.