### PR TITLE
fix(traefik): NetworkPolicy egress permitir ACME solver pods em qualquer namespace

### DIFF
--- a/platform/traefik/templates/networkpolicy.yaml
+++ b/platform/traefik/templates/networkpolicy.yaml
@@ -47,12 +47,19 @@ spec:
               kubernetes.io/metadata.name: {{ . | quote }}
         {{- end }}
     {{- end }}
-    # cert-manager solver Pods (HTTP-01 challenge) — namespace cert-manager
-    # pode hospedar challenge solver pods com label específico.
+    # cert-manager solver Pods (HTTP-01 challenge) nascem no MESMO namespace
+    # da Certificate resource — não no namespace `cert-manager` (que hospeda
+    # apenas o controller). Para Certificates em namespaces de apps (uniplus,
+    # keycloak, etc.) o solver pod nasce ali. Permitir egress para qualquer
+    # Pod com o label `acme.cert-manager.io/http01-solver=true`, em qualquer
+    # namespace, é o pattern correto. Sem isso, Traefik dá `502 Bad Gateway`
+    # em `/.well-known/acme-challenge/*` para Certificates fora de namespaces
+    # explicitamente listados em `appNamespaces` — ACME validation falha.
     - to:
-        - namespaceSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
-              kubernetes.io/metadata.name: cert-manager
+              acme.cert-manager.io/http01-solver: "true"
     # DNS (kube-dns).
     - to:
         - namespaceSelector:


### PR DESCRIPTION
## Resumo

Fix do bloqueador final da Fase 2.3 (validação cert Let's Encrypt). Tentativa de emitir cert via HTTP-01 falhava com 502 Bad Gateway no Traefik porque a NetworkPolicy bloqueava egress para o ACME solver pod.

## Causa raiz

NetworkPolicy do chart `platform/traefik/` (template `networkpolicy.yaml`) tinha um egress permitindo acesso ao namespace `cert-manager` "para hospedar challenge solver pods". **Comentário errado**: cert-manager *controller* vive em `cert-manager`, mas os **solver pods** do Challenge controller nascem no **mesmo namespace da Certificate resource**.

Para Certificate em qualquer namespace fora da whitelist `appNamespaces` (ex.: namespace de teste, ou apps que ainda não estão na whitelist), o solver era inalcançável → connection refused → 502.

Diagnóstico no cluster:
| Teste | Resultado |
|---|---|
| curl direto ao solver pod IP:porta com Host correto (de pod sem NP) | 200 OK + key esperado |
| curl do Traefik pod ao mesmo destino | connection refused |
| NP egress whitelist | uniplus, vault, keycloak, cert-manager, kube-system DNS |

## Fix

```diff
-    # cert-manager solver Pods (HTTP-01 challenge) — namespace cert-manager
-    # pode hospedar challenge solver pods com label específico.
+    # cert-manager solver Pods (HTTP-01 challenge) nascem no MESMO namespace
+    # da Certificate resource — não no namespace `cert-manager` (que hospeda
+    # apenas o controller). [...]
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: cert-manager
+        - namespaceSelector: {}          # qualquer namespace
+          podSelector:
+            matchLabels:
+              acme.cert-manager.io/http01-solver: "true"
```

Solver pods sempre carregam `acme.cert-manager.io/http01-solver=true` (label definida pelo upstream Challenge controller). A regra é cirúrgica — não amplia egress para qualquer pod, só para os solvers.

## Test plan

- [x] Lint: `yamllint -c .yamllint.yaml platform/traefik/templates/networkpolicy.yaml` clean
- [x] Render: `helm template platform/traefik/ -f environments/standalone/values.yaml` produz NP com `podSelector.matchLabels.acme.cert-manager.io/http01-solver: "true"`
- [ ] Pós-merge: emitir Certificate de teste em namespace fora da whitelist → Order valid → Certificate Ready=True

Closes #121. Destrava efetivamente Fase 2.3 do plano.