### PR TITLE
feat(scripts): bootstrap-standalone codifica Postgres 18 systemd unit + creds

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1104,11 +1104,16 @@ A função `step_data_setup_postgres` em `scripts/bootstrap-standalone.sh` provi
 
 1. Diretórios `/var/lib/uniplus/postgres/{data,init}` com ownership `70:70` (uid `postgres` no container `postgres:18-alpine` — Alpine usa uid 70, distinto do uid 999 das imagens Debian-based).
 2. `.bootstrap-creds` (root:root 600) em `/var/lib/uniplus/postgres/.bootstrap-creds` com `super_pw` + `keycloak_pw` (256 bits cada via `openssl rand -hex 32`) — gerado **somente na primeira execução**.
-3. Init SQL `/var/lib/uniplus/postgres/init/00-keycloak.sql` que cria role `keycloak` + database `keycloak` na primeira inicialização do cluster Postgres (entrypoint do `postgres:18-alpine` ignora o script silenciosamente em re-execuções com data dir já populado).
+3. Init SQL **efêmero** `/var/lib/uniplus/postgres/init/00-keycloak.sql` (mode `600`, owner `70:70`) — gerado APENAS quando o cluster ainda não foi inicializado (sem `PG_VERSION` em `data/`). Cria role `keycloak` + database `keycloak` na primeira inicialização. Após `pg_isready` confirmar que o entrypoint executou o script, o arquivo é shredded (`shred -u`) — `keycloak_pw` em cleartext NÃO persiste no filesystem do data-host entre runs (snapshots/backups da LVM `vg-postgres` não capturam cópia extra do secret).
 4. EnvironmentFile `/etc/uniplus-postgres.env` (root:root 600) com `POSTGRES_PASSWORD=<super_pw>` lido do `.bootstrap-creds`. `docker run` recebe a senha via `-e POSTGRES_PASSWORD` (sem `=value`) — evita exposure em `/proc/<pid>/cmdline`.
 5. `systemd` unit `/etc/systemd/system/uniplus-postgres.service` com `Restart=always`, `Type=simple`, container em `--network host` (Postgres listen em `10.0.2.87:5432`).
 
-**Idempotência:** re-runs preservam senhas e init SQL se `.bootstrap-creds` já existe; EnvironmentFile + systemd unit são sempre re-aplicados (cheap, corrige drift). Se o serviço já estiver `active`, o bootstrap não reinicia (evita downtime).
+**Idempotência (decisões independentes):**
+
+- `.bootstrap-creds`: se já existe, preserva; se não existe e cluster já inicializado, aborta apontando §9.4; senão, gera novas senhas.
+- Init SQL: regenerado sempre que o cluster ainda não tem `PG_VERSION` (cobre o fluxo §9.4 — restore creds, data dir vazio → SQL recriado a partir do `keycloak_pw` persistido). Cleanup defensivo se leftover persiste após cluster já estar inicializado.
+- EnvironmentFile + systemd unit: sempre re-aplicados (cheap, corrige drift sem afetar state do cluster).
+- Serviço já ativo: bootstrap não reinicia (evita downtime).
 
 **Verificação imediata pós-bootstrap:**
 
