### PR TITLE
ci(validate): kubeconform + check RFC 1123 + fix dup-key labels Prometheus

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -100,6 +100,75 @@ jobs:
             exit 1
           fi
 
+  manifest-validate:
+    name: Manifest Validate (kubeconform + RFC 1123)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.14.0'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML for RFC 1123 validator
+        run: pip install --quiet pyyaml
+
+      - name: Install kubeconform
+        run: |
+          curl -sL \
+            https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
+            | tar xz
+          sudo mv kubeconform /usr/local/bin/
+          kubeconform -v
+
+      - name: Render and validate charts
+        run: |
+          set -euo pipefail
+          K8S_VERSION="1.31.0"
+          FAILS=0
+          for chart in apps/*/ platform/*/ platform/observability/*/; do
+            [ -f "$chart/Chart.yaml" ] || continue
+            chart_name=$(basename "$chart")
+            echo "=== Validating $chart ==="
+            if grep -q '^dependencies:' "$chart/Chart.yaml"; then
+              helm dependency update "$chart" >/dev/null 2>&1
+            fi
+            if ! helm template "$chart_name" "$chart" > /tmp/render.yaml 2>/tmp/render.err; then
+              echo "✗ helm template failed for $chart"
+              cat /tmp/render.err
+              FAILS=$((FAILS+1))
+              continue
+            fi
+            # kubeconform: estrutura/OpenAPI (campos obrigatórios, tipos, kinds).
+            # -ignore-missing-schemas: pula CRDs (ServiceMonitor, IngressRoute,
+            # etc.) cujos schemas não vêm com kubeconform — endereçar em PR
+            # separado via -schema-location se necessário.
+            if ! kubeconform -strict -summary -kubernetes-version "$K8S_VERSION" \
+                -ignore-missing-schemas /tmp/render.yaml; then
+              echo "✗ kubeconform failed for $chart"
+              FAILS=$((FAILS+1))
+            fi
+            # RFC 1123: container names em workloads (Deployment/StatefulSet/
+            # DaemonSet/Job/CronJob/Pod). Captura bug de chart wrapper com
+            # `alias` que vira `Chart.Name` camelCase e produz container name
+            # inválido — kubeconform NÃO pega esse caso (regra de RFC 1123 não
+            # está no OpenAPI schema do K8s, só na admission do API server).
+            if ! python3 scripts/validate-rfc1123.py /tmp/render.yaml; then
+              echo "✗ RFC 1123 validation failed for $chart"
+              FAILS=$((FAILS+1))
+            fi
+          done
+          if [ "$FAILS" -gt 0 ]; then
+            echo "✗ $FAILS validação(ões) falharam"
+            exit 1
+          fi
+
   markdown-lint:
     name: Markdown Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -127,45 +127,51 @@ jobs:
           sudo mv kubeconform /usr/local/bin/
           kubeconform -v
 
-      - name: Render and validate charts
+      - name: Render and validate charts × environments
         run: |
           set -euo pipefail
           K8S_VERSION="1.31.0"
+          ENVS="lab-sp1 lab-sp2 lab-pa1 prod-sp1 prod-sp2 prod-pa1 standalone"
           FAILS=0
           for chart in apps/*/ platform/*/ platform/observability/*/; do
             [ -f "$chart/Chart.yaml" ] || continue
             chart_name=$(basename "$chart")
-            echo "=== Validating $chart ==="
             if grep -q '^dependencies:' "$chart/Chart.yaml"; then
               helm dependency update "$chart" >/dev/null 2>&1
             fi
