### PR TITLE
docs(runbooks): §8.4 — procedimento Shamir manual + ESO setup pós-unseal

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -916,56 +916,68 @@ sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
 
 Executar **uma vez** após o init, com o root token recém-emitido. Após esse setup, External Secrets passa a autenticar no Vault via ServiceAccount JWT — sem precisar de root token nas Apps.
 
+> **Nota de higiene de credenciais.** Os blocos abaixo evitam expandir o root token em argv de comandos (`kubectl exec ... sh -c "...$TOKEN..."` colocaria o token em `/proc/<pid>/cmdline`, visível em `ps`/auditoria). Em vez disso, abrimos um port-forward local e exportamos `VAULT_TOKEN` apenas no shell do operador — o token fica na memória do shell + processo `vault`, sem cruzar argv de outros processos.
+
 ```bash
-# Ler root token interativamente (sem echo, sem history) — mesmo
-# raciocínio das unseal keys.
-read -rsp "Root token: " ROOT; echo
-
+# 1) Port-forward local do Vault (background; trap para cleanup)
 sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
-  -n vault exec platform-vault-uniplus-standalone-0 -- sh -c "
-export VAULT_TOKEN=$ROOT
+  -n vault port-forward platform-vault-uniplus-standalone-0 8200:8200 \
+  > /tmp/vault-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null; unset VAULT_TOKEN VAULT_ADDR' EXIT
 
-# 1) Habilitar Kubernetes auth method
+# 2) Apontar a CLI vault para o port-forward
+export VAULT_ADDR=http://127.0.0.1:8200
+
+# Aguardar port-forward subir
+until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
+
+# 3) Ler root token interativamente (sem echo, sem history)
+read -rsp "Root token: " VAULT_TOKEN; echo
+export VAULT_TOKEN
+
+# 4) Habilitar Kubernetes auth method
 vault auth enable kubernetes
 
-# 2) Apontar para o API server local (token reviewer usa SA do próprio Pod)
+# 5) Apontar para o API server interno (token reviewer usa SA do próprio Pod)
 vault write auth/kubernetes/config \
   kubernetes_host=https://kubernetes.default.svc.cluster.local
 
-# 3) Policy de leitura no KV v2 (path 'secret/')
-vault policy write external-secrets-read - <<POLICY
-path \"secret/data/*\" { capabilities = [\"read\"] }
-path \"secret/metadata/*\" { capabilities = [\"read\"] }
+# 6) Policy de leitura no KV v2 (path `secret/`)
+vault policy write external-secrets-read - <<'POLICY'
+path "secret/data/*" { capabilities = ["read"] }
+path "secret/metadata/*" { capabilities = ["read"] }
 POLICY
 
-# 4) Role vinculando ServiceAccount external-secrets/external-secrets à policy
+# 7) Role vinculando ServiceAccount external-secrets/external-secrets à policy
 vault write auth/kubernetes/role/external-secrets \
   bound_service_account_names=external-secrets \
   bound_service_account_namespaces=external-secrets \
   policies=external-secrets-read \
   ttl=24h
 
-# 5) Habilitar KV v2 em 'secret/' (não vem montado por default em HA Raft)
+# 8) Habilitar KV v2 em `secret/` (não vem montado por default em HA Raft)
 vault secrets enable -path=secret -version=2 kv
-"
+
+# trap EXIT cuida do unset + kill — sair do shell encerra a sessão
 ```
 
 #### 8.4.4 Validação end-to-end (ClusterSecretStore + ExternalSecret)
