### PR TITLE
feat(standalone): habilitar ClusterSecretStore vault-default

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -283,7 +283,7 @@ networkPolicy:
 # provisionamento da policy + role no Vault.
 # ----------------------------------------------------------------------------
 clusterSecretStore:
-  enabled: false  # ligar quando #64 fechar
+  enabled: true
   vaultServer: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Resumo

Destrava o gate `clusterSecretStore.enabled: false → true` em `environments/standalone/values.yaml`. Depois deste merge, ExternalSecret consumers (Keycloak admin password, Postgres connection strings, MinIO access keys etc.) passam a ter backend para sintetizar Secrets a partir do Vault local.

## Pré-requisitos atendidos

- ✅ Vault initialized + unsealed (Shamir 5/3 manual — keys em gestor institucional)
- ✅ Kubernetes auth method habilitado em `auth/kubernetes/`
- ✅ Policy `external-secrets-read` (capabilities `read` em `secret/data/*` + `secret/metadata/*`)
- ✅ Role `external-secrets` vinculado a SA `external-secrets/external-secrets` com policy `external-secrets-read`
- ✅ ESO controller + cert-controller + webhook Running 1/1 (PR #111 NP fix)

## Mudança

```diff
 clusterSecretStore:
-  enabled: false  # ligar quando #64 fechar
+  enabled: true
   vaultServer: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
```

Resto do bloco (`vaultServer`, `vaultPath: secret`, `vaultAuth.role: external-secrets`, `vaultAuth.serviceAccount.{name,namespace}`) já estava correto desde o overlay original — só faltava destravar o gate.

## Validação esperada após merge

1. `kubectl get clustersecretstore vault-default` → `STATUS Valid READY True`
2. ExternalSecret de teste (PR separado) → Secret sintetizado em namespace consumer

## Test plan

- [x] Lint: `yamllint -c .yamllint.yaml environments/standalone/values.yaml` clean
- [x] Template: `helm template platform/external-secrets/ -f environments/standalone/values.yaml` renderiza ClusterSecretStore com role `external-secrets` + serviceAccountRef correto
- [ ] Pós-merge: ArgoCD sync + verificar status do CSS no cluster (validação manual)

Closes #112. Fecha o último item da Fase 1.3 do plano (caminho crítico do Vault).