@@ -1252,6 +1257,8 @@ EOF
 ```
 
 > O `super_pw` não é persistido no Vault (intencional — só é usado em break-glass do superuser). Se realmente necessário, recuperar do gestor institucional ou regenerar via `ALTER USER postgres WITH PASSWORD '...'` antes de re-rodar o bootstrap.
+
+**Após reconstituir `.bootstrap-creds`:** rodar `./scripts/bootstrap-standalone.sh --role=standalone-data` no data-host. Se o data dir do Postgres estiver vazio (ex.: re-provisionamento da LVM), o bootstrap detecta e regenera `00-keycloak.sql` a partir do `keycloak_pw` recém-restaurado, deixa o Postgres inicializar o cluster e shred o SQL após `pg_isready`. Se o cluster já estiver inicializado, o SQL não é gerado (cluster preserva role/db criados originalmente) — o bootstrap apenas re-aplica EnvironmentFile/systemd unit.
 
 ### 9.5 Backup e Restore do cluster Postgres
 

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1102,7 +1102,7 @@ Em standalone, os componentes stateful rodam **fora do K8s** — containers Dock
 
 A função `step_data_setup_postgres` em `scripts/bootstrap-standalone.sh` provisiona, na ordem:
 
-1. Diretórios `/var/lib/uniplus/postgres/{data,init}` com ownership `999:999` (uid `postgres` no container `postgres:18-alpine`).
+1. Diretórios `/var/lib/uniplus/postgres/{data,init}` com ownership `70:70` (uid `postgres` no container `postgres:18-alpine` — Alpine usa uid 70, distinto do uid 999 das imagens Debian-based).
 2. `.bootstrap-creds` (root:root 600) em `/var/lib/uniplus/postgres/.bootstrap-creds` com `super_pw` + `keycloak_pw` (256 bits cada via `openssl rand -hex 32`) — gerado **somente na primeira execução**.
 3. Init SQL `/var/lib/uniplus/postgres/init/00-keycloak.sql` que cria role `keycloak` + database `keycloak` na primeira inicialização do cluster Postgres (entrypoint do `postgres:18-alpine` ignora o script silenciosamente em re-execuções com data dir já populado).
 4. EnvironmentFile `/etc/uniplus-postgres.env` (root:root 600) com `POSTGRES_PASSWORD=<super_pw>` lido do `.bootstrap-creds`. `docker run` recebe a senha via `-e POSTGRES_PASSWORD` (sem `=value`) — evita exposure em `/proc/<pid>/cmdline`.
@@ -1202,10 +1202,18 @@ if [ -z "$KEYCLOAK_PW" ]; then
   return 1 2>/dev/null || exit 1
 fi
 
-# 3) Pod ad-hoc com psql (sem hostNetwork — usa flannel)
+# 3) Pod ad-hoc com psql (sem hostNetwork — usa flannel).
+#    Senha vai via stdin (here-string + `read -r` no pod), NÃO em argv:
+#    - `<<<` é processada pelo bash sem fork → senha não cruza argv do shell
+#      local nem aparece em /proc/<pid>/cmdline do k8s-host.
+#    - `kubectl run -i` conecta o stdin do bash ao stdin do container.
+#    - Dentro do pod, `read -r PW` consome a linha; `PGPASSWORD="$PW"` fica
+#      apenas no env do processo psql, NUNCA na spec do Pod salva no apiserver.
+#    Mesmo padrão de higiene de §8.4.2 (unseal keys via stdin do vault CLI).
 sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml run pg-validation \
   --image=postgres:18-alpine --restart=Never --rm -i --command -- \
-  sh -c "PGPASSWORD=$KEYCLOAK_PW psql -h 10.0.2.87 -U keycloak -d keycloak -c 'SELECT 1 AS ok;'"
+  sh -c 'read -r PW; PGPASSWORD="$PW" psql -h 10.0.2.87 -U keycloak -d keycloak -c "SELECT 1 AS ok;"' \
+  <<<"$KEYCLOAK_PW"
 # Esperado: 1 (uma linha)
 unset KEYCLOAK_PW
 ```

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -12,6 +12,7 @@
 - [6. Operações de Banco](#6-operações-de-banco)
 - [7. Diagnóstico](#7-diagnóstico)
 - [8. Bootstrap e Teardown — Ambiente Standalone OCI](#8-bootstrap-e-teardown--ambiente-standalone-oci)
+- [9. Data services no data-host (standalone)](#9-data-services-no-data-host-standalone)
 
 ## 1. Procedimentos Rotineiros
 
@@ -808,7 +809,7 @@ kubectl get pods -n argocd
 
 ### 8.2 Bootstrap do data-host
 
-> ⚠️ **Bloqueado** até a Epic `data/*` estar implementada (Postgres, Kafka, MinIO, Redis via Docker Compose). Os volumes LVM já são provisionados pelo bootstrap; os containers precisam dos charts/compose em `data/`.
+> **Postgres 18:** codificado no bootstrap (ver §9.1). Kafka, MinIO e Redis ainda dependem de sub-tasks da Epic `data/*` — volumes LVM já são provisionados, containers + systemd units serão adicionados conforme o mesmo padrão do Postgres.
 
 **Executar no data-host (via SSH do k8s-host):**
 
@@ -1092,6 +1093,156 @@ ssh -t -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87 \
 **O que é preservado:** dados nos block volumes OCI — o LVM fica intacto, apenas desmontado. Re-montagem pelo bootstrap recupera os dados.
 
 **Pós-teardown:** re-bootstrap via `./scripts/bootstrap-standalone.sh --role=standalone-data`.
+
+## 9. Data services no data-host (standalone)
+
+Em standalone, os componentes stateful rodam **fora do K8s** — containers Docker gerenciados por `systemd` no data-host. A primeira entrega da Epic `data/*` codifica o Postgres 18; Kafka, MinIO e Redis seguirão o mesmo padrão.
+
+### 9.1 Postgres 18 — bootstrap automatizado
+
+A função `step_data_setup_postgres` em `scripts/bootstrap-standalone.sh` provisiona, na ordem:
+
+1. Diretórios `/var/lib/uniplus/postgres/{data,init}` com ownership `999:999` (uid `postgres` no container `postgres:18-alpine`).
+2. `.bootstrap-creds` (root:root 600) em `/var/lib/uniplus/postgres/.bootstrap-creds` com `super_pw` + `keycloak_pw` (256 bits cada via `openssl rand -hex 32`) — gerado **somente na primeira execução**.
+3. Init SQL `/var/lib/uniplus/postgres/init/00-keycloak.sql` que cria role `keycloak` + database `keycloak` na primeira inicialização do cluster Postgres (entrypoint do `postgres:18-alpine` ignora o script silenciosamente em re-execuções com data dir já populado).
+4. EnvironmentFile `/etc/uniplus-postgres.env` (root:root 600) com `POSTGRES_PASSWORD=<super_pw>` lido do `.bootstrap-creds`. `docker run` recebe a senha via `-e POSTGRES_PASSWORD` (sem `=value`) — evita exposure em `/proc/<pid>/cmdline`.
+5. `systemd` unit `/etc/systemd/system/uniplus-postgres.service` com `Restart=always`, `Type=simple`, container em `--network host` (Postgres listen em `10.0.2.87:5432`).
+
+**Idempotência:** re-runs preservam senhas e init SQL se `.bootstrap-creds` já existe; EnvironmentFile + systemd unit são sempre re-aplicados (cheap, corrige drift). Se o serviço já estiver `active`, o bootstrap não reinicia (evita downtime).
+
+**Verificação imediata pós-bootstrap:**
+
+```bash
+sudo systemctl status uniplus-postgres
+sudo docker exec uniplus-postgres pg_isready -U postgres
+sudo docker exec uniplus-postgres psql -U keycloak -d keycloak -c 'SELECT current_user, current_database();'
+# Esperado: keycloak | keycloak
+```
+
+### 9.2 Custódia das senhas iniciais
+
+> ⚠️ **CRÍTICO.** O `.bootstrap-creds` é o **único rastro em disco** das senhas geradas. Custodiar imediatamente em gestor institucional + Vault standalone, depois `shred -u` o arquivo.
+
+**Passo 1 — Ler senhas no data-host:**
+
+```bash
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87
+sudo cat /var/lib/uniplus/postgres/.bootstrap-creds
+# super_pw=<64 hex>
+# keycloak_pw=<64 hex>
+```
+
+Salvar `keycloak_pw` no gestor institucional (Bitwarden, 1Password ou Vault corporativo separado). O `super_pw` pode ser descartado após o setup — é a senha do superuser `postgres`, usada apenas em break-glass; recuperável via re-bootstrap se necessário.
+
+**Passo 2 — Salvar `keycloak_pw` no Vault standalone (executar do k8s-host):**
+
+> Mesmo padrão de higiene da §8.4.3: port-forward + token via env do shell, não argv.
+
+```bash
+# 1) Ler keycloak_pw do data-host (ssh, sem cruzar argv local)
+read -rsp "Cole keycloak_pw (do passo 1): " KC_PW; echo
+
+# 2) Port-forward Vault
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault port-forward platform-vault-uniplus-standalone-0 8200:8200 \
+  > /tmp/vault-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null; unset KC_PW VAULT_TOKEN VAULT_ADDR' EXIT
+export VAULT_ADDR=http://127.0.0.1:8200
+until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
+
+# 3) Root token (sem echo, sem history)
+read -rsp "Root token: " VAULT_TOKEN; echo
+export VAULT_TOKEN
+
+# 4) PUT em secret/standalone/postgres/keycloak (KV v2)
+vault kv put secret/standalone/postgres/keycloak \
+  host=10.0.2.87 \
+  port=5432 \
+  database=keycloak \
+  username=keycloak \
+  password="$KC_PW"
+
+# 5) Confirmar
+vault kv get secret/standalone/postgres/keycloak
+# Esperado: campos host/port/database/username/password presentes
+
+# trap EXIT cuida de kill + unset ao sair do shell
+```
+
+**Passo 3 — Limpar `.bootstrap-creds` no data-host:**
+
+```bash
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87
+sudo shred -u /var/lib/uniplus/postgres/.bootstrap-creds
+```
+
+> ⚠️ Após `shred -u`, re-execução do bootstrap **regeneraria** as senhas (não há outro rastro em disco). Se for necessário re-rodar o script com data dir já populado, restaurar o `.bootstrap-creds` antes a partir do gestor institucional (ver §9.4).
+
+### 9.3 Validação end-to-end (pod K8s → Postgres)
+
+Confirma que pods do cluster K3s alcançam o Postgres no data-host via TCP. Pré-requisito: PR #125 aplicado (iptables FORWARD ACCEPT entre flannel CIDR e VCN).
+
+**Executar no k8s-host:**
+
+```bash
+# 1) Conectividade TCP bruta
+nc -zv 10.0.2.87 5432
+# Esperado: succeeded
+
+# 2) Pod ad-hoc com psql (sem hostNetwork — usa flannel)
+KEYCLOAK_PW=$(ssh ubuntu@10.0.2.87 \
+  "sudo grep keycloak_pw= /var/lib/uniplus/postgres/.bootstrap-creds 2>/dev/null | cut -d= -f2" || \
+  echo "<recuperar do Vault — ver §9.4>")
+
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml run pg-validation \
+  --image=postgres:18-alpine --restart=Never --rm -i --command -- \
+  sh -c "PGPASSWORD=$KEYCLOAK_PW psql -h 10.0.2.87 -U keycloak -d keycloak -c 'SELECT 1 AS ok;'"
+# Esperado: 1 (uma linha)
+unset KEYCLOAK_PW
+```
+
+Se o pod fica preso em `Pending` ou retorna `Host is unreachable`: revisar §8.6/§8.7 do plano-pai (#123) e confirmar que `iptables -L FORWARD` no k8s-host mostra os ACCEPTs flannel↔VCN antes do `REJECT --reject-with icmp-host-prohibited`.
+
+### 9.4 Restore: re-criar `.bootstrap-creds` a partir do Vault
+
+Caso o operador tenha rodado `shred -u` e precise re-executar o bootstrap (ou recuperar a senha localmente para troubleshooting), recriar o arquivo a partir do Vault:
+
+```bash
+# No k8s-host — port-forward + leitura do secret (mesmo pattern §9.2)
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault port-forward platform-vault-uniplus-standalone-0 8200:8200 \
+  > /tmp/vault-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null; unset KC_PW VAULT_TOKEN VAULT_ADDR' EXIT
+export VAULT_ADDR=http://127.0.0.1:8200
+until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
+
+read -rsp "Root token: " VAULT_TOKEN; echo
+export VAULT_TOKEN
+
+KC_PW=$(vault kv get -field=password secret/standalone/postgres/keycloak)
+
+# Transmitir para o data-host via stdin do ssh — não cruza argv
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87 \
+  "sudo tee /var/lib/uniplus/postgres/.bootstrap-creds > /dev/null && \
+   sudo chmod 600 /var/lib/uniplus/postgres/.bootstrap-creds && \
+   sudo chown root:root /var/lib/uniplus/postgres/.bootstrap-creds" <<EOF
+super_pw=<recuperar do gestor institucional, ou regenerar via ALTER USER postgres>
+keycloak_pw=$KC_PW
+EOF
+
+# Cleanup automático via trap
+```
+
+> O `super_pw` não é persistido no Vault (intencional — só é usado em break-glass do superuser). Se realmente necessário, recuperar do gestor institucional ou regenerar via `ALTER USER postgres WITH PASSWORD '...'` antes de re-rodar o bootstrap.
+
+### 9.5 Backup e Restore do cluster Postgres
+
+> Procedimento detalhado a ser codificado em sub-task da Epic `data/*` (paralelo à 3.4 MinIO). Resumo:
+>
+> - **Backup:** `pg_dump --format=custom keycloak` rodado periodicamente via systemd timer no data-host, output enviado para bucket MinIO (`s3://backups/postgres/<timestamp>.dump`).
+> - **Restore:** `pg_restore --clean --if-exists --no-owner --dbname=keycloak <dump>` em data-host com volume LVM intacto.
 
 ---
 

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1190,11 +1190,19 @@ Confirma que pods do cluster K3s alcançam o Postgres no data-host via TCP. Pré
 nc -zv 10.0.2.87 5432
 # Esperado: succeeded
 
-# 2) Pod ad-hoc com psql (sem hostNetwork — usa flannel)
+# 2) Senha do keycloak — fail fast se não disponível.
+#    Após §9.2 shred, .bootstrap-creds não existe mais; restaure via §9.4
+#    antes de rodar este bloco (ou cole a senha à mão via read -rsp).
 KEYCLOAK_PW=$(ssh ubuntu@10.0.2.87 \
-  "sudo grep keycloak_pw= /var/lib/uniplus/postgres/.bootstrap-creds 2>/dev/null | cut -d= -f2" || \
-  echo "<recuperar do Vault — ver §9.4>")
+  "sudo grep keycloak_pw= /var/lib/uniplus/postgres/.bootstrap-creds 2>/dev/null | cut -d= -f2")
+if [ -z "$KEYCLOAK_PW" ]; then
+  echo "ERRO: keycloak_pw não encontrado em .bootstrap-creds no data-host." >&2
+  echo "  - Se .bootstrap-creds foi shredded (§9.2), restaure via §9.4 antes" >&2
+  echo "    OU cole a senha manualmente: read -rsp 'keycloak_pw: ' KEYCLOAK_PW; echo" >&2
+  return 1 2>/dev/null || exit 1
+fi
 
+# 3) Pod ad-hoc com psql (sem hostNetwork — usa flannel)
 sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml run pg-validation \
   --image=postgres:18-alpine --restart=Never --rm -i --command -- \
   sh -c "PGPASSWORD=$KEYCLOAK_PW psql -h 10.0.2.87 -U keycloak -d keycloak -c 'SELECT 1 AS ok;'"

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -633,6 +633,16 @@ step_data_configure_iptables() {
 #   2. Salvar em secret/standalone/postgres/keycloak no Vault
 #   3. shred -u .bootstrap-creds
 step_data_setup_postgres() {
+    # Honra --skip-docker: se Docker não está disponível e o usuário pediu
+    # explicitamente para pular instalação, pulamos também o setup do Postgres
+    # (que depende de docker run/exec). Sem este guard, --skip-docker mutaria
+    # iptables + LVM e falharia tarde aqui — comportamento inconsistente com
+    # a flag documentada (Codex P2 round 4).
+    if $SKIP_DOCKER && ! command -v docker &>/dev/null; then
+        log_warn "Docker indisponível e --skip-docker ativo — pulando setup do Postgres."
+        return
+    fi
+
     log_info "Configurando Postgres 18 systemd..."
 
     local creds_file="$DATA_BASE/postgres/.bootstrap-creds"

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -636,12 +636,16 @@ step_data_setup_postgres() {
     local env_file="/etc/uniplus-postgres.env"
     local unit_file="/etc/systemd/system/uniplus-postgres.service"
 
-    # Diretórios + ownership: ambos pertencem ao uid 999 (postgres no container
-    # alpine). O entrypoint do postgres:18-alpine roda os scripts de init
-    # /docker-entrypoint-initdb.d/*.sql AS the postgres user, então precisa de
-    # acesso de leitura — chown evita o erro "Permission denied" ao traverse.
+    # Diretórios + ownership: ambos pertencem ao uid 70 (postgres no container
+    # postgres:18-alpine — Alpine usa uid 70, NÃO 999 que é a convenção das
+    # imagens Debian-based). O entrypoint do postgres:18-alpine roda os scripts
+    # de init /docker-entrypoint-initdb.d/*.sql AS the postgres user (uid 70 +
+    # gosu drop após chown -R do PGDATA). Com init dir owned 70:70 + mode 700,
+    # o uid 70 consegue traverse e ler — chown errado bloqueia silenciosamente
+    # o script de init e o role/db `keycloak` nunca é criado (#127 Codex P1 +
+    # code review).
     run "sudo mkdir -p $DATA_BASE/postgres/data $DATA_BASE/postgres/init"
-    run "sudo chown 999:999 $DATA_BASE/postgres/data $DATA_BASE/postgres/init"
+    run "sudo chown 70:70 $DATA_BASE/postgres/data $DATA_BASE/postgres/init"
     run "sudo chmod 700 $DATA_BASE/postgres/init"
 
     if sudo test -f "$creds_file" 2>/dev/null; then
@@ -690,7 +694,7 @@ CREATE ROLE keycloak WITH LOGIN PASSWORD '$keycloak_pw' NOSUPERUSER NOCREATEDB N
 CREATE DATABASE keycloak OWNER keycloak ENCODING 'UTF8' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;
 GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;
 EOF
-        sudo chown 999:999 "$init_sql"
+        sudo chown 70:70 "$init_sql"
         sudo chmod 600 "$init_sql"
 
         log_warn "Senhas geradas em $creds_file. Custódia obrigatória — ver runbook §9.2."

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -616,13 +616,17 @@ step_data_configure_iptables() {
 
 # Configura Postgres 18 como container Docker gerenciado por systemd no data-host.
 #
-# Idempotência:
-#   - Se .bootstrap-creds já existe, senhas e init SQL são preservados (não
-#     regenera). Garante que role/db já criados na primeira inicialização do
-#     cluster permanecem consistentes em re-runs.
-#   - EnvironmentFile e systemd unit são sempre re-aplicados (cheap, corrige
-#     drift sem afetar state do cluster).
-#   - Se o serviço já está ativo, não reinicia (evita downtime em re-runs).
+# Idempotência (decisões independentes):
+#   - .bootstrap-creds: se já existe, preserva senhas. Caso contrário, gera
+#     novas (256 bits cada) — exceto se cluster já inicializado sem creds,
+#     onde aborta apontando §9.4 do runbook.
+#   - 00-keycloak.sql (init SQL): efêmero. Gerado sempre que o cluster ainda
+#     não foi inicializado (PG_VERSION ausente em data/), shredded após o
+#     primeiro pg_isready OK. Cobre o fluxo §9.4 (restore creds, data dir
+#     vazio → SQL recriado) e elimina cópia persistente do keycloak_pw em
+#     cleartext em $DATA_BASE/postgres/init/ (Codex P2 round 2).
+#   - EnvironmentFile + systemd unit: sempre re-aplicados (cheap, corrige drift).
+#   - Serviço já ativo: não reinicia (evita downtime em re-runs).
 #
 # Pós-condições para o operador (ver runbook §9.2):
 #   1. Copiar keycloak_pw de .bootstrap-creds para gestor institucional
@@ -648,26 +652,33 @@ step_data_setup_postgres() {
     run "sudo chown 70:70 $DATA_BASE/postgres/data $DATA_BASE/postgres/init"
     run "sudo chmod 700 $DATA_BASE/postgres/init"
 
+    # Detectar se o cluster Postgres já foi inicializado pelo entrypoint.
+    # PG_VERSION é canônico — escrito por initdb na primeira inicialização e
+    # presente em qualquer layout de PGDATA (postgres:18 entrypoint cria sob
+    # /var/lib/postgresql/data ou subdir vendor-specific). `find -print -quit`
+    # retorna na primeira ocorrência, robusto a variações de layout.
+    local cluster_initialized=false
+    if ! $DRY_RUN && \
+       sudo find "$DATA_BASE/postgres/data" -name PG_VERSION -print -quit 2>/dev/null | grep -q .; then
+        cluster_initialized=true
+    fi
+
+    # ---- Decisão 1: .bootstrap-creds (preservar / gerar / abortar) ----
     if sudo test -f "$creds_file" 2>/dev/null; then
-        log_success "Bootstrap creds já existentes — preservando senhas e init SQL."
+        log_success "Bootstrap creds já existentes — preservando senhas."
     elif $DRY_RUN; then
         log_warn "Dry-run: senhas iniciais seriam geradas em $creds_file"
-        log_warn "Dry-run: init SQL seria gerado em $init_sql"
+    elif $cluster_initialized; then
+        # Guard: cluster inicializado mas sem .bootstrap-creds. Acontece quando
+        # operador rodou `shred -u` (runbook §9.2) e re-executa o bootstrap.
+        # Regenerar agora produziria mismatch — novo super_pw no EnvironmentFile
+        # vs senha antiga persistida no cluster. Persistir o keycloak_pw novo
+        # no Vault quebraria ESO/Keycloak com auth error.
+        log_error "$creds_file ausente, mas cluster Postgres já existe em $DATA_BASE/postgres/data"
+        log_error "Regenerar senhas agora produziria mismatch entre EnvironmentFile e cluster."
+        log_error "Restaure $creds_file a partir do Vault — ver docs/RUNBOOKS.md §9.4."
+        exit 1
     else
-        # Guard: cluster Postgres já inicializado mas sem .bootstrap-creds.
-        # Acontece quando operador rodou `shred -u` (runbook §9.2) e re-executa
-        # o bootstrap. Regenerar agora produziria mismatch — novo super_pw entra
-        # no EnvironmentFile, mas o cluster persistido mantém a senha antiga; o
-        # init SQL é ignorado pelo entrypoint do postgres:18-alpine quando o
-        # data dir já tem PG_VERSION. Persistir o keycloak_pw regenerado no
-        # Vault quebraria ESO/Keycloak com auth error.
-        if sudo find "$DATA_BASE/postgres/data" -name PG_VERSION -print -quit 2>/dev/null | grep -q .; then
-            log_error "$creds_file ausente, mas cluster Postgres já existe em $DATA_BASE/postgres/data"
-            log_error "Regenerar senhas agora produziria mismatch entre EnvironmentFile e cluster."
-            log_error "Restaure $creds_file a partir do Vault — ver docs/RUNBOOKS.md §9.4."
-            exit 1
-        fi
-
         log_info "Gerando senhas iniciais (256 bits cada)..."
         local super_pw keycloak_pw
         super_pw=$(openssl rand -hex 32)
@@ -682,22 +693,45 @@ keycloak_pw=$keycloak_pw
 EOF
         sudo chown root:root "$creds_file"
         sudo chmod 600 "$creds_file"
+        log_warn "Senhas geradas em $creds_file. Custódia obrigatória — ver runbook §9.2."
+    fi
 
-        # Init SQL: executado pelo entrypoint do postgres:18-alpine APENAS na
-        # primeira inicialização do cluster (data dir vazio). Re-execuções com
-        # cluster já inicializado ignoram o script silenciosamente. Heredoc
-        # unquoted permite expansão de $keycloak_pw. A senha é hex-only
-        # (openssl rand -hex), sem metacaracteres SQL — segura em
-        # single-quoted string.
+    # ---- Decisão 2: 00-keycloak.sql (efêmero — só existe pré-init do cluster) ----
+    # Gerado SEMPRE que cluster não está inicializado e .bootstrap-creds existe
+    # (cobre fluxo §9.4: restore creds, data dir vazio → SQL re-criado a partir
+    # da senha persistida no Vault). Após primeiro pg_isready OK, é shredded
+    # mais abaixo nesta função — keycloak_pw em cleartext NÃO persiste em
+    # $DATA_BASE/postgres/init/ entre runs (Codex P2 round 2: backups/snapshots
+    # do data-host não capturam cópia extra do secret).
+    if $DRY_RUN; then
+        if ! $cluster_initialized; then
+            log_warn "Dry-run: init SQL seria (re)gerado em $init_sql"
+        fi
+    elif $cluster_initialized; then
+        # Cleanup defensivo: se SQL leftover de run anterior persiste após
+        # cluster já estar inicializado (ex.: falha entre tee e pg_isready
+        # antes do shred), remover agora — não tem mais função e seria leak.
+        if sudo test -f "$init_sql" 2>/dev/null; then
+            log_warn "Cluster já inicializado mas $init_sql ainda existe — shredding."
+            run "sudo shred -u $init_sql"
+        fi
+    elif sudo test -f "$creds_file" 2>/dev/null; then
+        local kc_pw
+        kc_pw=$(sudo grep '^keycloak_pw=' "$creds_file" | cut -d= -f2)
+        if [[ -z "$kc_pw" ]]; then
+            log_error "keycloak_pw vazio em $creds_file — não consigo (re)gerar init SQL."
+            exit 1
+        fi
+        # Heredoc unquoted permite expansão de $kc_pw. Senha hex-only (openssl
+        # rand -hex 32), sem metacaracteres SQL — segura em single-quoted string.
         sudo tee "$init_sql" >/dev/null <<EOF
-CREATE ROLE keycloak WITH LOGIN PASSWORD '$keycloak_pw' NOSUPERUSER NOCREATEDB NOCREATEROLE;
+CREATE ROLE keycloak WITH LOGIN PASSWORD '$kc_pw' NOSUPERUSER NOCREATEDB NOCREATEROLE;
 CREATE DATABASE keycloak OWNER keycloak ENCODING 'UTF8' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;
 GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;
 EOF
         sudo chown 70:70 "$init_sql"
         sudo chmod 600 "$init_sql"
-
-        log_warn "Senhas geradas em $creds_file. Custódia obrigatória — ver runbook §9.2."
+        log_info "Init SQL pronto em $init_sql (será shredded após pg_isready OK)."
     fi
 
     # EnvironmentFile: sempre re-aplicado (super_pw lido do creds file). Usar
@@ -769,6 +803,13 @@ UNIT
         echo "[DRY-RUN] systemctl start uniplus-postgres + aguardaria pg_isready (60s)"
     elif sudo systemctl is-active --quiet uniplus-postgres; then
         log_success "uniplus-postgres já ativo — preservando state (sem restart)."
+        # Cleanup ainda assim — caso o init SQL tenha sido recriado neste run
+        # (fluxo §9.4 com cluster já existente é tratado no guard, mas se o
+        # serviço estava ativo em run anterior e o SQL persiste, shred agora).
+        if sudo test -f "$init_sql" 2>/dev/null; then
+            sudo shred -u "$init_sql"
+            log_success "Init SQL leftover shredded."
+        fi
     else
         sudo systemctl start uniplus-postgres
         log_info "Aguardando Postgres aceitar conexões..."
@@ -782,6 +823,16 @@ UNIT
             sleep 5
         done
         log_success "uniplus-postgres ativo + pg_isready OK."
+
+        # Init SQL cumpriu sua função (entrypoint do postgres:18-alpine
+        # executou os scripts em /docker-entrypoint-initdb.d antes de aceitar
+        # conexões). Shred elimina cópia persistente do keycloak_pw em
+        # cleartext — secret continua vivo apenas em .bootstrap-creds (até o
+        # operador custodiar e shred-ar) e no Vault standalone.
+        if sudo test -f "$init_sql" 2>/dev/null; then
+            sudo shred -u "$init_sql"
+            log_success "Init SQL shredded (keycloak_pw não persiste em $DATA_BASE/postgres/init)."
+        fi
     fi
 }
 

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -614,6 +614,159 @@ step_data_configure_iptables() {
     log_success "iptables INPUT configurado e persistido."
 }
 
+# Configura Postgres 18 como container Docker gerenciado por systemd no data-host.
+#
+# Idempotência:
+#   - Se .bootstrap-creds já existe, senhas e init SQL são preservados (não
+#     regenera). Garante que role/db já criados na primeira inicialização do
+#     cluster permanecem consistentes em re-runs.
+#   - EnvironmentFile e systemd unit são sempre re-aplicados (cheap, corrige
+#     drift sem afetar state do cluster).
+#   - Se o serviço já está ativo, não reinicia (evita downtime em re-runs).
+#
+# Pós-condições para o operador (ver runbook §9.2):
+#   1. Copiar keycloak_pw de .bootstrap-creds para gestor institucional
+#   2. Salvar em secret/standalone/postgres/keycloak no Vault
+#   3. shred -u .bootstrap-creds
+step_data_setup_postgres() {
+    log_info "Configurando Postgres 18 systemd..."
+
+    local creds_file="$DATA_BASE/postgres/.bootstrap-creds"
+    local init_sql="$DATA_BASE/postgres/init/00-keycloak.sql"
+    local env_file="/etc/uniplus-postgres.env"
+    local unit_file="/etc/systemd/system/uniplus-postgres.service"
+
+    # Diretórios + ownership: ambos pertencem ao uid 999 (postgres no container
+    # alpine). O entrypoint do postgres:18-alpine roda os scripts de init
+    # /docker-entrypoint-initdb.d/*.sql AS the postgres user, então precisa de
+    # acesso de leitura — chown evita o erro "Permission denied" ao traverse.
+    run "sudo mkdir -p $DATA_BASE/postgres/data $DATA_BASE/postgres/init"
+    run "sudo chown 999:999 $DATA_BASE/postgres/data $DATA_BASE/postgres/init"
+    run "sudo chmod 700 $DATA_BASE/postgres/init"
+
+    if sudo test -f "$creds_file" 2>/dev/null; then
+        log_success "Bootstrap creds já existentes — preservando senhas e init SQL."
+    elif $DRY_RUN; then
+        log_warn "Dry-run: senhas iniciais seriam geradas em $creds_file"
+        log_warn "Dry-run: init SQL seria gerado em $init_sql"
+    else
+        log_info "Gerando senhas iniciais (256 bits cada)..."
+        local super_pw keycloak_pw
+        super_pw=$(openssl rand -hex 32)
+        keycloak_pw=$(openssl rand -hex 32)
+
+        # .bootstrap-creds: rastro para operador exportar senhas para gestor
+        # institucional + Vault. Após custódia, deve ser removido com `shred -u`
+        # (procedimento documentado em docs/RUNBOOKS.md §9.2).
+        sudo tee "$creds_file" >/dev/null <<EOF
+super_pw=$super_pw
+keycloak_pw=$keycloak_pw
+EOF
+        sudo chown root:root "$creds_file"
+        sudo chmod 600 "$creds_file"
+
+        # Init SQL: executado pelo entrypoint do postgres:18-alpine APENAS na
+        # primeira inicialização do cluster (data dir vazio). Re-execuções com
+        # cluster já inicializado ignoram o script silenciosamente. Heredoc
+        # unquoted permite expansão de $keycloak_pw. A senha é hex-only
+        # (openssl rand -hex), sem metacaracteres SQL — segura em
+        # single-quoted string.
+        sudo tee "$init_sql" >/dev/null <<EOF
+CREATE ROLE keycloak WITH LOGIN PASSWORD '$keycloak_pw' NOSUPERUSER NOCREATEDB NOCREATEROLE;
+CREATE DATABASE keycloak OWNER keycloak ENCODING 'UTF8' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;
+GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;
+EOF
+        sudo chown 999:999 "$init_sql"
+        sudo chmod 600 "$init_sql"
+
+        log_warn "Senhas geradas em $creds_file. Custódia obrigatória — ver runbook §9.2."
+    fi
+
+    # EnvironmentFile: sempre re-aplicado (super_pw lido do creds file). Usar
+    # `docker run -e POSTGRES_PASSWORD` (sem `=value`) evita exposure da senha
+    # em /proc/<pid>/cmdline — docker puxa do env do systemd, populado via
+    # EnvironmentFile.
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Escreveria $env_file (POSTGRES_PASSWORD lido de $creds_file)"
+    else
+        local super_pw_current
+        super_pw_current=$(sudo grep '^super_pw=' "$creds_file" | cut -d= -f2)
+        if [[ -z "$super_pw_current" ]]; then
+            log_error "Não consegui ler super_pw de $creds_file. Abortando."
+            exit 1
+        fi
+        sudo tee "$env_file" >/dev/null <<EOF
+POSTGRES_PASSWORD=$super_pw_current
+POSTGRES_INITDB_ARGS=--encoding=UTF8
+EOF
+        sudo chown root:root "$env_file"
+        sudo chmod 600 "$env_file"
+    fi
+
+    # systemd unit: sempre re-aplicado. Heredoc single-quoted preserva o
+    # conteúdo literal — paths são hardcoded para alinhar com $DATA_BASE
+    # (/var/lib/uniplus). A unit em si não usa variáveis de shell; o systemd
+    # injeta POSTGRES_PASSWORD via EnvironmentFile no env do docker run.
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Escreveria $unit_file"
+    else
+        sudo tee "$unit_file" >/dev/null <<'UNIT'
+[Unit]
+Description=Uni+ Postgres 18 (standalone data-host)
+Documentation=https://github.com/unifesspa-edu-br/uniplus-infra/blob/main/docs/RUNBOOKS.md
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10
+TimeoutStartSec=120
+EnvironmentFile=/etc/uniplus-postgres.env
+
+ExecStartPre=-/usr/bin/docker rm -f uniplus-postgres
+ExecStart=/usr/bin/docker run --rm --name uniplus-postgres \
+  --network host \
+  -e POSTGRES_PASSWORD \
+  -e POSTGRES_INITDB_ARGS \
+  -v /var/lib/uniplus/postgres/data:/var/lib/postgresql \
+  -v /var/lib/uniplus/postgres/init:/docker-entrypoint-initdb.d:ro \
+  postgres:18-alpine \
+  -c listen_addresses=0.0.0.0 \
+  -c max_connections=200 \
+  -c shared_buffers=512MB
+
+ExecStop=/usr/bin/docker stop -t 30 uniplus-postgres
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+    fi
+
+    run "sudo systemctl daemon-reload"
+    run "sudo systemctl enable uniplus-postgres"
+
+    if $DRY_RUN; then
+        echo "[DRY-RUN] systemctl start uniplus-postgres + aguardaria pg_isready (60s)"
+    elif sudo systemctl is-active --quiet uniplus-postgres; then
+        log_success "uniplus-postgres já ativo — preservando state (sem restart)."
+    else
+        sudo systemctl start uniplus-postgres
+        log_info "Aguardando Postgres aceitar conexões..."
+        local attempts=0
+        until sudo docker exec uniplus-postgres pg_isready -U postgres &>/dev/null; do
+            attempts=$(( attempts + 1 ))
+            if (( attempts >= 12 )); then
+                log_error "Postgres não ficou ready em 60s. Ver: sudo journalctl -u uniplus-postgres -n 50"
+                exit 1
+            fi
+            sleep 5
+        done
+        log_success "uniplus-postgres ativo + pg_isready OK."
+    fi
+}
+
 summary_data() {
     echo ""
     echo "============================================"
@@ -627,13 +780,23 @@ summary_data() {
     echo "  $DATA_BASE/vault     ← $DISK_VAULT    (LVM vg-vault)"
     echo "  $DATA_BASE/redis     (disco local)"
     echo ""
+    echo "Postgres 18 systemd:"
+    echo "  systemctl status uniplus-postgres"
+    echo ""
+    echo "Custódia das senhas iniciais (PRIMEIRA EXECUÇÃO — ver runbook §9.2):"
+    echo "  1. Ler senhas:    sudo cat $DATA_BASE/postgres/.bootstrap-creds"
+    echo "  2. Salvar no gestor institucional + Vault standalone"
+    echo "     (kubectl exec no k8s-host → vault kv put secret/standalone/postgres/keycloak)"
+    echo "  3. Após custódia: sudo shred -u $DATA_BASE/postgres/.bootstrap-creds"
+    echo ""
     echo "Próximos passos (Epic data/*):"
-    echo "  Os serviços (Postgres, Kafka, MinIO, Vault, Redis) serão provisionados"
-    echo "  via docker-compose pelo Epic data/* usando esses mount points."
+    echo "  Os serviços Kafka, MinIO e Redis serão provisionados em sub-tasks futuras"
+    echo "  (mesmo padrão do Postgres: container Docker via systemd nos mounts dedicados)."
     echo ""
     echo "Validar:"
     echo "  df -h $DATA_BASE/*"
     echo "  sudo vgs && sudo lvs"
+    echo "  sudo docker exec uniplus-postgres pg_isready -U postgres"
 }
 
 # ============================================================================
@@ -662,6 +825,7 @@ case "$ROLE" in
         discover_disks
         step_setup_lvm
         step_create_placeholder_dirs
+        step_data_setup_postgres
         summary_data
         ;;
 esac

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -650,6 +650,20 @@ step_data_setup_postgres() {
         log_warn "Dry-run: senhas iniciais seriam geradas em $creds_file"
         log_warn "Dry-run: init SQL seria gerado em $init_sql"
     else
+        # Guard: cluster Postgres já inicializado mas sem .bootstrap-creds.
+        # Acontece quando operador rodou `shred -u` (runbook §9.2) e re-executa
+        # o bootstrap. Regenerar agora produziria mismatch — novo super_pw entra
+        # no EnvironmentFile, mas o cluster persistido mantém a senha antiga; o
+        # init SQL é ignorado pelo entrypoint do postgres:18-alpine quando o
+        # data dir já tem PG_VERSION. Persistir o keycloak_pw regenerado no
+        # Vault quebraria ESO/Keycloak com auth error.
+        if sudo find "$DATA_BASE/postgres/data" -name PG_VERSION -print -quit 2>/dev/null | grep -q .; then
+            log_error "$creds_file ausente, mas cluster Postgres já existe em $DATA_BASE/postgres/data"
+            log_error "Regenerar senhas agora produziria mismatch entre EnvironmentFile e cluster."
+            log_error "Restaure $creds_file a partir do Vault — ver docs/RUNBOOKS.md §9.4."
+            exit 1
+        fi
+
         log_info "Gerando senhas iniciais (256 bits cada)..."
         local super_pw keycloak_pw
         super_pw=$(openssl rand -hex 32)


### PR DESCRIPTION
## Sumário

Empacota Postgres 18 systemd no `bootstrap-standalone.sh` — codifica o que estava vivo manualmente no data-host desde a sessão noturna 2026-05-06. Re-bootstrap via Tofu agora recria o stack consistentemente.

- `step_data_setup_postgres`: provisiona diretórios + ownership 999:999, gera senhas (256 bits), escreve `.bootstrap-creds`, init SQL, EnvironmentFile e systemd unit. Idempotente: preserva senhas existentes; não reinicia serviço já ativo
- Senhas nunca em argv: `docker run -e POSTGRES_PASSWORD` (sem valor) puxa do EnvironmentFile injetado pelo systemd, evita exposure em `/proc/<pid>/cmdline`
- `docs/RUNBOOKS.md` §9: bootstrap, custódia manual via Vault (`port-forward` + `read -rsp` + `vault kv put`), validação end-to-end pod K8s → Postgres, restore

Closes #126. Sub-task de #118 (Story: data services no data-host).

## Decisões arquiteturais

- **postgres:18-alpine + `--network host`**: container listen em `10.0.2.87:5432` direto, sem port-forward
- **Mount em `/var/lib/postgresql`** (parent), não `/data`: layout do Postgres 18+ exige mount do parent
- **Init SQL roda apenas na primeira inicialização** do cluster (data dir vazio); re-execuções com cluster populado ignoram silenciosamente — alinhado à idempotência das senhas
- **`super_pw` não é persistido no Vault** (intencional): só usado em break-glass do superuser, recuperável via `ALTER USER postgres` se necessário
- **`Documentation=` na systemd unit** aponta pro runbook deste PR — URL ficará válida pós-merge

## Test plan

### Local (concluído)
- [x] `bash -n scripts/bootstrap-standalone.sh` — sintaxe OK
- [x] `shellcheck` (via Docker `koalaman/shellcheck:stable`) — zero issues
- [x] `markdownlint-cli2` em `docs/RUNBOOKS.md` — zero erros
- [x] Plano-pai documentado em `~/.claude/plans/standalone-postgres-empacotado.md`

### CI
- [ ] yaml-lint (não toca YAML — esperado verde)
- [ ] helm-lint (não toca charts — esperado verde)
- [ ] shellcheck (severity warning — verde local)
- [ ] schema-validate
- [ ] manifest-validate
- [ ] markdown-lint

### Validação na VM real (pós-merge, mesma sessão)
- [ ] Rodar `bootstrap-standalone.sh --role=standalone-data` no data-host atual:
  - Detecta LVM já configurado → skip
  - Detecta `.bootstrap-creds` existente → preserva senhas + init SQL
  - Re-aplica systemd unit + envfile (idempotente)
  - Detecta `uniplus-postgres` já ativo → skip start
- [ ] `sudo systemctl status uniplus-postgres` → `active (running)`
- [ ] `sudo docker exec uniplus-postgres pg_isready -U postgres` → `accepting connections`
- [ ] Cross-VM do k8s-host: pod K8s sem `hostNetwork` consegue `psql -h 10.0.2.87 -U keycloak -c 'SELECT 1'` → retorna `1`
