### PR TITLE
fix(standalone): desligar redirect global HTTP→HTTPS no Traefik (ACME HTTP-01)

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -309,6 +309,18 @@ traefik:
   ports:
     web:
       hostPort: 80
+      # Desligar redirect global HTTP→HTTPS no entryPoint `web` em standalone.
+      # O default do chart wrapper redireciona toda request HTTP, o que quebra
+      # o ACME HTTP-01 challenge (Let's Encrypt requer GET HTTP em
+      # `/.well-known/acme-challenge/*` SEM redirect — antes do cert existir
+      # não há HTTPS válido para servir). Em standalone, IngressRoutes
+      # individuais aplicam Middleware redirect-https quando precisarem
+      # (apps reais quando aterrissarem; Vault UI já é exposto só em
+      # `websecure`). Em prod 3-DC, redirect global é mantido (LE via
+      # DNS-01 com cert-manager-webhook OCI/AWS/Azure quando aterrissar,
+      # ou cert manual — sem dependência de HTTP-01).
+      http:
+        redirections: null
     websecure:
       hostPort: 443
 


### PR DESCRIPTION
## Resumo

Override em `environments/standalone/values.yaml` removendo `traefik.ports.web.http.redirections`. Destrava o ACME HTTP-01 challenge bloqueado por redirect global do Traefik.

## Problema observado

Após habilitar ClusterIssuers Let's Encrypt (PR #115), tentativa de emitir Certificate falhou:

```
$ curl -sI http://standalone.portaluni.com.br/.well-known/acme-challenge/dummy
HTTP/1.1 308 Permanent Redirect
Location: https://standalone.portaluni.com.br/.well-known/acme-challenge/dummy
```

Let's Encrypt staging GET no challenge URL recebe 308 → ACME validação inválida → `order pending` indefinidamente. Sem cert válido em HTTPS, Traefik não pode terminar TLS (chicken-and-egg).

## Causa raiz

Chart wrapper `platform/traefik/values.yaml` configura redirect global no entryPoint `web`:

```yaml
ports:
  web:
    http:
      redirections:
        entryPoint: { to: websecure, scheme: https, permanent: true }
```

EntryPoint redirections aplicam **antes** de qualquer IngressRoute matching — não há como excluir path via priority.

## Fix

```diff
 traefik:
   ports:
     web:
       hostPort: 80
+      http:
+        redirections: null
```

Tradeoffs:

| Cluster | Comportamento HTTP | Comportamento HTTPS |
|---|---|---|
| **standalone** (este PR) | Sem redirect automático — apps respondem em HTTP se IngressRoute mapear `web` | IngressRoutes individuais aplicam Middleware redirect-https quando precisarem |
| **prod 3-DC** | Redirect global mantido (default do chart) | DNS-01 evita HTTP-01, sem necessidade de exception |

Vault UI já é exposto só em `websecure`. Apps reais (web/api) ainda não aterrissaram — quando aterrissarem, IngressRoute específica adiciona Middleware redirect-https e o efeito é equivalente ao default do chart.

## Validação esperada após merge

1. `curl -sI http://standalone.portaluni.com.br/.well-known/acme-challenge/dummy` → 404 (não 308)
2. Re-emitir Certificate teste → `Order valid` → `Certificate Ready=True` em <60s
3. `curl -k -sI https://standalone.portaluni.com.br/whoami` → 200 com cert staging Fake-LE-Intermediate

## Test plan

- [x] Lint: `yamllint -c .yamllint.yaml environments/standalone/values.yaml` clean
- [x] Template: `helm template platform/traefik/ -f environments/standalone/values.yaml` confirma ausência de `--entryPoints.web.http.redirections.*` na args do Deployment
- [ ] Pós-merge: emitir Certificate de teste contra `letsencrypt-staging`

Closes #119. Fecha caminho de Fase 2.3 do plano.