+
+> Mesmo padrão de higiene da §8.4.3: port-forward + `VAULT_TOKEN` em env do shell local. O `trap EXIT` definido na §8.4.3 já cuida do cleanup; se você abriu uma nova sessão para esta validação, refazer os passos 1-3 da §8.4.3 antes.
 
 ```bash
 # 1) Confirmar ClusterSecretStore Valid + Ready:
 sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get clustersecretstore vault-default
 # Esperado: STATUS=Valid, READY=True
 
-# 2) PUT secret de teste no Vault:
-sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
-  -n vault exec platform-vault-uniplus-standalone-0 -- sh -c "
-export VAULT_TOKEN=$ROOT
-vault kv put secret/test/eso-validation message=hello timestamp=\$(date -u +%FT%TZ)
-"
+# 2) PUT secret de teste no Vault (token vem do env, não do argv):
+vault kv put secret/test/eso-validation \
+  message=hello \
+  timestamp="$(date -u +%FT%TZ)"
 
 # 3) Criar ExternalSecret consumer (default ns, refresh 1m):
-cat <<EOF | sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml apply -f -
+cat <<'EOF' | sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml apply -f -
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -992,13 +1004,9 @@ sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
 # 5) Cleanup:
 sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
   -n default delete externalsecret eso-validation
-sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
-  -n vault exec platform-vault-uniplus-standalone-0 -- sh -c "
-export VAULT_TOKEN=$ROOT
 vault kv metadata delete secret/test/eso-validation
-"
-unset ROOT
-history -c 2>/dev/null || true
+# Sair do shell (ou explicitamente):
+exit  # dispara o trap EXIT da §8.4.3 → kill port-forward + unset VAULT_TOKEN VAULT_ADDR
 ```
 
 #### 8.4.5 Migração futura para OCI KMS auto-unseal

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -853,25 +853,148 @@ argocd cluster add default --name uniplus-standalone --in-cluster
 
 Após o registro, o ApplicationSet em `argocd/applicationset.yaml` detecta o cluster pelo label e inicia a sincronização.
 
-### 8.4 Init e verificação do Vault (OCI KMS auto-unseal)
+### 8.4 Init, unseal e configuração do Vault (Shamir manual)
 
-> Procedimento detalhado a ser documentado em #87. Resumo:
+> **Decisão arquitetural temporária (2026-05-05):** standalone usa **Shamir seal com unseal manual** em vez de OCI KMS auto-unseal. OCI KMS provisionado e pronto, mas Vault 1.20.x/1.21.x panicam consistentemente em `go-kms-wrapping@v2.0.9/ocikms.go:290` na pre-flight encrypt validation (Resource Principal *e* API Key falham; OCI CLI direto funciona — bug é no Vault, não na infra). Migração para `seal "ocikms"` quando Vault 1.22+ chegar com go-kms-wrapping atualizado. Detalhes do bloco `seal` provisional em `environments/standalone/values.yaml` (comentário no chart vault).
 
-O Vault standalone usa **OCI Vault KMS** para auto-unseal (diferente do lab, que usa Transit em PA1). O pod sobe selado e desvela automaticamente ao encontrar o KMS configurado.
+#### 8.4.1 Init na primeira vez
 
 ```bash
-# Verificar estado do Vault
-kubectl exec -n vault vault-0 -- vault status
+# 1) Verificar que o Vault está running mas não inicializado:
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault exec platform-vault-uniplus-standalone-0 -- vault status
+# Esperado: Initialized=false, Sealed=true
 
-# Se Initialized=false, inicializar:
-kubectl exec -n vault vault-0 -- vault operator init \
-    -recovery-shares=5 -recovery-threshold=3
-# Guardar recovery keys conforme procedimento institucional (Apêndice A)
+# 2) Inicializar com Shamir 5/3 (5 shares, threshold 3):
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault exec platform-vault-uniplus-standalone-0 -- \
+  vault operator init -format=json -key-shares=5 -key-threshold=3 \
+  > /tmp/vault-init.json
+chmod 600 /tmp/vault-init.json
+```
 