-            if ! helm template "$chart_name" "$chart" > /tmp/render.yaml 2>/tmp/render.err; then
-              echo "✗ helm template failed for $chart"
-              cat /tmp/render.err
-              FAILS=$((FAILS+1))
-              continue
-            fi
-            # kubeconform: estrutura/OpenAPI (campos obrigatórios, tipos, kinds).
-            # -ignore-missing-schemas: pula CRDs (ServiceMonitor, IngressRoute,
-            # etc.) cujos schemas não vêm com kubeconform — endereçar em PR
-            # separado via -schema-location se necessário.
-            if ! kubeconform -strict -summary -kubernetes-version "$K8S_VERSION" \
-                -ignore-missing-schemas /tmp/render.yaml; then
-              echo "✗ kubeconform failed for $chart"
-              FAILS=$((FAILS+1))
-            fi
-            # RFC 1123: container names em workloads (Deployment/StatefulSet/
-            # DaemonSet/Job/CronJob/Pod). Captura bug de chart wrapper com
-            # `alias` que vira `Chart.Name` camelCase e produz container name
-            # inválido — kubeconform NÃO pega esse caso (regra de RFC 1123 não
-            # está no OpenAPI schema do K8s, só na admission do API server).
-            if ! python3 scripts/validate-rfc1123.py /tmp/render.yaml; then
-              echo "✗ RFC 1123 validation failed for $chart"
-              FAILS=$((FAILS+1))
-            fi
+            for env in $ENVS; do
+              env_values="environments/$env/values.yaml"
+              [ -f "$env_values" ] || continue
+              echo "=== $chart × $env ==="
+              if ! helm template "$chart_name" "$chart" \
+                  -f "$env_values" > /tmp/render.yaml 2>/tmp/render.err; then
+                echo "✗ helm template failed"
+                cat /tmp/render.err
+                FAILS=$((FAILS+1))
+                continue
+              fi
+              # Charts desabilitados em env (ex.: vault em PA1, grafana em PA1)
+              # produzem render vazio — kubeconform/RFC 1123 passam trivialmente.
+              # kubeconform: estrutura/OpenAPI (campos obrigatórios, tipos,
+              # kinds, YAML duplicate-key). -ignore-missing-schemas pula CRDs
+              # (ServiceMonitor, IngressRoute, etc.) sem schema disponível.
+              if ! kubeconform -strict -summary \
+                  -kubernetes-version "$K8S_VERSION" \
+                  -ignore-missing-schemas /tmp/render.yaml; then
+                echo "✗ kubeconform failed for $chart × $env"
+                FAILS=$((FAILS+1))
+              fi
+              # RFC 1123: container names em workloads. Captura bug de chart
+              # wrapper com `alias` virando Chart.Name camelCase + bug de
+              # nomes longos > 63 chars que K8s API rejeita.
+              if ! python3 scripts/validate-rfc1123.py /tmp/render.yaml; then
+                echo "✗ RFC 1123 validation failed for $chart × $env"
+                FAILS=$((FAILS+1))
+              fi
+            done
           done
           if [ "$FAILS" -gt 0 ]; then
-            echo "✗ $FAILS validação(ões) falharam"
+            echo "✗ $FAILS combinação(ões) chart × env falharam"
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ dumps/
 # Configs locais geradas durante setup
 local-config/
 .local/
+__pycache__/

--- a/platform/observability/prometheus/values.yaml
+++ b/platform/observability/prometheus/values.yaml
@@ -20,10 +20,17 @@ kubePrometheusStack:
   # platform/external-secrets/ e platform/cert-manager/.
   nameOverride: kube-prometheus-stack
 
-  # Labels padrão Uni+ aplicados em todos os recursos do subchart.
+  # Labels Uni+ aplicados em todos os recursos do subchart.
   # NÃO incluir `app.kubernetes.io/component` aqui (pode quebrar selectors).
+  # NÃO incluir `app.kubernetes.io/part-of: uniplus` aqui — o subchart
+  # kube-prometheus-stack já adiciona `app.kubernetes.io/part-of:
+  # kube-prometheus-stack` em cada recurso. Sobrescrever via commonLabels
+  # produz YAML com chave duplicada (kubeconform falha; K8s API aceita
+  # com last-wins mas é tecnicamente malformado). Para tracking Uni+,
+  # usar `uniplus.io/managed: "true"` (label de domínio próprio, não
+  # colide com convenções de chart).
   commonLabels:
-    app.kubernetes.io/part-of: uniplus
+    uniplus.io/managed: "true"
 
   # Instalar CRDs (ServiceMonitor, PodMonitor, PrometheusRule, etc.)
   # ArgoCD reconcilia. O subchart upstream já aplica `helm.sh/resource-policy:

