### PR TITLE
fix(standalone): incluir host CIDR no kubeApiCidrs de NetworkPolicies

### DIFF
--- a/environments/standalone/README.md
+++ b/environments/standalone/README.md
@@ -58,6 +58,36 @@ Para usar outro provider:
 
 Tudo o mais (Postgres single-primary, Keycloak sem Gov.br, observabilidade single-stack, `StorageClass: standalone-local-nvme`, ingress single-host) é universal.
 
+### Host CIDR no `kubeApiCidrs` (provider-/cluster-specific)
+
+`networkPolicy.kubeApiCidrs` em `values.yaml` inclui dois CIDRs:
+
+| CIDR | Significado | Portátil? |
+|---|---|---|
+| `10.43.0.0/16` | Service CIDR default do K3s | Sim |
+| `10.0.1.0/24` | Subnet OCI VCN da VM standalone de referência (Epic #40, sa-saopaulo-1) | **Não** — substituir por cluster |
+
+Por que dois CIDRs: K3s embedded kube-router avalia regras de egress NetworkPolicy *após* o DNAT do kube-proxy. Quando um Pod conecta `10.43.0.1:443` (Service IP do K8s API), kube-proxy reescreve o destino para `<node-ip>:6443` (em K3s o API server é processo no host, não Pod). Sem o CIDR do nó na lista, ESO controller, ESO cert-controller e cert-manager-cainjector ficam em CrashLoopBackOff com `dial tcp 10.43.0.1:443: connect: connection refused` no `init()` — webhook ESO não é afetado por não consumir K8s API no startup. PR #111 e issue #110 documentam o achado.
+
+Para registrar um cluster standalone em **outro** ambiente:
+
+1. Identificar o CIDR real do nó K8s no host:
+   ```bash
+   ip -4 addr show | awk '/inet 10\./ || /inet 172\./ || /inet 192\./ {print $2}'
+   ```
+2. Substituir `10.0.1.0/24` em `environments/standalone/values.yaml` pelo CIDR observado (geralmente `/24` da subnet, não o `/32` do nó — cobre re-provisionamento futuro).
+3. Em provisioning Tofu (quando aterrissar — Stories #75–#80), expor o CIDR como output da network e referenciar por convenção em vez de hardcode.
+
+Exemplos por provider de referência:
+
+| Provider | CIDR típico de subnet privada |
+|---|---|
+| OCI VCN default | `10.0.0.0/16` (subnet `10.0.1.0/24` deste cluster) |
+| AWS VPC default | `172.31.0.0/16` |
+| Azure VNet default | `10.0.0.0/16` |
+| GCP VPC default (auto mode) | `10.128.0.0/9` (uma sub-faixa por região) |
+| Bare-metal/lab corporativo | depende do range corporativo (consultar redes) |
+
 ## Como o ApplicationSet aplica
 
 `argocd/applicationset.yaml` é genérico via label `environment: <env>`. Para o ArgoCD reconciliar este overlay basta registrar o cluster com:

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -246,7 +246,7 @@ vaultTransit:
 #
 # `kubeApiCidrs` consumido pelos charts platform/external-secrets/ e
 # platform/cert-manager/ — egress permitido para o K8s API server. Inclui
-# o CIDR do host K8s (10.0.1.0/24) além do service CIDR (10.43.0.0/16):
+# o CIDR do host K8s além do service CIDR (10.43.0.0/16):
 # em K3s, o API server roda como processo no host (não como Pod K8s) e o
 # kube-proxy faz DNAT do Service IP 10.43.0.1:443 para <node-ip>:6443. O
 # kube-router (default NP enforcer do K3s) avalia a regra de egress
@@ -254,6 +254,16 @@ vaultTransit:
 # o pacote já reescrito para o IP do nó. Sem o CIDR do host, ESO controller,
 # ESO cert-controller e cert-manager-cainjector ficam em CrashLoopBackOff
 # com `dial tcp 10.43.0.1:443: connect: connection refused` no init().
+#
+# IMPORTANTE — host CIDR é provider-/cluster-specific:
+# O CIDR `10.0.1.0/24` abaixo corresponde à subnet OCI VCN do cluster
+# standalone de referência (Epic #40, VM em sa-saopaulo-1). Para QUALQUER
+# outro cluster standalone (outra VCN/subnet, outra região, outro provider
+# como AWS/Azure/bare-metal) o operator DEVE substituir esse CIDR pelo
+# range real do nó K8s antes de registrar o cluster no ArgoCD. Inspecionar
+# com `ip -4 addr` no host ou conferir o output Tofu da rede provisionada
+# (ver provisioning/<provider>/standalone/network.tf quando disponível).
+# Procedimento e exemplos por provider em environments/standalone/README.md.
 # Em prod 3-DC com IPs de control plane em ranges diferentes, override
 # por env reflete a rede real (ex.: 10.20.0.0/16 em prod-sp1).
 networkPolicy:
@@ -262,7 +272,7 @@ networkPolicy:
   traefikNamespace: traefik
   kubeApiCidrs:
     - 10.43.0.0/16
-    - 10.0.1.0/24
+    - 10.0.1.0/24  # ajustar por cluster — ver bloco acima
 
 # ----------------------------------------------------------------------------
 # External Secrets (chart platform/external-secrets/) — endpoint do Vault.

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -243,10 +243,26 @@ vaultTransit:
   enabled: false
 
 # NetworkPolicy do chart vault/ — sem egress Transit (vaultTransit.enabled=false).
+#
+# `kubeApiCidrs` consumido pelos charts platform/external-secrets/ e
+# platform/cert-manager/ — egress permitido para o K8s API server. Inclui
+# o CIDR do host K8s (10.0.1.0/24) além do service CIDR (10.43.0.0/16):
+# em K3s, o API server roda como processo no host (não como Pod K8s) e o
+# kube-proxy faz DNAT do Service IP 10.43.0.1:443 para <node-ip>:6443. O
+# kube-router (default NP enforcer do K3s) avalia a regra de egress
+# *após* o DNAT, então o ipBlock 10.43.0.0/16 sozinho não basta — bloqueia
+# o pacote já reescrito para o IP do nó. Sem o CIDR do host, ESO controller,
+# ESO cert-controller e cert-manager-cainjector ficam em CrashLoopBackOff
+# com `dial tcp 10.43.0.1:443: connect: connection refused` no init().
+# Em prod 3-DC com IPs de control plane em ranges diferentes, override
+# por env reflete a rede real (ex.: 10.20.0.0/16 em prod-sp1).
 networkPolicy:
   enabled: true
   externalSecretsNamespace: external-secrets
   traefikNamespace: traefik
+  kubeApiCidrs:
+    - 10.43.0.0/16
+    - 10.0.1.0/24
 
 # ----------------------------------------------------------------------------
 # External Secrets (chart platform/external-secrets/) — endpoint do Vault.


### PR DESCRIPTION
## Resumo

Fix do bloqueador `connection refused` em ESO controller, ESO cert-controller e cert-manager-cainjector no cluster standalone OCI.

## Problema

3 pods em CrashLoopBackOff persistente com:
```
dial tcp 10.43.0.1:443: connect: connection refused
```

mesmo com NetworkPolicy egress permitindo `ipBlock: 10.43.0.0/16` (service CIDR onde está o Service IP do K8s API).

## Causa raiz

Em K3s, o kube-router (default NP enforcer) avalia regras egress **após o DNAT** do kube-proxy:

1. Pod tenta conectar `10.43.0.1:443` (Service IP do API server)
2. kube-proxy faz DNAT para `<node-ip>:6443` (em K3s o API server roda como processo no host, não Pod)
3. kube-router avalia o IP **pós-DNAT** (`10.0.1.61`) contra `10.43.0.0/16` → não match → drop

Webhook ESO não era afetado porque não consome K8s API no `init()`.

## Fix

Adicionar override em `environments/standalone/values.yaml` incluindo o CIDR da subnet OCI da VM (`10.0.1.0/24`):

```yaml
networkPolicy:
  kubeApiCidrs:
    - 10.43.0.0/16
    - 10.0.1.0/24
```

Charts `platform/external-secrets/` e `platform/cert-manager/` consomem o mesmo path top-level → uma fix cobre ambos.

## Validação

Aplicado direto no cluster (`kubectl patch`). Após reconcile do kube-router (~60s):

```
NAME                                                              READY   STATUS    RESTARTS   AGE
platform-external-secrets-uniplus-standalone-97947ff4c-fcwjv      1/1     Running   0          45s
platform-external-secrets-uniplus-standalone-cert-controlln2g65   1/1     Running   1          45s
platform-external-secrets-uniplus-standalone-webhook-77dcf5b5rf   1/1     Running   0          5m
platform-cert-manager-uniplus-standalone-554d8df7c9-hjwzc         1/1     Running   0          3h57m
platform-cert-manager-uniplus-standalone-cainjector-6d6884kzlsf   1/1     Running   1          3m
platform-cert-manager-uniplus-standalone-webhook-f4957569cz2fkj   1/1     Running   0          3h57m
```

6/6 pods Running 1/1.

## Impacto em outros ambientes

Nenhum. Default dos charts wrapper continua `["10.43.0.0/16"]`. Lab e prod 3-DC adicionarão seus próprios overrides quando aterrissarem (ranges reais de control plane podem variar).

## Test plan

- [x] Lint: `yamllint -c .yamllint.yaml environments/standalone/values.yaml` clean
- [x] Template: `helm template platform/{external-secrets,cert-manager}/ -f environments/standalone/values.yaml` renderiza ambos ipBlocks
- [x] Cluster: 6 pods Running 1/1 após reconcile

Closes #110. Sub-issue de #40.