-# Validar auto-unseal ativo (Sealed=false sem intervenção manual):
-kubectl exec -n vault vault-0 -- vault status | grep Sealed
+> ⚠️ **CRÍTICO — guarda das keys.** O comando acima imprime as 5 unseal keys e o root token **uma única vez**. Custodiar imediatamente em gestor institucional (Bitwarden, 1Password ou Vault corporativo separado). Após exportar, **deletar com `shred -u /tmp/vault-init.json`** — não deixar em disco do host.
+>
+> Em caso de perda das 3 das 5 keys (threshold), o Vault fica selado permanentemente. Em standalone isso é recuperável re-bootstrappeando (perde os secrets do Vault — aceitável porque o overlay é descartável). Em prod 3-DC seria catastrófico — por isso prod usa Transit auto-unseal, não Shamir.
+
+#### 8.4.2 Unseal manual (após cada Pod restart)
+
+Cada vez que o Pod do Vault reinicia (upgrade K3s, manutenção da VM, OOMKill etc.) o Vault sobe `Sealed=true` e exige 3 das 5 unseal keys para destravar. **Não é one-shot — é um procedimento operacional recorrente em standalone.**
+
+```bash
+# 1) Recuperar 3 das 5 keys do gestor institucional. Atribuir a variáveis:
+K1="<unseal_key_1_b64>"
+K2="<unseal_key_2_b64>"
+K3="<unseal_key_3_b64>"
+
+# 2) Unseal sequencial (cada chamada destrava 1 share; após threshold, Sealed=false):
+for K in "$K1" "$K2" "$K3"; do
+  sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+    -n vault exec platform-vault-uniplus-standalone-0 -- \
+    vault operator unseal "$K"
+done
+
+# 3) Confirmar:
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault exec platform-vault-uniplus-standalone-0 -- vault status | grep Sealed
 # Esperado: Sealed          false
 ```
+
+#### 8.4.3 Configuração inicial pós-unseal (Kubernetes auth + ESO role)
+
+Executar **uma vez** após o init, com o root token recém-emitido. Após esse setup, External Secrets passa a autenticar no Vault via ServiceAccount JWT — sem precisar de root token nas Apps.
+
+```bash
+ROOT="<root_token>"
+
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault exec platform-vault-uniplus-standalone-0 -- sh -c "
+export VAULT_TOKEN=$ROOT
+
+# 1) Habilitar Kubernetes auth method
+vault auth enable kubernetes
+
+# 2) Apontar para o API server local (token reviewer usa SA do próprio Pod)
+vault write auth/kubernetes/config \
+  kubernetes_host=https://kubernetes.default.svc.cluster.local
+
+# 3) Policy de leitura no KV v2 (path 'secret/')
+vault policy write external-secrets-read - <<POLICY
+path \"secret/data/*\" { capabilities = [\"read\"] }
+path \"secret/metadata/*\" { capabilities = [\"read\"] }
+POLICY
+
+# 4) Role vinculando ServiceAccount external-secrets/external-secrets à policy
+vault write auth/kubernetes/role/external-secrets \
+  bound_service_account_names=external-secrets \
+  bound_service_account_namespaces=external-secrets \
+  policies=external-secrets-read \
+  ttl=24h
+
+# 5) Habilitar KV v2 em 'secret/' (não vem montado por default em HA Raft)
+vault secrets enable -path=secret -version=2 kv
+"
+```
+
+#### 8.4.4 Validação end-to-end (ClusterSecretStore + ExternalSecret)
+
+```bash
+# 1) Confirmar ClusterSecretStore Valid + Ready:
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get clustersecretstore vault-default
+# Esperado: STATUS=Valid, READY=True
+
+# 2) PUT secret de teste no Vault:
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault exec platform-vault-uniplus-standalone-0 -- sh -c "
+export VAULT_TOKEN=$ROOT
+vault kv put secret/test/eso-validation message=hello timestamp=\$(date -u +%FT%TZ)
+"
+
+# 3) Criar ExternalSecret consumer (default ns, refresh 1m):
+cat <<EOF | sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml apply -f -
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: eso-validation
+  namespace: default
+spec:
+  refreshInterval: 1m
+  secretStoreRef: { name: vault-default, kind: ClusterSecretStore }
+  target: { name: eso-validation, creationPolicy: Owner }
+  data:
+    - secretKey: message
+      remoteRef: { key: test/eso-validation, property: message }
+EOF
+
+# 4) Conferir Secret sintetizado em ~10-30s:
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n default get externalsecret eso-validation
+# Esperado: STATUS=SecretSynced, READY=True
+
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n default get secret eso-validation -o jsonpath='{.data.message}' | base64 -d
+# Esperado: hello
+
+# 5) Cleanup:
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n default delete externalsecret eso-validation
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault exec platform-vault-uniplus-standalone-0 -- sh -c "
+export VAULT_TOKEN=$ROOT
+vault kv metadata delete secret/test/eso-validation
+"
+```
+
+#### 8.4.5 Migração futura para OCI KMS auto-unseal
+
+Quando Vault 1.22+ aterrissar (go-kms-wrapping atualizado), a migração elimina o procedimento manual de unseal:
+
+1. Adicionar bloco `seal "ocikms"` em `vault.server.ha.raft.config` (override standalone), apontando para o OCI Vault + Master Key já provisionados (OCIDs em `environments/standalone/values.yaml` — comentário do chart vault).
+2. Provisionar Secret `vault-ocikms-config` via ESO/Vault (será emitido pelo próprio Vault standalone via `secret/data/standalone/ocikms`).
+3. `vault operator migrate` para converter Shamir → OCI KMS.
+4. Restart do StatefulSet — Pod sobe com `Sealed=false` automaticamente.
+
+Validar antes em ambiente de teste com `letsencrypt-staging` cert do Vault (qualquer regressão fica rasteada). Não migrar em prod sem validação no lab.
 
 ### 8.5 Validação completa do ambiente
 

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -886,30 +886,40 @@ echo "Init output em $INIT_FILE — exportar para gestor institucional e shred."
 
 Cada vez que o Pod do Vault reinicia (upgrade K3s, manutenção da VM, OOMKill etc.) o Vault sobe `Sealed=true` e exige 3 das 5 unseal keys para destravar. **Não é one-shot — é um procedimento operacional recorrente em standalone.**
 