--- a/scripts/validate-rfc1123.py
+++ b/scripts/validate-rfc1123.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Valida nomes de container em manifests K8s renderizados (Pod templates) contra
+RFC 1123 label, complementando `kubeconform` (que valida estrutura/OpenAPI mas
+não captura regras de naming impostas pela admission do API server).
+
+O bug que motivou este script: charts wrapper que usam `alias: externalSecrets`
+(Chart.yaml) acabam com Chart.Name camelCase. O template upstream usa
+`{{ .Chart.Name }}` literalmente como nome do container. Resultado: container
+`externalSecrets` no rendered output — K8s API rejeita por RFC 1123:
+  "Invalid value: 'externalSecrets': a lowercase RFC 1123 label must consist
+   of lower case alphanumeric characters or '-', and must start and end with
+   an alphanumeric character"
+
+helm lint, helm template, kubeconform e kubectl --dry-run=client NÃO pegam
+isso. Só `kubectl --dry-run=server` (cluster real) pega — daí esta validação
+estática focada.
+
+Uso:
+  python3 scripts/validate-rfc1123.py <manifests.yaml> [...]
+  helm template chart/ | python3 scripts/validate-rfc1123.py -
+
+Saída: zero issues → exit 0; qualquer issue → exit 1 com lista no stderr.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+RFC1123_LABEL = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+
+# Kinds que carregam Pod template embedded.
+WORKLOAD_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Pod", "Job"}
+
+
+def pod_spec(doc: dict) -> dict | None:
+    """Extrai o PodSpec embedded de um manifest workload."""
+    kind = doc.get("kind")
+    spec = doc.get("spec", {})
+    if kind == "Pod":
+        return spec
+    if kind == "CronJob":
+        return spec.get("jobTemplate", {}).get("spec", {}).get("template", {}).get("spec")
+    if kind in WORKLOAD_KINDS:
+        return spec.get("template", {}).get("spec")
+    return None
+
+
+def validate_doc(doc: dict, source: str) -> list[str]:
+    """Devolve lista de issues encontradas no doc."""
+    issues: list[str] = []
+    if not isinstance(doc, dict):
+        return issues
+    kind = doc.get("kind")
+    name = doc.get("metadata", {}).get("name", "<no-name>")
+
+    ps = pod_spec(doc)
+    if ps is None:
+        return issues
+
+    for container_field in ("containers", "initContainers"):
+        for container in ps.get(container_field, []) or []:
+            cname = container.get("name", "")
+            if not RFC1123_LABEL.match(cname):
+                issues.append(
+                    f"{source}: {kind}/{name} {container_field}[].name=\"{cname}\" "
+                    "fails RFC 1123 label "
+                    "(lowercase alphanumeric + '-', start/end alphanumeric)"
+                )
+    return issues
+
+
+def validate_stream(stream, source: str) -> list[str]:
+    issues: list[str] = []
+    try:
+        docs = list(yaml.safe_load_all(stream))
+    except yaml.YAMLError as exc:
+        return [f"{source}: YAML parse error: {exc}"]
+    for doc in docs:
+        issues.extend(validate_doc(doc, source))
+    return issues
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    all_issues: list[str] = []
+    for arg in argv[1:]:
+        if arg == "-":
+            all_issues.extend(validate_stream(sys.stdin, "<stdin>"))
+        else:
+            path = Path(arg)
+            if not path.is_file():
+                print(f"error: {arg}: not a file", file=sys.stderr)
+                return 2
+            with path.open("r", encoding="utf-8") as fh:
+                all_issues.extend(validate_stream(fh, str(path)))
+
+    if all_issues:
+        print(f"✗ RFC 1123 violations ({len(all_issues)}):", file=sys.stderr)
+        for issue in all_issues:
+            print(f"  {issue}", file=sys.stderr)
+        return 1
+    print("✓ all container names pass RFC 1123 label validation", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/validate-rfc1123.py
+++ b/scripts/validate-rfc1123.py
@@ -30,7 +30,10 @@ from pathlib import Path
 
 import yaml
 
+# RFC 1123 label: regex de caracteres + start/end alphanumeric.
 RFC1123_LABEL = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+# RFC 1123 também limita comprimento a 63 caracteres (DNS label limit).
+RFC1123_MAX_LEN = 63
 
 # Kinds que carregam Pod template embedded.
 WORKLOAD_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Pod", "Job"}
@@ -69,6 +72,11 @@ def validate_doc(doc: dict, source: str) -> list[str]:
                     f"{source}: {kind}/{name} {container_field}[].name=\"{cname}\" "
                     "fails RFC 1123 label "
                     "(lowercase alphanumeric + '-', start/end alphanumeric)"
+                )
+            elif len(cname) > RFC1123_MAX_LEN:
+                issues.append(
+                    f"{source}: {kind}/{name} {container_field}[].name=\"{cname}\" "
+                    f"exceeds RFC 1123 length cap ({len(cname)} > {RFC1123_MAX_LEN})"
                 )
     return issues
 


