### PR TITLE
fix(vault/standalone): listener IPv4 + remover service_registration kubernetes

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -201,20 +201,30 @@ vault:
         setNodeId: true
         # Config Raft sem bloco `seal` — Vault usa Shamir por default.
         # `vault operator init -key-shares=5 -key-threshold=3` na inicialização.
+        #
+        # `service_registration "kubernetes"` REMOVIDO em standalone:
+        # K3s/flannel + service-account auth gera `nil response` no GET
+        # do Pod, e Vault BLOQUEIA a resposta HTTP de qualquer request
+        # síncrono enquanto retry-loop service_registration está ativo.
+        # Sintoma: `vault operator init` retorna `context deadline exceeded`
+        # após 60s mesmo com keys já geradas — keys perdidas. Service
+        # registration é nice-to-have (atualiza labels active/standby),
+        # não-essencial para single-replica standalone. Em prod 3-DC
+        # manter habilitado (Patroni-like leader election).
+        # Override para listener IPv4 explícito porque Vault CLI default
+        # usa http://127.0.0.1:8200 e [::]:8200 com bindv6only=1 não atende.
         config: |
           ui = true
 
           listener "tcp" {
             tls_disable     = 1
-            address         = "[::]:8200"
-            cluster_address = "[::]:8201"
+            address         = "0.0.0.0:8200"
+            cluster_address = "0.0.0.0:8201"
           }
 
           storage "raft" {
             path = "/vault/data"
           }
-
-          service_registration "kubernetes" {}
 
     dataStorage:
       size: 5Gi


### PR DESCRIPTION
## Sumário

Após pivotar pra Shamir seal (PR #108), `vault operator init` retornava `context deadline exceeded` consistentemente. Vault inicializava internamente mas a resposta HTTP com keys nunca chegava ao client — cada tentativa "perdia" 5 keys + root token, exigindo nuke do PVC.

Investigação no cluster identificou 2 causas combinadas.

## Causa 1: service_registration kubernetes bloqueando respostas

```
[WARN] service_registration.kubernetes: unable to set initial state due to
GET https://10.43.0.1:443/api/v1/namespaces/vault/pods/platform-vault-uniplus-standalone-0
giving up after 11 attempt(s): nil response
```

O handler de service_registration faz GET sincrono na K8s API e recebe `nil response` repetidamente (provavelmente conflito K3s/flannel + ServiceAccount JWT). Vault entra em retry-loop síncrono que bloqueia respostas HTTP de outros requests. Init succeed server-side mas client timeout após 60s.

Service registration apenas atualiza labels `vault-active`/`vault-standby` no Pod — nice-to-have para leader discovery em HA multi-réplica. Single-replica standalone não precisa. Lab/prod 3-DC mantêm habilitado.

## Causa 2: listener IPv6-only + Vault CLI IPv4 default

`address = "[::]:8200"` (dual-stack IPv6) com `net.ipv6.bindv6only=1` (default em K3s containers): IPv4 packets para `127.0.0.1:8200` não chegam no socket IPv6. Vault CLI default usa `VAULT_ADDR=http://127.0.0.1:8200`, então `vault status`/`vault operator init` falham com timeout silencioso.

Trocado para `0.0.0.0:8200` (IPv4 explicit).

## Validação

Após apply manual (com ArgoCD controller pausado pra impedir revert):

```
vault status → <1s response, Initialized=false, Sealed=true
vault operator init -key-shares=5 -key-threshold=3 → keys + root_token retornados
vault operator unseal × 3 → Sealed=false
vault auth enable kubernetes → success
vault write auth/kubernetes/role/external-secrets ... → success
```

5 unseal keys + 1 root token capturados e armazenados em gestor institucional (procedimento detalhado em RUNBOOKS.md §8.4 a ser atualizado em PR separado).

## Test plan

- [ ] CI verde
- [ ] Após merge, ArgoCD reconcilia, Pod reinicia
- [ ] Operador re-unsealea com 3 das 5 shares (procedimento manual standalone)
- [ ] ESO consegue autenticar via Vault Kubernetes auth role `external-secrets`
- [ ] Habilitar `clusterSecretStore.enabled: true` em PR separado destrava ESO end-to-end

## Issues relacionadas

Continuação do trabalho da PR #108. Destrava parte operacional do #64 (Vault unsealed + auth k8s). Auto-unseal via OCI KMS continua pendente até Vault 1.22+ (fora deste PR).