+> **Pré-requisito**: HashiCorp `vault` CLI instalada na workstation do operador (`brew install vault` / pacote oficial). Os blocos abaixo evitam expandir as unseal keys em argv de `kubectl exec` (que vazaria via `/proc/<pid>/cmdline`, `ps`, auditoria) — em vez disso, conectamos `vault` CLI local ao Vault via port-forward e passamos cada share por **stdin** (`vault operator unseal -`).
+
 ```bash
-# 1) Recuperar 3 das 5 keys do gestor institucional e ler interativamente
-#    com `read -rs` — o flag `-s` desabilita echo (chave não aparece no
-#    terminal) e a entrada NÃO vai para ~/.bash_history (vs colar
-#    literalmente em `K1="..."`, que persiste no histórico do shell).
+# 1) Port-forward local do Vault + apontar a CLI (mesmo pattern de §8.4.3)
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault port-forward platform-vault-uniplus-standalone-0 8200:8200 \
+  > /tmp/vault-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null; unset K1 K2 K3 VAULT_ADDR' EXIT
+export VAULT_ADDR=http://127.0.0.1:8200
+
+# Aguardar port-forward subir
+until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
+
+# 2) Ler 3 das 5 keys do gestor institucional (sem echo, sem history).
+#    Cada `read -rs` desabilita o eco (chave não aparece no terminal) e
+#    NÃO vai para ~/.bash_history.
 read -rsp "Unseal Key 1: " K1; echo
 read -rsp "Unseal Key 2: " K2; echo
 read -rsp "Unseal Key 3: " K3; echo
 
-# 2) Unseal sequencial (cada chamada destrava 1 share; após threshold, Sealed=false).
-#    `unset` + `history -c` ao final garantem que as variáveis e qualquer
-#    eco residual saiam da sessão antes do logout.
+# 3) Unseal via stdin do `vault operator unseal -` — chave NÃO entra em argv,
+#    invisível em /proc/<pid>/cmdline. Após 3 shares válidas, Sealed=false.
 for K in "$K1" "$K2" "$K3"; do
-  sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
-    -n vault exec platform-vault-uniplus-standalone-0 -- \
-    vault operator unseal "$K"
+  printf '%s\n' "$K" | vault operator unseal -
 done
 unset K K1 K2 K3
 history -c 2>/dev/null || true
 
-# 3) Confirmar:
-sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
-  -n vault exec platform-vault-uniplus-standalone-0 -- vault status | grep Sealed
+# 4) Confirmar:
+vault status | grep Sealed
 # Esperado: Sealed          false
+
+# trap EXIT ao sair do shell encerra port-forward + cleanup das envs
 ```
 
 #### 8.4.3 Configuração inicial pós-unseal (Kubernetes auth + ESO role)

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -865,15 +865,20 @@ sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
   -n vault exec platform-vault-uniplus-standalone-0 -- vault status
 # Esperado: Initialized=false, Sealed=true
 