### PR DESCRIPTION
## Sumário

Adiciona 2 validações ao CI que pegam classes de bug invisíveis para `helm lint` + `helm template`. Encontrados HOJE durante validação contra cluster real:

1. **Bug do alias** (ESO + cert-manager): `alias: externalSecrets`/`certManager` → Chart.Name camelCase → container name camelCase → K8s API rejeita por RFC 1123. Endereçado em PR #106.
2. **Bug duplicate-key labels** (Prometheus): `commonLabels.app.kubernetes.io/part-of: uniplus` colide com `part-of: kube-prometheus-stack` que o subchart upstream já emite — 60 recursos com YAML duplicate-key. Fix incluído nesta PR.

## Validações novas

### kubeconform (-strict, -ignore-missing-schemas)
Estrutura/OpenAPI: campos obrigatórios, tipos, kinds inválidos, YAML duplicate-key. `-ignore-missing-schemas` pula CRDs sem schema (ServiceMonitor, IngressRoute, Certificate).

### scripts/validate-rfc1123.py
Script Python ~80 linhas que valida `containers[].name` e `initContainers[].name` em Deployment/StatefulSet/DaemonSet/Job/CronJob/Pod contra regex `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`.

`kubectl --dry-run=server` seria mais completo mas exige cluster real (Opção B do trade-off discutido). Este check estático cobre o caso mais comum (RFC 1123 em container names) sem cluster ephemeral.

## Fix bundled: Prometheus duplicate-key

`platform/observability/prometheus/values.yaml`:
- Antes: `commonLabels.app.kubernetes.io/part-of: uniplus` → YAML com chave duplicada com upstream
- Depois: `commonLabels.uniplus.io/managed: "true"` → label de domínio Uni+, sem colisão

## Validação local

Rodei a CI nova localmente contra todos os charts:

| Chart | kubeconform | RFC 1123 |
|---|---|---|
| apps/* (6 esqueletos) | OK (zero recursos) | OK |
| platform/storage | OK | OK |
| platform/traefik | OK | OK |
| platform/vault | OK | OK |
| platform/vault-transit | OK | OK |
| platform/observability/grafana | OK | OK |
| platform/observability/prometheus | OK *(após fix duplicate-key)* | OK |
| platform/cert-manager (main) | OK | **4 fails** *(arrumado por #106)* |
| platform/external-secrets (main) | OK | **1 fail** *(arrumado por #106)* |

Ou seja: kubeconform pega o duplicate-key (Prometheus); RFC 1123 pega o alias bug (ESO/cert-manager). Combinados cobrem os bugs encontrados.

## Dependência

CI só fica verde depois de PR #106 (alias removal). Sequência sugerida:
1. Merge #105 (AppSet path bug) — independente
2. Merge #106 (alias removal) — destrava CI desta PR
3. Rebase + merge esta PR

## Test plan

- [ ] CI passa após #106 merger
- [ ] Adicionar `kubectl apply --dry-run=server` (Opção B) fica para PR futuro se aparecerem bugs em CRD-specific webhooks (cert-manager validating webhook, vault injector). Por enquanto a Opção A+ cobre o que apareceu.