### PR TITLE
feat(standalone): habilitar ClusterIssuers Let's Encrypt (staging + prod)

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -287,6 +287,16 @@ clusterSecretStore:
   vaultServer: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
 
 # ----------------------------------------------------------------------------
+# cert-manager ClusterIssuers — HTTP-01 via Traefik (chart platform/traefik/).
+# Standalone tem IP público + DNS A `standalone.portaluni.com.br → 164.152.53.29`
+# resolvendo. HTTP-01 é mais simples que DNS-01 (não precisa de credencial OCI
+# DNS / registrar). Defaults do chart (staging + production both enabled,
+# email `ctic@unifesspa.edu.br`, servers oficiais Let's Encrypt) são adequados.
+# ----------------------------------------------------------------------------
+clusterIssuers:
+  enabled: true
+
+# ----------------------------------------------------------------------------
 # Traefik (chart platform/traefik/) — exposição externa em standalone.
 # Single-host com IP público bindando hostPort 80/443 direto na VM,
 # evitando dependência de NodePort range > 30000 e LoadBalancer (provider


### PR DESCRIPTION
## Resumo

Destrava o gate top-level `clusterIssuers.enabled: false → true` em `environments/standalone/values.yaml`. Após merge, o chart `platform/cert-manager/` renderiza os 2 ClusterIssuers (`letsencrypt-staging`, `letsencrypt-prod`), e IngressRoutes anotadas com `cert-manager.io/cluster-issuer: letsencrypt-prod` passam a emitir certificado Let's Encrypt válido via challenge HTTP-01 atendido pelo Traefik.

## Pré-requisitos atendidos

- ✅ DNS A `standalone.portaluni.com.br → 164.152.53.29` propagado (`dig +short` confirmado)
- ✅ cert-manager Running 1/1 (controller + webhook + cainjector — após PR #111 NP fix)
- ✅ Traefik Running com hostPort 80/443 + IngressClass `traefik` registrada (`curl http://standalone.portaluni.com.br/` retorna 308 redirect HTTPS)
- ✅ Defaults do chart já corretos: email `ctic@unifesspa.edu.br`, servers oficiais Let's Encrypt, staging + production both enabled

## Mudança

```diff
+# cert-manager ClusterIssuers — HTTP-01 via Traefik
+clusterIssuers:
+  enabled: true
```

HTTP-01 (não DNS-01) porque standalone tem IP público + DNS controlado, sem necessidade de credencial OCI DNS / registrar.

## Validação esperada após merge

1. `kubectl get clusterissuer` → 2 issuers READY True
2. IngressRoute de teste anotada → Certificate resource criado → Secret `tls` populado em <60s

## Test plan

- [x] Lint: `yamllint -c .yamllint.yaml environments/standalone/values.yaml` clean
- [x] Template: `helm template platform/cert-manager/ -f environments/standalone/values.yaml` renderiza ambos `kind: ClusterIssuer`
- [ ] Pós-merge: emitir cert de teste em IngressRoute (validação manual)

Closes #114. Fecha Fase 2.3 do plano (validação cert Let's Encrypt).