-# 2) Inicializar com Shamir 5/3 (5 shares, threshold 3):
+# 2) Inicializar com Shamir 5/3 (5 shares, threshold 3).
+#    Criar o arquivo destino COM mode 0600 ANTES do redirect — evita
+#    janela de exposição em que o init output (com 5 unseal keys + root
+#    token) ficaria legível por outros usuários do host até o chmod rodar.
+INIT_FILE=$(mktemp -t vault-init.XXXXXX.json)
+chmod 600 "$INIT_FILE"
 sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
   -n vault exec platform-vault-uniplus-standalone-0 -- \
   vault operator init -format=json -key-shares=5 -key-threshold=3 \
-  > /tmp/vault-init.json
-chmod 600 /tmp/vault-init.json
+  > "$INIT_FILE"
+echo "Init output em $INIT_FILE — exportar para gestor institucional e shred."
 ```
 
-> ⚠️ **CRÍTICO — guarda das keys.** O comando acima imprime as 5 unseal keys e o root token **uma única vez**. Custodiar imediatamente em gestor institucional (Bitwarden, 1Password ou Vault corporativo separado). Após exportar, **deletar com `shred -u /tmp/vault-init.json`** — não deixar em disco do host.
+> ⚠️ **CRÍTICO — guarda das keys.** O comando acima imprime as 5 unseal keys e o root token **uma única vez**. Custodiar imediatamente em gestor institucional (Bitwarden, 1Password ou Vault corporativo separado). Após exportar, **deletar com `shred -u "$INIT_FILE"`** — não deixar em disco do host.
 >
 > Em caso de perda das 3 das 5 keys (threshold), o Vault fica selado permanentemente. Em standalone isso é recuperável re-bootstrappeando (perde os secrets do Vault — aceitável porque o overlay é descartável). Em prod 3-DC seria catastrófico — por isso prod usa Transit auto-unseal, não Shamir.
 
@@ -882,17 +887,24 @@ chmod 600 /tmp/vault-init.json
 Cada vez que o Pod do Vault reinicia (upgrade K3s, manutenção da VM, OOMKill etc.) o Vault sobe `Sealed=true` e exige 3 das 5 unseal keys para destravar. **Não é one-shot — é um procedimento operacional recorrente em standalone.**
 
 ```bash
-# 1) Recuperar 3 das 5 keys do gestor institucional. Atribuir a variáveis:
-K1="<unseal_key_1_b64>"
-K2="<unseal_key_2_b64>"
-K3="<unseal_key_3_b64>"
+# 1) Recuperar 3 das 5 keys do gestor institucional e ler interativamente
+#    com `read -rs` — o flag `-s` desabilita echo (chave não aparece no
+#    terminal) e a entrada NÃO vai para ~/.bash_history (vs colar
+#    literalmente em `K1="..."`, que persiste no histórico do shell).
+read -rsp "Unseal Key 1: " K1; echo
+read -rsp "Unseal Key 2: " K2; echo
+read -rsp "Unseal Key 3: " K3; echo
 
-# 2) Unseal sequencial (cada chamada destrava 1 share; após threshold, Sealed=false):
+# 2) Unseal sequencial (cada chamada destrava 1 share; após threshold, Sealed=false).
+#    `unset` + `history -c` ao final garantem que as variáveis e qualquer
+#    eco residual saiam da sessão antes do logout.
 for K in "$K1" "$K2" "$K3"; do
   sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
     -n vault exec platform-vault-uniplus-standalone-0 -- \
     vault operator unseal "$K"
 done
+unset K K1 K2 K3
+history -c 2>/dev/null || true
 
 # 3) Confirmar:
 sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
@@ -905,7 +917,9 @@ sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
 Executar **uma vez** após o init, com o root token recém-emitido. Após esse setup, External Secrets passa a autenticar no Vault via ServiceAccount JWT — sem precisar de root token nas Apps.
 
 ```bash
-ROOT="<root_token>"
+# Ler root token interativamente (sem echo, sem history) — mesmo
+# raciocínio das unseal keys.
+read -rsp "Root token: " ROOT; echo
 
 sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
   -n vault exec platform-vault-uniplus-standalone-0 -- sh -c "
@@ -983,6 +997,8 @@ sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
 export VAULT_TOKEN=$ROOT
 vault kv metadata delete secret/test/eso-validation
 "
+unset ROOT
+history -c 2>/dev/null || true
 ```
 
 #### 8.4.5 Migração futura para OCI KMS auto-unseal


### PR DESCRIPTION
## Resumo

Substitui o placeholder esquemático da §8.4 (que descrevia OCI KMS auto-unseal) pelo procedimento real Shamir manual em standalone — refletindo a decisão temporária de 2026-05-05.

## Por que Shamir e não OCI KMS

OCI KMS provisionado e pronto, mas Vault 1.20.x/1.21.x panicam consistentemente em `go-kms-wrapping@v2.0.9/ocikms.go:290` na pre-flight encrypt validation. Testado:
- Resource Principal (Dynamic Group): panic
- API Key (User credential): panic
- OCI CLI direto contra mesmo KMS: ✅ funciona

Bug é no Vault, não na infra OCI. Migração para `seal "ocikms"` quando Vault 1.22+ chegar com go-kms-wrapping atualizado. Detalhes do bloco `seal` provisional documentados em `environments/standalone/values.yaml` (comentário no chart vault).

## Estrutura da §8.4 nova

| Sub-seção | Conteúdo |
|---|---|
| 8.4.1 Init na primeira vez | `vault operator init -key-shares=5 -key-threshold=3` + aviso de custódia institucional das 5 keys |
| 8.4.2 Unseal manual após Pod restart | Procedimento operacional recorrente em standalone (cada upgrade K3s, manutenção VM, OOMKill exige 3 das 5 keys) |
| 8.4.3 Configuração pós-unseal | Kubernetes auth method + policy `external-secrets-read` + role `external-secrets` + KV v2 em `secret/` (não vem montado em HA Raft) |
| 8.4.4 Validação end-to-end | ClusterSecretStore Valid + ExternalSecret consumer + Secret sintetizado (com cleanup) |
| 8.4.5 Migração futura para OCI KMS | `vault operator migrate` quando Vault 1.22+ chegar |

## Test plan

- [x] Procedimento foi de fato executado no cluster standalone OCI nesta sessão (2026-05-05); todos os comandos transcritos refletem o que rodou
- [x] Validação end-to-end funcionou (`SecretSynced=True 11s`, base64 decoded confere)
- [ ] Markdownlint cuida via CI

Closes #116. Parcial em #87 — lab/prod 3-DC continuam com Transit auto-unseal (não afetado pelo bug). Sub-issue de #40. Fecha Fase 1.4 do plano.