### PR TITLE
feat(keycloak-replica): chart Keycloak 26.6 + realm uniplus + IngressRoute (standalone)

### DIFF
--- a/apps/keycloak-replica/Chart.yaml
+++ b/apps/keycloak-replica/Chart.yaml
@@ -1,19 +1,32 @@
 apiVersion: v2
 name: keycloak-replica
-description: Serviço OIDC local do Uni+; nome do chart mantido por compatibilidade
+description: |
+  Serviço OIDC local do Uni+ baseado em Keycloak 26.6.x. Nome do chart
+  preservado por compatibilidade com o ApplicationSet existente.
 type: application
-version: 0.1.0
-appVersion: "1.0.0"
-keywords:
-  - uniplus
-  - auth
-  - unifesspa
+
+# Versão do chart wrapper Uni+. Bump em qualquer mudança de template/values.
+version: 0.2.0
+
+# Versão do Keycloak upstream empacotada (sincronizar com image.tag).
+appVersion: "26.6.1"
+
 home: https://github.com/unifesspa-edu-br/uniplus-infra
 sources:
   - https://github.com/unifesspa-edu-br/uniplus-infra
+  - https://github.com/keycloak/keycloak
+
 maintainers:
   - name: CTIC UNIFESSPA
     email: jeferson.ferreira@unifesspa.edu.br
+
+keywords:
+  - uniplus
+  - auth
+  - keycloak
+  - oidc
+  - unifesspa
+
 annotations:
   category: auth
   licenses: MIT

--- a/apps/keycloak-replica/README.md
+++ b/apps/keycloak-replica/README.md
@@ -17,8 +17,8 @@ Ver [docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md) para o contexto arquitetu
 - Vault de aplicação inicializado, ESO `ClusterSecretStore` `vault-default` com STATUS=Valid+Ready
 - Secrets no Vault:
   - `secret/standalone/postgres/keycloak` (fields: `host`, `port`, `database`, `username`, `password`)
-  - `secret/standalone/keycloak/admin` (fields: `username`, `password`) — bootstrap admin
-  - `secret/standalone/keycloak/clients/uniplus-portal` (field: `client_secret`)
+  - `secret/standalone/keycloak/admin` (fields: `username`, `password`) — bootstrap admin do master realm
+  - O client `uniplus-portal` é **public client** (SPA + PKCE) — não há `client_secret` para custodiar.
 - cert-manager + ClusterIssuer `letsencrypt-staging` ou `letsencrypt-prod` Ready
 - Traefik Running com hostPort 80/443 (single-host) ou Service LoadBalancer (multi-DC)
 
@@ -32,7 +32,7 @@ Por padrão o chart fica **desabilitado** (`keycloak.enabled: false`). Apenas en
 
 - `templates/deployment.yaml` — Deployment Keycloak 26.6.x com `start --import-realm`, env vars de DB/admin via secret refs, probes na management port 9000
 - `templates/service.yaml` — ClusterIP com port `http` (8080) + port `management` (9000)
-- `templates/externalsecret.yaml` — 3 ExternalSecrets (DB, bootstrap admin, client secret) consumindo `ClusterSecretStore vault-default`
+- `templates/externalsecret.yaml` — 2 ExternalSecrets (DB credentials + bootstrap admin) consumindo `ClusterSecretStore vault-default`
 - `templates/configmap-realm.yaml` — ConfigMap com `uniplus-realm.json` montado em `/opt/keycloak/data/import/`
 - `templates/ingressroute.yaml` — Traefik IngressRoute path `/auth/*` com TLS via cert-manager
 - `templates/networkpolicy.yaml` — egress: data-host:5432, vault, DNS; ingress: Traefik (8080), Prometheus (9000)
@@ -55,13 +55,13 @@ O chart codifica estas opções de configuração runtime do Keycloak 26.x:
 | `KC_PROXY_HEADERS=xforwarded` | values | Substitui `KC_PROXY=edge` (deprecado em 26.x) |
 | `KC_HEALTH_ENABLED=true` | values | `/health/{live,ready,started}` na port 9000 |
 | `KC_METRICS_ENABLED=true` | values | `/metrics` na port 9000 |
-| `UNIPLUS_PORTAL_CLIENT_SECRET` | ExternalSecret (Vault) | Substituído em `uniplus-realm.json` via `${VAR}` |
+| `KC_HTTP_MANAGEMENT_RELATIVE_PATH=/` | hardcoded | Isola management interface do `KC_HTTP_RELATIVE_PATH=/auth` (probes/scrape ficam em `:9000/health/*` e `:9000/metrics`) |
 
 ## Decisões de design
 
 - **Imagem stock + `start --import-realm`** (sem rebuild custom): a imagem `quay.io/keycloak/keycloak:26.6.1` traz health/metrics built-in. `start` (sem `--optimized`) deixa o Keycloak fazer auto-build na primeira inicialização — `startupProbe.failureThreshold: 60` (×10s = 10min) absorve a janela.
 - **Realm import idempotente**: `--import-realm` em 26.x **não re-importa** se o realm já existir, preservando mudanças via Admin UI. Para forçar reimport: `kc.sh import` explícito (não automático).
-- **Client secret via env substitution**: `uniplus-realm.json` declara `"secret": "${UNIPLUS_PORTAL_CLIENT_SECRET}"` — Keycloak substitui no parse com o env var setado pela ExternalSecret. Sem hardcode no Git.
+- **`uniplus-portal` é public client (SPA + PKCE)**: realm JSON declara `"publicClient": true` sem `client_secret`. Browsers não podem custodiar segredo; PKCE substitui o secret em fluxos de Authorization Code (`code_verifier` gerado pelo SPA garante a posse do code). Para futuros clients confidenciais (ex.: backend BFF, Vault UI integration #34), criar entradas separadas no realm com seus próprios secrets via Vault.
 - **Sem PV**: estado durável vive todo no Postgres. `/tmp` em emptyDir.
 - **`hostNetwork: false` por default**: workaround de #123 não é mais necessário após PR #125. Manter o flag para fallback se houver regressão.
 
@@ -69,7 +69,7 @@ O chart codifica estas opções de configuração runtime do Keycloak 26.x:
 
 - **Single-replica only neste chart**: standalone single-node = 1 réplica (correto). Para multi-DC ativo-ativo (lab/prod-{sp1,sp2}) o approach será diferente — issue separada.
 - **Federação Gov.br não implementada**: `keycloak.govbr.enabled: false` é flag inerte hoje. ADR-018 cobre o roadmap; depende deste chart estar de pé.
-- **Sem rotação automática do client secret**: rotacionar requer `kcadm.sh set-client-secret` + atualizar Vault — procedimento em `docs/RUNBOOKS.md §10`.
+- **Sem rotação automática do admin password**: procedimento manual em `docs/RUNBOOKS.md §10.4` (atualiza Vault → ESO refresh → `kcadm.sh set-password` → restart do Pod para refletir env do processo).
 
 ## Validação
 

--- a/apps/keycloak-replica/README.md
+++ b/apps/keycloak-replica/README.md
@@ -1,33 +1,90 @@
 # keycloak-replica
 
-Serviço OIDC local do Uni+.
+Serviço OIDC local do Uni+ baseado em **Keycloak 26.6.x**.
 
-> O nome do chart ainda é legado. Na arquitetura, este componente deve ser tratado como serviço OIDC local; a implementação atual usa Keycloak.
-
-> ⚠️ **Status:** placeholder inicial. Implementação dos templates pendente.
+> O nome do chart é legado (mantido para compatibilidade com o ApplicationSet existente). Na arquitetura, este componente é o serviço OIDC local de cada DC.
 
 ## Visão geral
 
-Componente da plataforma Uni+ responsável por login OIDC local em cada DC. Veja [docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md) para contexto.
+Componente da plataforma Uni+ responsável por login OIDC local em cada DC. Persiste em Postgres externo (data-host em standalone; Patroni em SP1/SP2 quando aplicável), expõe-se via Traefik IngressRoute em path `/auth/*` e provisiona o realm `uniplus` declarativamente via `--import-realm`.
+
+Ver [docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md) para o contexto arquitetural e [docs/RUNBOOKS.md §10](../../docs/RUNBOOKS.md) para procedimentos operacionais.
 
 ## Pré-requisitos
 
-- Kubernetes 1.30+
-- Helm 3.x
-- Vault + External Secrets Operator (para secrets)
+- Kubernetes 1.30+ + Helm 3.x
+- Postgres com database `keycloak` + role `keycloak` provisionados (em standalone, codificado em `scripts/bootstrap-standalone.sh::step_data_setup_postgres`)
+- Vault de aplicação inicializado, ESO `ClusterSecretStore` `vault-default` com STATUS=Valid+Ready
+- Secrets no Vault:
+  - `secret/standalone/postgres/keycloak` (fields: `host`, `port`, `database`, `username`, `password`)
+  - `secret/standalone/keycloak/admin` (fields: `username`, `password`) — bootstrap admin
+  - `secret/standalone/keycloak/clients/uniplus-portal` (field: `client_secret`)
+- cert-manager + ClusterIssuer `letsencrypt-staging` ou `letsencrypt-prod` Ready
+- Traefik Running com hostPort 80/443 (single-host) ou Service LoadBalancer (multi-DC)
 
-## Implementação pendente
+## Como o chart é aplicado
 
-- [ ] templates/deployment.yaml
-- [ ] templates/service.yaml
-- [ ] templates/ingressroute.yaml (se exposto externamente)
-- [ ] templates/configmap.yaml
-- [ ] templates/externalsecret.yaml
-- [ ] templates/networkpolicy.yaml
-- [ ] templates/servicemonitor.yaml
+`apps/keycloak-replica/` é referenciado pelo ApplicationSet `uniplus-apps` em `argocd/applicationset.yaml`. Cada cluster registrado (label `uniplus.io/managed=true`) recebe uma `Application` chamada `keycloak-replica-<release>` que aterrissa no namespace `uniplus`.
 
-Veja [apps/uniplus-web](../uniplus-web/) como referência para estrutura.
+Por padrão o chart fica **desabilitado** (`keycloak.enabled: false`). Apenas environments que explicitamente ligam (ex.: `environments/standalone/values.yaml`) sobem os recursos.
+
+## Templates entregues
+
+- `templates/deployment.yaml` — Deployment Keycloak 26.6.x com `start --import-realm`, env vars de DB/admin via secret refs, probes na management port 9000
+- `templates/service.yaml` — ClusterIP com port `http` (8080) + port `management` (9000)
+- `templates/externalsecret.yaml` — 3 ExternalSecrets (DB, bootstrap admin, client secret) consumindo `ClusterSecretStore vault-default`
+- `templates/configmap-realm.yaml` — ConfigMap com `uniplus-realm.json` montado em `/opt/keycloak/data/import/`
+- `templates/ingressroute.yaml` — Traefik IngressRoute path `/auth/*` com TLS via cert-manager
+- `templates/networkpolicy.yaml` — egress: data-host:5432, vault, DNS; ingress: Traefik (8080), Prometheus (9000)
+- `templates/servicemonitor.yaml` — scrape do `/metrics` na management port (gateado por `serviceMonitor.enabled`)
+
+## Variáveis Keycloak relevantes
+
+O chart codifica estas opções de configuração runtime do Keycloak 26.x:
+
+| Env var | Origem | Notas |
+|---|---|---|
+| `KC_DB=postgres` | values | Único vendor suportado pelo chart |
+| `KC_DB_URL_HOST/PORT/DATABASE` | values (`keycloak.database.*`) | Endpoint do Postgres externo |
+| `KC_DB_USERNAME` / `KC_DB_PASSWORD` | ExternalSecret (Vault) | `secret/.../postgres/keycloak` |
+| `KC_BOOTSTRAP_ADMIN_USERNAME/PASSWORD` | ExternalSecret (Vault) | Substitui `KEYCLOAK_ADMIN` (deprecado em 26.x) |
+| `KC_HOSTNAME` | values (`keycloak.hostname.url`) | URL completa com path (`https://example.org/auth`) — recomendado em 26.x atrás de proxy com path |
+| `KC_HOSTNAME_STRICT=true` | values | Default em prod profile |
+| `KC_HTTP_ENABLED=true` | values | TLS termina no Traefik |
+| `KC_HTTP_RELATIVE_PATH=/auth` | values | Path-routing servido por Keycloak |
+| `KC_PROXY_HEADERS=xforwarded` | values | Substitui `KC_PROXY=edge` (deprecado em 26.x) |
+| `KC_HEALTH_ENABLED=true` | values | `/health/{live,ready,started}` na port 9000 |
+| `KC_METRICS_ENABLED=true` | values | `/metrics` na port 9000 |
+| `UNIPLUS_PORTAL_CLIENT_SECRET` | ExternalSecret (Vault) | Substituído em `uniplus-realm.json` via `${VAR}` |
+
+## Decisões de design
+
+- **Imagem stock + `start --import-realm`** (sem rebuild custom): a imagem `quay.io/keycloak/keycloak:26.6.1` traz health/metrics built-in. `start` (sem `--optimized`) deixa o Keycloak fazer auto-build na primeira inicialização — `startupProbe.failureThreshold: 60` (×10s = 10min) absorve a janela.
+- **Realm import idempotente**: `--import-realm` em 26.x **não re-importa** se o realm já existir, preservando mudanças via Admin UI. Para forçar reimport: `kc.sh import` explícito (não automático).
+- **Client secret via env substitution**: `uniplus-realm.json` declara `"secret": "${UNIPLUS_PORTAL_CLIENT_SECRET}"` — Keycloak substitui no parse com o env var setado pela ExternalSecret. Sem hardcode no Git.
+- **Sem PV**: estado durável vive todo no Postgres. `/tmp` em emptyDir.
+- **`hostNetwork: false` por default**: workaround de #123 não é mais necessário após PR #125. Manter o flag para fallback se houver regressão.
+
+## Limitações conhecidas
+
+- **Single-replica only neste chart**: standalone single-node = 1 réplica (correto). Para multi-DC ativo-ativo (lab/prod-{sp1,sp2}) o approach será diferente — issue separada.
+- **Federação Gov.br não implementada**: `keycloak.govbr.enabled: false` é flag inerte hoje. ADR-018 cobre o roadmap; depende deste chart estar de pé.
+- **Sem rotação automática do client secret**: rotacionar requer `kcadm.sh set-client-secret` + atualizar Vault — procedimento em `docs/RUNBOOKS.md §10`.
+
+## Validação
+
+```bash
+# Lint local
+helm lint apps/keycloak-replica/
+
+# Render contra standalone (envs reais)
+helm template keycloak-replica apps/keycloak-replica/ \
+  -f environments/standalone/values.yaml | kubectl apply --dry-run=client -f -
+
+# Schema
+make schema-validate
+```
 
 ## Contribuindo
 
-PRs em [unifesspa-edu-br/uniplus-infra](https://github.com/unifesspa-edu-br/uniplus-infra).
+PRs em [unifesspa-edu-br/uniplus-infra](https://github.com/unifesspa-edu-br/uniplus-infra). Mudanças que tocam `environments/prod-*` exigem 2 aprovações conforme [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -29,10 +29,10 @@
     {
       "clientId": {{ .Values.keycloak.realmImport.portalClient.clientId | quote }},
       "name": "Uni+ Portal (frontend Angular)",
-      "description": "Cliente OIDC do portal institucional Uni+. Authorization Code + PKCE.",
+      "description": "Cliente OIDC do portal institucional Uni+. Public client + Authorization Code + PKCE (sem client_secret — SPAs em browser não podem custodiar segredo).",
       "enabled": true,
       "protocol": "openid-connect",
-      "publicClient": false,
+      "publicClient": true,
       "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": false,
@@ -41,7 +41,6 @@
       "rootUrl": {{ .Values.keycloak.realmImport.portalClient.rootUrl | quote }},
       "redirectUris": {{ .Values.keycloak.realmImport.portalClient.redirectUris | toJson }},
       "webOrigins": {{ .Values.keycloak.realmImport.portalClient.webOrigins | toJson }},
-      "secret": "${UNIPLUS_PORTAL_CLIENT_SECRET}",
       "attributes": {
         "pkce.code.challenge.method": "S256",
         "post.logout.redirect.uris": "+"

--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -1,0 +1,72 @@
+{
+  "realm": {{ .Values.keycloak.realmImport.realmName | quote }},
+  "displayName": "Uni+ — Sistema Unificado Unifesspa",
+  "displayNameHtml": "<b>Uni+</b> · Unifesspa",
+  "enabled": true,
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "rememberMe": true,
+  "verifyEmail": false,
+  "internationalizationEnabled": true,
+  "supportedLocales": ["pt-BR", "en"],
+  "defaultLocale": "pt-BR",
+  "sslRequired": "external",
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "browserSecurityHeaders": {
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xContentTypeOptions": "nosniff",
+    "xFrameOptions": "SAMEORIGIN",
+    "xRobotsTag": "none",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "clients": [
+    {
+      "clientId": {{ .Values.keycloak.realmImport.portalClient.clientId | quote }},
+      "name": "Uni+ Portal (frontend Angular)",
+      "description": "Cliente OIDC do portal institucional Uni+. Authorization Code + PKCE.",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "frontchannelLogout": true,
+      "rootUrl": {{ .Values.keycloak.realmImport.portalClient.rootUrl | quote }},
+      "redirectUris": {{ .Values.keycloak.realmImport.portalClient.redirectUris | toJson }},
+      "webOrigins": {{ .Values.keycloak.realmImport.portalClient.webOrigins | toJson }},
+      "secret": "${UNIPLUS_PORTAL_CLIENT_SECRET}",
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "+"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access"
+      ]
+    }
+  ],
+  "roles": {
+    "realm": [
+      { "name": "uniplus-user", "description": "Usuário autenticado básico do Uni+" },
+      { "name": "uniplus-staff", "description": "Servidor/colaborador da Unifesspa" },
+      { "name": "uniplus-admin", "description": "Administrador da plataforma Uni+" }
+    ]
+  },
+  "requiredCredentials": ["password"],
+  "passwordPolicy": "length(8)"
+}

--- a/apps/keycloak-replica/templates/_helpers.tpl
+++ b/apps/keycloak-replica/templates/_helpers.tpl
@@ -73,10 +73,6 @@ Mesmo nome serve para os outros (admin, client) com sufixo distinto.
 {{- printf "%s-bootstrap-admin" (include "keycloak-replica.fullname" .) }}
 {{- end }}
 
-{{- define "keycloak-replica.portalClientSecretName" -}}
-{{- printf "%s-client-uniplus-portal" (include "keycloak-replica.fullname" .) }}
-{{- end }}
-
 {{- define "keycloak-replica.realmConfigMapName" -}}
 {{- printf "%s-realm-uniplus" (include "keycloak-replica.fullname" .) }}
 {{- end }}

--- a/apps/keycloak-replica/templates/_helpers.tpl
+++ b/apps/keycloak-replica/templates/_helpers.tpl
@@ -1,0 +1,82 @@
+{{/*
+Helpers comuns do chart apps/keycloak-replica/.
+Usar `keycloak-replica.fullname` em todos os recursos para garantir
+consistência entre Deployment, Service, ExternalSecret, IngressRoute, etc.
+*/}}
+
+{{/*
+Nome base. Default: Release.Name (ApplicationSet gera `keycloak-replica-<cluster>`).
+Override via `nameOverride`/`fullnameOverride` (não setados por default).
+*/}}
+{{- define "keycloak-replica.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "keycloak-replica.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Labels padrão Uni+ — compostos de Helm builtin + commonLabels do values.
+Aplicar como `nindent 4` em metadata.labels.
+*/}}
+{{- define "keycloak-replica.labels" -}}
+app.kubernetes.io/name: {{ include "keycloak-replica.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels — subset estável usado em selectors (Deployment.spec.selector,
+Service.spec.selector, NetworkPolicy.spec.podSelector). NÃO incluir version/chart
+aqui — selectors são imutáveis e mudar version quebra rolling update.
+*/}}
+{{- define "keycloak-replica.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keycloak-replica.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Nome da ServiceAccount.
+*/}}
+{{- define "keycloak-replica.serviceAccountName" -}}
+{{- if .Values.keycloak.serviceAccount.create }}
+{{- default (include "keycloak-replica.fullname" .) .Values.keycloak.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.keycloak.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Nome do Secret K8s sintetizado a partir do ExternalSecret de DB credentials.
+Mesmo nome serve para os outros (admin, client) com sufixo distinto.
+*/}}
+{{- define "keycloak-replica.dbSecretName" -}}
+{{- printf "%s-db" (include "keycloak-replica.fullname" .) }}
+{{- end }}
+
+{{- define "keycloak-replica.adminSecretName" -}}
+{{- printf "%s-bootstrap-admin" (include "keycloak-replica.fullname" .) }}
+{{- end }}
+
+{{- define "keycloak-replica.portalClientSecretName" -}}
+{{- printf "%s-client-uniplus-portal" (include "keycloak-replica.fullname" .) }}
+{{- end }}
+
+{{- define "keycloak-replica.realmConfigMapName" -}}
+{{- printf "%s-realm-uniplus" (include "keycloak-replica.fullname" .) }}
+{{- end }}

--- a/apps/keycloak-replica/templates/certificate.yaml
+++ b/apps/keycloak-replica/templates/certificate.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.keycloak.enabled .Values.keycloak.ingress.enabled .Values.keycloak.ingress.tls.enabled .Values.keycloak.ingress.tls.certManager.enabled }}
+{{- $tls := .Values.keycloak.ingress.tls -}}
+{{- if not $tls.certManager.clusterIssuer -}}
+{{- fail "keycloak.ingress.tls.certManager.enabled=true exige keycloak.ingress.tls.certManager.clusterIssuer não vazio (ex.: letsencrypt-staging, letsencrypt-prod)." -}}
+{{- end -}}
+{{- if not $tls.secretName -}}
+{{- fail "keycloak.ingress.tls.certManager.enabled=true exige keycloak.ingress.tls.secretName não vazio — esse Secret recebe o cert emitido pelo cert-manager e é referenciado pelo IngressRoute." -}}
+{{- end -}}
+# Certificate cert-manager.io/v1 — emite o Secret TLS consumido pelo
+# IngressRoute. cert-manager faz HTTP-01 challenge via Traefik (single-host
+# em standalone) ou DNS-01 (multi-DC quando aterrissar). Renova
+# automaticamente 30 dias antes do expiry.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "keycloak-replica.fullname" . }}
+  labels:
+    {{- include "keycloak-replica.labels" . | nindent 4 }}
+spec:
+  secretName: {{ $tls.secretName | quote }}
+  issuerRef:
+    name: {{ $tls.certManager.clusterIssuer | quote }}
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+    - {{ .Values.keycloak.ingress.host | quote }}
+{{- end }}

--- a/apps/keycloak-replica/templates/configmap-realm.yaml
+++ b/apps/keycloak-replica/templates/configmap-realm.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.keycloak.enabled .Values.keycloak.realmImport.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "keycloak-replica.realmConfigMapName" . }}
+  labels:
+    {{- include "keycloak-replica.labels" . | nindent 4 }}
+data:
+  # Filename derivado de realmImport.realmName ({{ .Values.keycloak.realmImport.realmName }}-realm.json).
+  # Mantém consistência se o operador trocar o realm name — o ConfigMap-as-volume
+  # mount monta as keys como arquivos no diretório, então o filename observado
+  # pelo Keycloak segue a key do ConfigMap automaticamente.
+  #
+  # `tpl` expande sintaxe Helm dentro do arquivo (clientId/rootUrl/redirectUris/
+  # webOrigins vêm de .Values; o client_secret continua como ${VAR} resolvido
+  # no parse do Keycloak a partir do env var injetado pelo ExternalSecret).
+  # O arquivo NÃO é JSON puro durante a edição — render via `helm template`
+  # produz o JSON final que vai pro ConfigMap.
+  {{ .Values.keycloak.realmImport.realmName }}-realm.json: |-
+{{ tpl (.Files.Get "files/uniplus-realm.json") . | indent 4 }}
+{{- end }}

--- a/apps/keycloak-replica/templates/deployment.yaml
+++ b/apps/keycloak-replica/templates/deployment.yaml
@@ -1,0 +1,181 @@
+{{- if .Values.keycloak.enabled }}
+{{- $kc := .Values.keycloak -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "keycloak-replica.fullname" . }}
+  labels:
+    {{- include "keycloak-replica.labels" . | nindent 4 }}
+spec:
+  replicas: {{ $kc.replicas }}
+  # Single-node em standalone — Recreate evita 2 pods escrevendo no mesmo
+  # Postgres durante rolling update. Em multi-DC isso seria substituído
+  # por RollingUpdate quando o chart suportar HA (fora do escopo deste PR).
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "keycloak-replica.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "keycloak-replica.labels" . | nindent 8 }}
+      annotations:
+        # Re-cria pod quando o realm JSON muda (ConfigMap update). O checksum
+        # precisa bater com o conteúdo renderizado pelo `tpl` no ConfigMap —
+        # caso contrário, mudanças em values (clientId, redirectUris, etc.)
+        # atualizam o ConfigMap mas o annotation não muda, e o pod fica com
+        # realm staling até restart manual.
+        checksum/realm: {{ tpl (.Files.Get "files/uniplus-realm.json") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "keycloak-replica.serviceAccountName" . }}
+      {{- with $kc.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      hostNetwork: {{ $kc.hostNetwork }}
+      {{- if $kc.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+      securityContext:
+        {{- toYaml $kc.podSecurityContext | nindent 8 }}
+      containers:
+        - name: keycloak
+          image: "{{ $kc.image.registry }}/{{ $kc.image.repository }}:{{ $kc.image.tag }}"
+          imagePullPolicy: {{ $kc.image.pullPolicy }}
+          securityContext:
+            {{- toYaml $kc.containerSecurityContext | nindent 12 }}
+          # `start --import-realm`: comando recomendado para imagem stock
+          # 26.x. `start` (sem --optimized) faz auto-build na 1ª inicialização
+          # — o startupProbe absorve a janela. `--import-realm` é idempotente:
+          # pula se realm já existir, preservando mudanças via Admin UI.
+          args:
+            - "start"
+            - "--import-realm"
+          env:
+            # Database
+            - name: KC_DB
+              value: {{ $kc.database.vendor | quote }}
+            - name: KC_DB_URL_HOST
+              value: {{ $kc.database.host | quote }}
+            - name: KC_DB_URL_PORT
+              value: {{ $kc.database.port | quote }}
+            - name: KC_DB_URL_DATABASE
+              value: {{ $kc.database.name | quote }}
+            # Hostname / proxy
+            {{- if $kc.hostname.url }}
+            - name: KC_HOSTNAME
+              value: {{ $kc.hostname.url | quote }}
+            {{- end }}
+            - name: KC_HOSTNAME_STRICT
+              value: {{ $kc.hostname.strict | quote }}
+            # Hardcoded true: chart só suporta HTTP-to-Traefik (TLS termina
+            # no proxy). Setar false faria Keycloak servir só HTTPS em 8443
+            # e o IngressRoute (hardcoded httpPort/HTTP scheme) quebraria.
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            - name: KC_HTTP_PORT
+              value: {{ $kc.http.httpPort | quote }}
+            {{- if $kc.http.relativePath }}
+            - name: KC_HTTP_RELATIVE_PATH
+              value: {{ $kc.http.relativePath | quote }}
+            {{- end }}
+            # Management interface (port 9000) HERDA `KC_HTTP_RELATIVE_PATH`
+            # por default em 26.x — sem este override explícito, com
+            # KC_HTTP_RELATIVE_PATH=/auth os endpoints viram /auth/health/*
+            # e /auth/metrics, quebrando os probes do Pod (que apontam
+            # /health/*) e o scrape do ServiceMonitor (que aponta /metrics).
+            # Forçando `/` mantém management isolado do path da aplicação.
+            - name: KC_HTTP_MANAGEMENT_RELATIVE_PATH
+              value: "/"
+            {{- if $kc.http.proxyHeaders }}
+            - name: KC_PROXY_HEADERS
+              value: {{ $kc.http.proxyHeaders | quote }}
+            {{- end }}
+            # Health & metrics — endpoints expostos na management port (9000).
+            - name: KC_HEALTH_ENABLED
+              value: {{ $kc.health.enabled | quote }}
+            - name: KC_METRICS_ENABLED
+              value: {{ $kc.metrics.enabled | quote }}
+            # client_secret do uniplus-portal: a única substituição
+            # `${VAR}` no realm JSON é o secret. clientId/rootUrl/redirectUris
+            # já chegam renderizados pelo tpl no ConfigMap (suporta arrays
+            # completos, sem truncar para o primeiro elemento). O env
+            # UNIPLUS_PORTAL_CLIENT_SECRET vem do envFrom do ExternalSecret
+            # `keycloak-replica.portalClientSecretName` abaixo.
+            {{- with $kc.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            # DB credentials (KC_DB_USERNAME, KC_DB_PASSWORD).
+            - secretRef:
+                name: {{ include "keycloak-replica.dbSecretName" . }}
+            # Bootstrap admin (KC_BOOTSTRAP_ADMIN_USERNAME, _PASSWORD).
+            - secretRef:
+                name: {{ include "keycloak-replica.adminSecretName" . }}
+            # Client secret (UNIPLUS_PORTAL_CLIENT_SECRET).
+            - secretRef:
+                name: {{ include "keycloak-replica.portalClientSecretName" . }}
+          ports:
+            - name: http
+              containerPort: {{ $kc.http.httpPort }}
+              protocol: TCP
+            - name: management
+              containerPort: {{ $kc.managementPort }}
+              protocol: TCP
+          # Probes: quando `keycloak.health.enabled=true` (default), batem em
+          # /health/{started,live,ready} na management port (9000) — endpoints
+          # nativos de 26.x. Se o operador desligar o flag, fallback para
+          # `tcpSocket` na port HTTP (8080) — menos informativo mas mantém o
+          # pod funcional (sem isso, probes falhariam continuamente já que os
+          # endpoints /health não existem com KC_HEALTH_ENABLED=false).
+          startupProbe:
+            {{- if $kc.health.enabled }}
+            httpGet:
+              path: /health/started
+              port: management
+            {{- else }}
+            tcpSocket:
+              port: http
+            {{- end }}
+            failureThreshold: {{ $kc.startupProbe.failureThreshold }}
+            periodSeconds: {{ $kc.startupProbe.periodSeconds }}
+          livenessProbe:
+            {{- if $kc.health.enabled }}
+            httpGet:
+              path: /health/live
+              port: management
+            {{- else }}
+            tcpSocket:
+              port: http
+            {{- end }}
+            periodSeconds: {{ $kc.livenessProbe.periodSeconds }}
+          readinessProbe:
+            {{- if $kc.health.enabled }}
+            httpGet:
+              path: /health/ready
+              port: management
+            {{- else }}
+            tcpSocket:
+              port: http
+            {{- end }}
+            periodSeconds: {{ $kc.readinessProbe.periodSeconds }}
+          resources:
+            {{- toYaml $kc.resources | nindent 12 }}
+          volumeMounts:
+            {{- if $kc.realmImport.enabled }}
+            - name: realm-import
+              mountPath: /opt/keycloak/data/import
+              readOnly: true
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        {{- if $kc.realmImport.enabled }}
+        - name: realm-import
+          configMap:
+            name: {{ include "keycloak-replica.realmConfigMapName" . }}
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/apps/keycloak-replica/templates/deployment.yaml
+++ b/apps/keycloak-replica/templates/deployment.yaml
@@ -97,12 +97,10 @@ spec:
               value: {{ $kc.health.enabled | quote }}
             - name: KC_METRICS_ENABLED
               value: {{ $kc.metrics.enabled | quote }}
-            # client_secret do uniplus-portal: a única substituição
-            # `${VAR}` no realm JSON é o secret. clientId/rootUrl/redirectUris
-            # já chegam renderizados pelo tpl no ConfigMap (suporta arrays
-            # completos, sem truncar para o primeiro elemento). O env
-            # UNIPLUS_PORTAL_CLIENT_SECRET vem do envFrom do ExternalSecret
-            # `keycloak-replica.portalClientSecretName` abaixo.
+            # uniplus-portal é PUBLIC client (SPA Angular) + Authorization
+            # Code com PKCE — sem client_secret. clientId/rootUrl/redirectUris
+            # chegam ao realm JSON via tpl render do ConfigMap; nada precisa
+            # vir de Vault aqui.
             {{- with $kc.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -113,9 +111,6 @@ spec:
             # Bootstrap admin (KC_BOOTSTRAP_ADMIN_USERNAME, _PASSWORD).
             - secretRef:
                 name: {{ include "keycloak-replica.adminSecretName" . }}
-            # Client secret (UNIPLUS_PORTAL_CLIENT_SECRET).
-            - secretRef:
-                name: {{ include "keycloak-replica.portalClientSecretName" . }}
           ports:
             - name: http
               containerPort: {{ $kc.http.httpPort }}

--- a/apps/keycloak-replica/templates/externalsecret.yaml
+++ b/apps/keycloak-replica/templates/externalsecret.yaml
@@ -62,30 +62,4 @@ spec:
       remoteRef:
         key: {{ $eso.bootstrapAdmin.vaultPath }}
         property: {{ $eso.bootstrapAdmin.passwordKey }}
----
-# Client secret do uniplus-portal — substituído em uniplus-realm.json
-# via placeholder ${UNIPLUS_PORTAL_CLIENT_SECRET}.
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: {{ include "keycloak-replica.portalClientSecretName" . }}
-  labels:
-    {{- include "keycloak-replica.labels" . | nindent 4 }}
-spec:
-  refreshInterval: {{ $eso.refreshInterval | quote }}
-  secretStoreRef:
-    kind: {{ $eso.secretStoreRef.kind }}
-    name: {{ $eso.secretStoreRef.name }}
-  target:
-    name: {{ include "keycloak-replica.portalClientSecretName" . }}
-    creationPolicy: Owner
-    template:
-      type: Opaque
-      data:
-        UNIPLUS_PORTAL_CLIENT_SECRET: "{{ "{{" }} .clientSecret {{ "}}" }}"
-  data:
-    - secretKey: clientSecret
-      remoteRef:
-        key: {{ $eso.portalClientSecret.vaultPath }}
-        property: {{ $eso.portalClientSecret.secretKey }}
 {{- end }}

--- a/apps/keycloak-replica/templates/externalsecret.yaml
+++ b/apps/keycloak-replica/templates/externalsecret.yaml
@@ -1,0 +1,91 @@
+{{- if and .Values.keycloak.enabled .Values.keycloak.externalSecrets.enabled }}
+{{- $eso := .Values.keycloak.externalSecrets -}}
+# DB credentials — usado pelo Deployment como envFrom (KC_DB_USERNAME, KC_DB_PASSWORD).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "keycloak-replica.dbSecretName" . }}
+  labels:
+    {{- include "keycloak-replica.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $eso.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $eso.secretStoreRef.kind }}
+    name: {{ $eso.secretStoreRef.name }}
+  target:
+    name: {{ include "keycloak-replica.dbSecretName" . }}
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        # Chaves consumidas como env vars KC_DB_USERNAME / KC_DB_PASSWORD.
+        KC_DB_USERNAME: "{{ "{{" }} .username {{ "}}" }}"
+        KC_DB_PASSWORD: "{{ "{{" }} .password {{ "}}" }}"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: {{ $eso.db.vaultPath }}
+        property: {{ $eso.db.usernameKey }}
+    - secretKey: password
+      remoteRef:
+        key: {{ $eso.db.vaultPath }}
+        property: {{ $eso.db.passwordKey }}
+---
+# Bootstrap admin — usado UMA vez na primeira inicialização para criar
+# o usuário admin master. Depois é seguro deixar o secret no cluster
+# (Keycloak ignora se o admin já existir).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "keycloak-replica.adminSecretName" . }}
+  labels:
+    {{- include "keycloak-replica.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $eso.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $eso.secretStoreRef.kind }}
+    name: {{ $eso.secretStoreRef.name }}
+  target:
+    name: {{ include "keycloak-replica.adminSecretName" . }}
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        KC_BOOTSTRAP_ADMIN_USERNAME: "{{ "{{" }} .username {{ "}}" }}"
+        KC_BOOTSTRAP_ADMIN_PASSWORD: "{{ "{{" }} .password {{ "}}" }}"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: {{ $eso.bootstrapAdmin.vaultPath }}
+        property: {{ $eso.bootstrapAdmin.usernameKey }}
+    - secretKey: password
+      remoteRef:
+        key: {{ $eso.bootstrapAdmin.vaultPath }}
+        property: {{ $eso.bootstrapAdmin.passwordKey }}
+---
+# Client secret do uniplus-portal — substituído em uniplus-realm.json
+# via placeholder ${UNIPLUS_PORTAL_CLIENT_SECRET}.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "keycloak-replica.portalClientSecretName" . }}
+  labels:
+    {{- include "keycloak-replica.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $eso.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $eso.secretStoreRef.kind }}
+    name: {{ $eso.secretStoreRef.name }}
+  target:
+    name: {{ include "keycloak-replica.portalClientSecretName" . }}
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        UNIPLUS_PORTAL_CLIENT_SECRET: "{{ "{{" }} .clientSecret {{ "}}" }}"
+  data:
+    - secretKey: clientSecret
+      remoteRef:
+        key: {{ $eso.portalClientSecret.vaultPath }}
+        property: {{ $eso.portalClientSecret.secretKey }}
+{{- end }}

--- a/apps/keycloak-replica/templates/ingressroute.yaml
+++ b/apps/keycloak-replica/templates/ingressroute.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.keycloak.enabled .Values.keycloak.ingress.enabled }}
+{{- $ing := .Values.keycloak.ingress -}}
+{{- if not $ing.host -}}
+{{- fail "keycloak.ingress.enabled=true exige keycloak.ingress.host não vazio. Sobrescrever em environments/<env>/values.yaml com o FQDN público (ex.: standalone.portaluni.com.br)." -}}
+{{- end -}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "keycloak-replica.fullname" . }}
+  labels:
+    {{- include "keycloak-replica.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ $ing.entryPoint | quote }}
+  routes:
+    # Match exato do prefixo `/auth` — Keycloak serve tudo sob esse path
+    # quando KC_HTTP_RELATIVE_PATH=/auth está setado. Sem StripPrefix:
+    # Keycloak espera receber `/auth/...` no upstream.
+    - match: Host(`{{ $ing.host }}`) && PathPrefix(`{{ $ing.pathPrefix }}`)
+      kind: Rule
+      services:
+        - name: {{ include "keycloak-replica.fullname" . }}
+          port: {{ .Values.keycloak.http.httpPort }}
+  {{- if $ing.tls.enabled }}
+  tls:
+    {{- if $ing.tls.secretName }}
+    secretName: {{ $ing.tls.secretName | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/apps/keycloak-replica/templates/networkpolicy.yaml
+++ b/apps/keycloak-replica/templates/networkpolicy.yaml
@@ -1,0 +1,67 @@
+{{- if and .Values.keycloak.enabled .Values.keycloak.networkPolicy.enabled }}
+{{- $np := .Values.keycloak.networkPolicy -}}
+{{- if not $np.dataHostCIDR -}}
+{{- fail "keycloak.networkPolicy.dataHostCIDR é obrigatório quando keycloak.networkPolicy.enabled=true. Sem ele, o egress para Postgres é bloqueado pelo default-deny do NetworkPolicy (policyTypes inclui Egress) e o Pod fica em CrashLoopBackOff sem conseguir conectar ao DB. Setar para <ip>/32 do data-host em environments/<env>/values.yaml (ex.: 10.0.2.87/32 em standalone). Para desabilitar a guarda, setar networkPolicy.enabled=false." -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "keycloak-replica.fullname" . }}
+  labels:
+    {{- include "keycloak-replica.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "keycloak-replica.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Traefik consome o Service na port 8080 (HTTP).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.traefikNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.keycloak.http.httpPort }}
+    # Prometheus scrape /metrics + /health na management port (9000).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.monitoringNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.keycloak.managementPort }}
+  egress:
+    # Postgres no data-host. CIDR/porta vêm dos values do environment;
+    # ausência de dataHostCIDR é fail-fast no início do template (acima).
+    - to:
+        - ipBlock:
+            cidr: {{ $np.dataHostCIDR | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ $np.dataHostPort }}
+    # Vault — ESO em standalone alimenta os Secrets, mas o Pod do Keycloak
+    # NÃO chama o Vault diretamente (ESO é quem fala). Mantemos egress aqui
+    # apenas para cenários futuros (ex.: provider customizado lendo Vault
+    # em runtime). Em standalone single-host o serviço Vault está em
+    # 10.43.0.0/16 (cluster IP), coberto pelo egress DNS+API abaixo.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.vaultNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: 8200
+    # DNS (kube-dns) — resolução de nomes de Service, externos.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}

--- a/apps/keycloak-replica/templates/networkpolicy.yaml
+++ b/apps/keycloak-replica/templates/networkpolicy.yaml
@@ -42,18 +42,6 @@ spec:
       ports:
         - protocol: TCP
           port: {{ $np.dataHostPort }}
-    # Vault — ESO em standalone alimenta os Secrets, mas o Pod do Keycloak
-    # NÃO chama o Vault diretamente (ESO é quem fala). Mantemos egress aqui
-    # apenas para cenários futuros (ex.: provider customizado lendo Vault
-    # em runtime). Em standalone single-host o serviço Vault está em
-    # 10.43.0.0/16 (cluster IP), coberto pelo egress DNS+API abaixo.
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $np.vaultNamespace | quote }}
-      ports:
-        - protocol: TCP
-          port: 8200
     # DNS (kube-dns) — resolução de nomes de Service, externos.
     - to:
         - namespaceSelector:

--- a/apps/keycloak-replica/templates/service.yaml
+++ b/apps/keycloak-replica/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.keycloak.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "keycloak-replica.fullname" . }}
+  labels:
+    {{- include "keycloak-replica.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "keycloak-replica.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.keycloak.http.httpPort }}
+      targetPort: http
+      protocol: TCP
+    - name: management
+      port: {{ .Values.keycloak.managementPort }}
+      targetPort: management
+      protocol: TCP
+{{- end }}

--- a/apps/keycloak-replica/templates/serviceaccount.yaml
+++ b/apps/keycloak-replica/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.keycloak.enabled .Values.keycloak.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "keycloak-replica.serviceAccountName" . }}
+  labels:
+    {{- include "keycloak-replica.labels" . | nindent 4 }}
+{{- end }}

--- a/apps/keycloak-replica/templates/servicemonitor.yaml
+++ b/apps/keycloak-replica/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.keycloak.enabled .Values.keycloak.serviceMonitor.enabled .Values.keycloak.metrics.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "keycloak-replica.fullname" . }}
+  labels:
+    {{- include "keycloak-replica.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "keycloak-replica.selectorLabels" . | nindent 6 }}
+  endpoints:
+    # /metrics em 26.x mora na management port (default 9000) quando
+    # KC_METRICS_ENABLED=true e management interface ligado (ambos default
+    # com KC_HEALTH_ENABLED=true também ligado).
+    - port: management
+      path: /metrics
+      interval: {{ .Values.keycloak.serviceMonitor.interval | quote }}
+      scheme: http
+{{- end }}

--- a/apps/keycloak-replica/values.schema.json
+++ b/apps/keycloak-replica/values.schema.json
@@ -131,15 +131,7 @@
               }
             },
             "db": { "$ref": "#/$defs/vaultUserPassRef" },
-            "bootstrapAdmin": { "$ref": "#/$defs/vaultUserPassRef" },
-            "portalClientSecret": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "vaultPath": { "type": "string" },
-                "secretKey": { "type": "string" }
-              }
-            }
+            "bootstrapAdmin": { "$ref": "#/$defs/vaultUserPassRef" }
           }
         },
         "ingress": {
@@ -175,7 +167,6 @@
             "enabled": { "type": "boolean" },
             "traefikNamespace": { "type": "string" },
             "monitoringNamespace": { "type": "string" },
-            "vaultNamespace": { "type": "string" },
             "dataHostCIDR": { "type": "string" },
             "dataHostPort": { "type": "integer", "minimum": 1, "maximum": 65535 }
           }

--- a/apps/keycloak-replica/values.schema.json
+++ b/apps/keycloak-replica/values.schema.json
@@ -155,7 +155,15 @@
               "additionalProperties": false,
               "properties": {
                 "enabled": { "type": "boolean" },
-                "secretName": { "type": "string" }
+                "secretName": { "type": "string" },
+                "certManager": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "clusterIssuer": { "type": "string" }
+                  }
+                }
               }
             }
           }

--- a/apps/keycloak-replica/values.schema.json
+++ b/apps/keycloak-replica/values.schema.json
@@ -1,0 +1,239 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/unifesspa-edu-br/uniplus-infra/apps/keycloak-replica/values.schema.json",
+  "title": "keycloak-replica chart values",
+  "description": "Schema dos values do chart apps/keycloak-replica/. Valida overrides em environments/<env>/values.yaml. additionalProperties=true permite que blocos cross-chart (ex.: ingress, postgres) coexistam no mesmo values.yaml de environment sem falhar.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "commonLabels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "keycloak": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "registry": { "type": "string" },
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          }
+        },
+        "imagePullSecrets": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "replicas": { "type": "integer", "minimum": 1 },
+        "resources": { "$ref": "#/$defs/k8sResources" },
+        "hostNetwork": { "type": "boolean" },
+        "serviceAccount": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "create": { "type": "boolean" },
+            "name": { "type": "string" }
+          }
+        },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "vendor": { "type": "string", "enum": ["postgres"] },
+            "host": { "type": "string" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "name": { "type": "string" }
+          }
+        },
+        "hostname": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "url": { "type": "string" },
+            "strict": { "type": "boolean" }
+          }
+        },
+        "http": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "httpPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "relativePath": { "type": "string" },
+            "proxyHeaders": {
+              "type": "string",
+              "enum": ["forwarded", "xforwarded", ""]
+            }
+          }
+        },
+        "health": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": { "enabled": { "type": "boolean" } }
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": { "enabled": { "type": "boolean" } }
+        },
+        "managementPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "govbr": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": { "enabled": { "type": "boolean" } }
+        },
+        "realmImport": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "realmName": { "type": "string" },
+            "portalClient": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "clientId": { "type": "string" },
+                "rootUrl": { "type": "string" },
+                "redirectUris": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "webOrigins": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "externalSecrets": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "refreshInterval": { "type": "string" },
+            "secretStoreRef": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": ["ClusterSecretStore", "SecretStore"]
+                },
+                "name": { "type": "string" }
+              }
+            },
+            "db": { "$ref": "#/$defs/vaultUserPassRef" },
+            "bootstrapAdmin": { "$ref": "#/$defs/vaultUserPassRef" },
+            "portalClientSecret": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "vaultPath": { "type": "string" },
+                "secretKey": { "type": "string" }
+              }
+            }
+          }
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "entryPoint": { "type": "string" },
+            "host": { "type": "string" },
+            "pathPrefix": { "type": "string" },
+            "tls": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "secretName": { "type": "string" }
+              }
+            }
+          }
+        },
+        "networkPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "traefikNamespace": { "type": "string" },
+            "monitoringNamespace": { "type": "string" },
+            "vaultNamespace": { "type": "string" },
+            "dataHostCIDR": { "type": "string" },
+            "dataHostPort": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "interval": { "type": "string" }
+          }
+        },
+        "startupProbe": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "failureThreshold": { "type": "integer", "minimum": 1 },
+            "periodSeconds": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "livenessProbe": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "periodSeconds": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "readinessProbe": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "periodSeconds": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "podSecurityContext": { "type": "object", "additionalProperties": true },
+        "containerSecurityContext": { "type": "object", "additionalProperties": true },
+        "extraEnv": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "k8sResources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "additionalProperties": { "type": ["string", "number"] }
+        },
+        "limits": {
+          "type": "object",
+          "additionalProperties": { "type": ["string", "number"] }
+        }
+      }
+    },
+    "vaultUserPassRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "vaultPath": { "type": "string" },
+        "usernameKey": { "type": "string" },
+        "passwordKey": { "type": "string" }
+      }
+    }
+  }
+}

--- a/apps/keycloak-replica/values.yaml
+++ b/apps/keycloak-replica/values.yaml
@@ -130,9 +130,19 @@ keycloak:
     pathPrefix: /auth
     tls:
       enabled: true
-      # Quando preenchido, o Traefik usa o Secret TLS gerado pelo
-      # cert-manager (Certificate emitido com `dnsNames: [host]`).
+      # Nome do Secret TLS consumido pelo IngressRoute. Se
+      # `certManager.enabled: true`, o chart cria um `Certificate`
+      # cert-manager apontando este `secretName` para o `clusterIssuer`
+      # configurado, e o cert-manager preenche o Secret automaticamente.
+      # Se `certManager.enabled: false`, o operador deve garantir que o
+      # Secret já exista (ex.: cert manualmente emitido ou Certificate
+      # criado fora deste chart).
       secretName: ""
+      certManager:
+        # Quando true, o chart emite um `Certificate` cert-manager.io/v1
+        # com `dnsNames: [ingress.host]` apontando para `secretName`.
+        enabled: false
+        clusterIssuer: ""
 
   # NetworkPolicy. Egress liberado para data-host (Postgres), Vault e DNS.
   # Ingress permitido a partir de Traefik (HTTP) e Prometheus (management).

--- a/apps/keycloak-replica/values.yaml
+++ b/apps/keycloak-replica/values.yaml
@@ -118,9 +118,9 @@ keycloak:
       vaultPath: secret/standalone/keycloak/admin
       usernameKey: username
       passwordKey: password
-    portalClientSecret:
-      vaultPath: secret/standalone/keycloak/clients/uniplus-portal
-      secretKey: client_secret
+      # uniplus-portal é public client (SPA + PKCE) — não há client_secret
+      # para custodiar. Ver apps/keycloak-replica/files/uniplus-realm.json
+      # (`publicClient: true`).
 
   # Exposição externa via Traefik IngressRoute — TLS via cert-manager.
   ingress:
@@ -144,13 +144,14 @@ keycloak:
         enabled: false
         clusterIssuer: ""
 
-  # NetworkPolicy. Egress liberado para data-host (Postgres), Vault e DNS.
+  # NetworkPolicy. Egress liberado para data-host (Postgres) + DNS.
   # Ingress permitido a partir de Traefik (HTTP) e Prometheus (management).
+  # Pod NÃO fala diretamente com Vault — ESO sintetiza os Secrets em
+  # nome do operator e o Keycloak consome via envFrom.
   networkPolicy:
     enabled: true
     traefikNamespace: traefik
     monitoringNamespace: observability-prometheus
-    vaultNamespace: vault
     dataHostCIDR: ""
     dataHostPort: 5432
 

--- a/apps/keycloak-replica/values.yaml
+++ b/apps/keycloak-replica/values.yaml
@@ -1,22 +1,179 @@
-# Default values para o serviço OIDC local (chart legado keycloak-replica)
-# TODO: implementar conforme estrutura do uniplus-web
+# Defaults do chart apps/keycloak-replica/.
+# Cada environment (environments/<env>/values.yaml) sobrescreve apenas o
+# necessário. Por padrão o chart fica DESABILITADO — overlays que precisam
+# de Keycloak (ex.: standalone) ligam via `keycloak.enabled: true`.
 
-replicas: 2
-
-image:
-  registry: ghcr.io
-  repository: unifesspa-edu-br/keycloak-replica
-  pullPolicy: IfNotPresent
-  tag: ""
-
-resources:
-  requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 500m
-    memory: 256Mi
-
+# Labels padrão Uni+ aplicados em todos os recursos.
 commonLabels:
   app.kubernetes.io/part-of: uniplus
   app.kubernetes.io/component: auth
+
+# ============================================================================
+# Bloco principal `keycloak.*`. O nome do bloco coincide com a key já em uso
+# em environments/standalone/values.yaml (`keycloak.enabled`, `keycloak.govbr`).
+# ============================================================================
+keycloak:
+  # Liga/desliga o chart inteiro. Default false — só os ambientes que
+  # precisam de Keycloak (ex.: standalone) ligam explicitamente. Em
+  # lab/prod-{sp1,sp2} a federação institucional usa o Keycloak central
+  # do CTIC (fora deste chart).
+  enabled: false
+
+  image:
+    registry: quay.io
+    repository: keycloak/keycloak
+    # Versão upstream estável validada para 26.x (mantém alinhamento com
+    # appVersion do Chart.yaml). Bumps de patch (26.6.x) são seguros;
+    # major/minor exige checagem de migration guide.
+    tag: "26.6.1"
+    pullPolicy: IfNotPresent
+
+  imagePullSecrets: []
+
+  replicas: 1
+
+  resources:
+    requests:
+      cpu: 200m
+      memory: 768Mi
+    limits:
+      cpu: 1000m
+      memory: 1536Mi
+
+  # `hostNetwork: true` é workaround do issue #123 (pods flannel não
+  # alcançam o data-host). Após PR #125 o caminho via flannel funciona
+  # — manter false por padrão e validar empiricamente em standalone.
+  hostNetwork: false
+
+  serviceAccount:
+    create: true
+    name: ""
+
+  # Banco de dados (Postgres). Credenciais (username/password) chegam
+  # via ExternalSecret — ver bloco `externalSecrets.db` abaixo.
+  database:
+    vendor: postgres
+    host: ""
+    port: 5432
+    name: keycloak
+
+  # Hostname público com que Keycloak se identifica em URIs OIDC. Em 26.x
+  # aceita URL completa com path (recomendado quando atrás de proxy
+  # servindo sob path — `KC_HOSTNAME=https://example.org/auth`).
+  hostname:
+    url: ""
+    strict: true
+
+  # HTTP listener interno. TLS termina no Traefik — Keycloak fala HTTP
+  # em cluster. KC_HTTP_ENABLED é hardcoded como true no deployment
+  # (chart só suporta HTTP-to-Traefik; cenário HTTPS-direto exigiria
+  # cert+TLS no Pod, fora do escopo dessa topologia).
+  http:
+    httpPort: 8080
+    relativePath: /auth
+    proxyHeaders: xforwarded
+
+  # Endpoints de health/metrics na management port (9000 default em 26.x).
+  health:
+    enabled: true
+  metrics:
+    enabled: true
+  managementPort: 9000
+
+  # Federação Gov.br (Login Único) — ADR-018. Não implementado no MVP
+  # standalone; conferir o flag para que overrides existentes (ex.:
+  # standalone setando `keycloak.govbr.enabled: false`) não quebrem schema.
+  govbr:
+    enabled: false
+
+  # Realm import declarativo via `--import-realm` (idempotente em 26.x:
+  # se realm existir, importação é pulada — mudanças via Admin UI são
+  # preservadas em re-starts).
+  realmImport:
+    enabled: true
+    realmName: uniplus
+    # Client OIDC do portal — secret real chega via env var
+    # `UNIPLUS_PORTAL_CLIENT_SECRET` (ExternalSecret), substituído no
+    # JSON via placeholder `${VAR}` suportado pelo Keycloak.
+    portalClient:
+      clientId: uniplus-portal
+      rootUrl: ""
+      redirectUris: []
+      webOrigins:
+        - "+"
+
+  # ExternalSecrets — todos os secrets vivem no Vault (`secret/...`).
+  # Manifests no Git contêm apenas referências.
+  externalSecrets:
+    enabled: true
+    refreshInterval: "1h"
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: vault-default
+    db:
+      vaultPath: secret/standalone/postgres/keycloak
+      usernameKey: username
+      passwordKey: password
+    bootstrapAdmin:
+      vaultPath: secret/standalone/keycloak/admin
+      usernameKey: username
+      passwordKey: password
+    portalClientSecret:
+      vaultPath: secret/standalone/keycloak/clients/uniplus-portal
+      secretKey: client_secret
+
+  # Exposição externa via Traefik IngressRoute — TLS via cert-manager.
+  ingress:
+    enabled: false
+    entryPoint: websecure
+    host: ""
+    pathPrefix: /auth
+    tls:
+      enabled: true
+      # Quando preenchido, o Traefik usa o Secret TLS gerado pelo
+      # cert-manager (Certificate emitido com `dnsNames: [host]`).
+      secretName: ""
+
+  # NetworkPolicy. Egress liberado para data-host (Postgres), Vault e DNS.
+  # Ingress permitido a partir de Traefik (HTTP) e Prometheus (management).
+  networkPolicy:
+    enabled: true
+    traefikNamespace: traefik
+    monitoringNamespace: observability-prometheus
+    vaultNamespace: vault
+    dataHostCIDR: ""
+    dataHostPort: 5432
+
+  # ServiceMonitor — desligado até platform/observability/prometheus/
+  # aterrissar (issue #26).
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+
+  # Probes. `startupProbe` com failureThreshold alto absorve a primeira
+  # inicialização (auto-build do Keycloak quando `start` sem --optimized).
+  startupProbe:
+    failureThreshold: 60
+    periodSeconds: 10
+  livenessProbe:
+    periodSeconds: 10
+  readinessProbe:
+    periodSeconds: 5
+
+  # SecurityContext do Pod e do container. Imagem oficial
+  # quay.io/keycloak/keycloak:26.6.1 roda como UID 1000.
+  podSecurityContext:
+    fsGroup: 1000
+  containerSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    # Keycloak escreve em /opt/keycloak/data (cache, themes); read-only
+    # rootfs exigiria mounts adicionais — out of scope deste PR.
+    readOnlyRootFilesystem: false
+
+  # Env vars adicionais (lista de `{name, value}` ou `{name, valueFrom}`).
+  extraEnv: []

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1288,23 +1288,18 @@ until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep
 read -rsp "Root token: " VAULT_TOKEN; echo
 export VAULT_TOKEN
 
-# 1) Bootstrap admin — gera senha aleatória (32 bytes hex), persiste e custodia
+# Bootstrap admin — gera senha aleatória (32 bytes hex), persiste e custodia
 ADMIN_PW=$(openssl rand -hex 32)
 vault kv put secret/standalone/keycloak/admin \
   username=admin password="$ADMIN_PW"
 echo "Admin password (salvar no gestor institucional): $ADMIN_PW"
 
-# 2) Client secret do uniplus-portal — também aleatório (será setado no realm
-#    via ${VAR} substitution; rotação posterior via kcadm.sh, ver §10.4)
-CLIENT_SECRET=$(openssl rand -hex 32)
-vault kv put secret/standalone/keycloak/clients/uniplus-portal \
-  client_id=uniplus-portal client_secret="$CLIENT_SECRET"
-echo "Client secret (salvar no gestor institucional): $CLIENT_SECRET"
-
 # trap EXIT cuida de kill + unset ao sair do shell
 ```
 
-> ⚠️ **Custódia:** salvar `ADMIN_PW` e `CLIENT_SECRET` em gestor institucional (Bitwarden, 1Password, Vault corporativo). Standalone não é cofre durável — re-bootstrap via Tofu pode regenerar Shamir keys e perder estes secrets. Rotacionar via §10.4 antes de promover para hml/prod.
+> ⚠️ **Custódia:** salvar `ADMIN_PW` em gestor institucional (Bitwarden, 1Password, Vault corporativo). Standalone não é cofre durável — re-bootstrap via Tofu pode regenerar Shamir keys e perder este secret.
+>
+> O client `uniplus-portal` é **public client** (SPA Angular + Authorization Code + PKCE) — não há `client_secret` para custodiar. PKCE substitui o secret em fluxos de browser; o `code_verifier` gerado pelo SPA garante que apenas o cliente que iniciou a authorization request consegue trocar o code por tokens.
 
 ### 10.2 Verificar pod e ESO
 
@@ -1313,10 +1308,9 @@ kc() { sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "$@"; }
 
 # 1) ExternalSecrets sintetizaram os Secrets K8s
 kc get externalsecret -n uniplus
-# Esperado: 3 ESOs com STATUS=SecretSynced READY=True
+# Esperado: 2 ESOs com STATUS=SecretSynced READY=True
 #   - keycloak-replica-uniplus-standalone-db
 #   - keycloak-replica-uniplus-standalone-bootstrap-admin
-#   - keycloak-replica-uniplus-standalone-client-uniplus-portal
 
 # 2) Pod Running 1/1
 kc get pod -n uniplus -l app.kubernetes.io/name=keycloak-replica
@@ -1349,41 +1343,39 @@ xdg-open https://standalone.portaluni.com.br/auth/admin/
 #    visível em "Clients" com Authorization Code + PKCE habilitado
 ```
 
-### 10.4 Rotacionar client secret do `uniplus-portal`
+### 10.4 Rotacionar admin password (master realm)
 
-Quando necessário (comprometimento, política de rotação periódica):
+`uniplus-portal` é public client com PKCE — não tem secret pra rotacionar. Para o admin do master realm (única credencial Keycloak custodiada em Vault):
 
 ```bash
-# 1) Gerar novo secret e atualizar Vault primeiro
-NEW_SECRET=$(openssl rand -hex 32)
-vault kv put secret/standalone/keycloak/clients/uniplus-portal \
-  client_id=uniplus-portal client_secret="$NEW_SECRET"
+# 1) Gerar novo password e atualizar Vault
+NEW_ADMIN_PW=$(openssl rand -hex 32)
+vault kv put secret/standalone/keycloak/admin \
+  username=admin password="$NEW_ADMIN_PW"
 
-# 2) Forçar refresh do ExternalSecret (espera até refreshInterval=1h ou refresh imediato)
+# 2) Forçar refresh imediato do ExternalSecret (sem esperar refreshInterval=1h)
 kc annotate externalsecret -n uniplus \
-  keycloak-replica-uniplus-standalone-client-uniplus-portal \
+  keycloak-replica-uniplus-standalone-bootstrap-admin \
   force-sync="$(date +%s)" --overwrite
 
-# 3) Aplicar no Keycloak via kcadm.sh (realm-import só cria; rotação é via API).
-#    NEW_SECRET vai via stdin (here-string + `read -r` no pod) — NUNCA em argv,
-#    evitando exposure em /proc/<pid>/cmdline e a armadilha clássica de
-#    quoting (single vs. double quotes em `bash -c`). O password de admin
-#    vem do env var KC_BOOTSTRAP_ADMIN_PASSWORD que já existe no Pod
-#    (envFrom da ExternalSecret keycloak-bootstrap-admin).
+# 3) Aplicar no Keycloak via kcadm.sh — usa o admin antigo (que ainda está
+#    no env do pod via envFrom) pra autenticar e setar a nova senha. NEW_ADMIN_PW
+#    vai via stdin (here-string + read -r), nunca em argv.
 kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c '
-  read -r NEW_SECRET
+  read -r NEW_PW
   /opt/keycloak/bin/kcadm.sh config credentials \
     --server http://localhost:8080/auth --realm master \
     --user "$KC_BOOTSTRAP_ADMIN_USERNAME" --password "$KC_BOOTSTRAP_ADMIN_PASSWORD"
-  CLIENT_UUID=$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus \
-    -q clientId=uniplus-portal --fields id --format csv --noquotes | tail -1)
-  /opt/keycloak/bin/kcadm.sh update "clients/$CLIENT_UUID" -r uniplus \
-    -s "secret=$NEW_SECRET"
-' <<<"$NEW_SECRET"
-unset NEW_SECRET
+  /opt/keycloak/bin/kcadm.sh set-password -r master \
+    --username "$KC_BOOTSTRAP_ADMIN_USERNAME" --new-password "$NEW_PW"
+' <<<"$NEW_ADMIN_PW"
+unset NEW_ADMIN_PW
 
-# 4) Atualizar configuração dos consumers (apps que usam o client) — via redeploy
-#    quando os apps reais aterrissarem (Fase 5)
+# 4) Restart do Pod para que o env KC_BOOTSTRAP_ADMIN_PASSWORD reflita o
+#    novo valor (envFrom já trocou via ESO, mas o env do processo é
+#    capturado no startup — restart é necessário para próximas operações
+#    de kcadm.sh dentro do pod usarem a senha nova).
+kc rollout restart deployment -n uniplus keycloak-replica-uniplus-standalone
 ```
 
 ### 10.5 Re-importar realm (forçar replace)
@@ -1422,12 +1414,10 @@ spec:
             - /opt/keycloak/data/import/uniplus-realm.json
           envFrom:
             # DB credentials (KC_DB_USERNAME, KC_DB_PASSWORD) — Postgres no data-host.
+            # Único Secret necessário para offline import: o realm JSON foi
+            # renderizado pelo Helm no ConfigMap (clientId/rootUrl/redirectUris
+            # via tpl) e o uniplus-portal é public client (sem secret).
             - secretRef: { name: keycloak-replica-uniplus-standalone-db }
-            # client_secret do uniplus-portal — UNIPLUS_PORTAL_CLIENT_SECRET é
-            # referenciado como ${VAR} no realm JSON. Sem este envFrom, o
-            # `kc.sh import --override` substituiria o placeholder por string
-            # vazia/literal, quebrando OIDC do client após restore.
-            - secretRef: { name: keycloak-replica-uniplus-standalone-client-uniplus-portal }
           env:
             - { name: KC_DB, value: postgres }
             - { name: KC_DB_URL_HOST, value: 10.0.2.87 }

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1267,6 +1267,222 @@ EOF
 > - **Backup:** `pg_dump --format=custom keycloak` rodado periodicamente via systemd timer no data-host, output enviado para bucket MinIO (`s3://backups/postgres/<timestamp>.dump`).
 > - **Restore:** `pg_restore --clean --if-exists --no-owner --dbname=keycloak <dump>` em data-host com volume LVM intacto.
 
+## 10. Keycloak (standalone)
+
+Operações do serviço OIDC local em standalone — chart `apps/keycloak-replica/`. Pré-requisito: §9 Postgres systemd ativo no data-host + Vault unsealed + ESO `ClusterSecretStore vault-default` STATUS=Valid+Ready.
+
+### 10.1 Pré-flight: secrets no Vault
+
+Antes do ArgoCD reconciliar o chart, persistir as 3 credenciais consumidas via ExternalSecret. O Postgres já está coberto pela §9.2; falta o admin do Keycloak e o client secret do `uniplus-portal`:
+
+```bash
+# No k8s-host — port-forward + autenticação (mesmo pattern §9.2)
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault port-forward platform-vault-uniplus-standalone-0 8200:8200 \
+  > /tmp/vault-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null; unset VAULT_TOKEN VAULT_ADDR ADMIN_PW CLIENT_SECRET' EXIT
+export VAULT_ADDR=http://127.0.0.1:8200
+until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
+
+read -rsp "Root token: " VAULT_TOKEN; echo
+export VAULT_TOKEN
+
+# 1) Bootstrap admin — gera senha aleatória (32 bytes hex), persiste e custodia
+ADMIN_PW=$(openssl rand -hex 32)
+vault kv put secret/standalone/keycloak/admin \
+  username=admin password="$ADMIN_PW"
+echo "Admin password (salvar no gestor institucional): $ADMIN_PW"
+
+# 2) Client secret do uniplus-portal — também aleatório (será setado no realm
+#    via ${VAR} substitution; rotação posterior via kcadm.sh, ver §10.4)
+CLIENT_SECRET=$(openssl rand -hex 32)
+vault kv put secret/standalone/keycloak/clients/uniplus-portal \
+  client_id=uniplus-portal client_secret="$CLIENT_SECRET"
+echo "Client secret (salvar no gestor institucional): $CLIENT_SECRET"
+
+# trap EXIT cuida de kill + unset ao sair do shell
+```
+
+> ⚠️ **Custódia:** salvar `ADMIN_PW` e `CLIENT_SECRET` em gestor institucional (Bitwarden, 1Password, Vault corporativo). Standalone não é cofre durável — re-bootstrap via Tofu pode regenerar Shamir keys e perder estes secrets. Rotacionar via §10.4 antes de promover para hml/prod.
+
+### 10.2 Verificar pod e ESO
+
+```bash
+kc() { sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "$@"; }
+
+# 1) ExternalSecrets sintetizaram os Secrets K8s
+kc get externalsecret -n uniplus
+# Esperado: 3 ESOs com STATUS=SecretSynced READY=True
+#   - keycloak-replica-uniplus-standalone-db
+#   - keycloak-replica-uniplus-standalone-bootstrap-admin
+#   - keycloak-replica-uniplus-standalone-client-uniplus-portal
+
+# 2) Pod Running 1/1
+kc get pod -n uniplus -l app.kubernetes.io/name=keycloak-replica
+# Esperado: keycloak-replica-uniplus-standalone-<hash>  1/1  Running
+
+# 3) Logs limpos (sem erros DB connection, sem realm-import error)
+kc logs -n uniplus -l app.kubernetes.io/name=keycloak-replica --tail=200
+
+# 4) Probes na management port (9000) respondem
+kc exec -n uniplus -l app.kubernetes.io/name=keycloak-replica -- \
+  curl -sf http://localhost:9000/health/ready
+# Esperado: {"status": "UP", "checks": [...]}
+```
+
+### 10.3 Smoke test end-to-end
+
+Do laptop (sem precisar de SSH):
+
+```bash
+# 1) Discovery OIDC
+curl -sk https://standalone.portaluni.com.br/auth/realms/uniplus/.well-known/openid-configuration \
+  | jq '.issuer, .authorization_endpoint, .token_endpoint'
+# Esperado: issuer = "https://standalone.portaluni.com.br/auth/realms/uniplus"
+
+# 2) Admin console (UI) — aceitar warning de cert (Let's Encrypt staging)
+xdg-open https://standalone.portaluni.com.br/auth/admin/
+
+# 3) Login com admin user lido do Vault (§10.1) — realm `uniplus` deve
+#    aparecer no dropdown superior esquerdo + client `uniplus-portal`
+#    visível em "Clients" com Authorization Code + PKCE habilitado
+```
+
+### 10.4 Rotacionar client secret do `uniplus-portal`
+
+Quando necessário (comprometimento, política de rotação periódica):
+
+```bash
+# 1) Gerar novo secret e atualizar Vault primeiro
+NEW_SECRET=$(openssl rand -hex 32)
+vault kv put secret/standalone/keycloak/clients/uniplus-portal \
+  client_id=uniplus-portal client_secret="$NEW_SECRET"
+
+# 2) Forçar refresh do ExternalSecret (espera até refreshInterval=1h ou refresh imediato)
+kc annotate externalsecret -n uniplus \
+  keycloak-replica-uniplus-standalone-client-uniplus-portal \
+  force-sync="$(date +%s)" --overwrite
+
+# 3) Aplicar no Keycloak via kcadm.sh (realm-import só cria; rotação é via API).
+#    NEW_SECRET vai via stdin (here-string + `read -r` no pod) — NUNCA em argv,
+#    evitando exposure em /proc/<pid>/cmdline e a armadilha clássica de
+#    quoting (single vs. double quotes em `bash -c`). O password de admin
+#    vem do env var KC_BOOTSTRAP_ADMIN_PASSWORD que já existe no Pod
+#    (envFrom da ExternalSecret keycloak-bootstrap-admin).
+kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c '
+  read -r NEW_SECRET
+  /opt/keycloak/bin/kcadm.sh config credentials \
+    --server http://localhost:8080/auth --realm master \
+    --user "$KC_BOOTSTRAP_ADMIN_USERNAME" --password "$KC_BOOTSTRAP_ADMIN_PASSWORD"
+  CLIENT_UUID=$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus \
+    -q clientId=uniplus-portal --fields id --format csv --noquotes | tail -1)
+  /opt/keycloak/bin/kcadm.sh update "clients/$CLIENT_UUID" -r uniplus \
+    -s "secret=$NEW_SECRET"
+' <<<"$NEW_SECRET"
+unset NEW_SECRET
+
+# 4) Atualizar configuração dos consumers (apps que usam o client) — via redeploy
+#    quando os apps reais aterrissarem (Fase 5)
+```
+
+### 10.5 Re-importar realm (forçar replace)
+
+Por padrão o `--import-realm` em 26.x **pula** se o realm já existir, preservando mudanças via Admin UI. Para forçar reimport (perde mudanças não commitadas no `uniplus-realm.json`):
+
+> ⚠️ **Pré-requisito: Keycloak parado.** `kc.sh import --override` exige que **nenhum nó esteja rodando** (doc oficial Keycloak 26.x — port conflicts e state inconsistente se executado contra server live). Procedimento abaixo escala o Deployment para 0, roda um Job descartável de import, depois escala de volta.
+
+```bash
+# 1) Scale-down do Deployment + aguardar pods sumirem
+kc scale deployment -n uniplus keycloak-replica-uniplus-standalone --replicas=0
+kc wait pod -n uniplus -l app.kubernetes.io/name=keycloak-replica \
+  --for=delete --timeout=120s
+
+# 2) Job ad-hoc rodando `kc.sh import --override` offline. Mesma imagem do
+#    Deployment + envFrom dos Secrets de DB (gerados pelas ExternalSecrets)
+#    + volume com o ConfigMap do realm.
+kc apply -f - <<'EOF'
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: keycloak-import-override
+  namespace: uniplus
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: kc-import
+          image: quay.io/keycloak/keycloak:26.6.1
+          args:
+            - import
+            - --override=true
+            - --file
+            - /opt/keycloak/data/import/uniplus-realm.json
+          envFrom:
+            # DB credentials (KC_DB_USERNAME, KC_DB_PASSWORD) — Postgres no data-host.
+            - secretRef: { name: keycloak-replica-uniplus-standalone-db }
+            # client_secret do uniplus-portal — UNIPLUS_PORTAL_CLIENT_SECRET é
+            # referenciado como ${VAR} no realm JSON. Sem este envFrom, o
+            # `kc.sh import --override` substituiria o placeholder por string
+            # vazia/literal, quebrando OIDC do client após restore.
+            - secretRef: { name: keycloak-replica-uniplus-standalone-client-uniplus-portal }
+          env:
+            - { name: KC_DB, value: postgres }
+            - { name: KC_DB_URL_HOST, value: 10.0.2.87 }
+            - { name: KC_DB_URL_PORT, value: "5432" }
+            - { name: KC_DB_URL_DATABASE, value: keycloak }
+          volumeMounts:
+            - { name: realm, mountPath: /opt/keycloak/data/import, readOnly: true }
+      volumes:
+        - name: realm
+          configMap:
+            name: keycloak-replica-uniplus-standalone-realm-uniplus
+EOF
+
+# 3) Aguardar conclusão e conferir logs
+kc wait job -n uniplus keycloak-import-override \
+  --for=condition=complete --timeout=300s
+kc logs -n uniplus job/keycloak-import-override
+
+# 4) Scale-up de volta (Job é GC-removido por ttlSecondsAfterFinished=300s)
+kc scale deployment -n uniplus keycloak-replica-uniplus-standalone --replicas=1
+```
+
+### 10.6 Promover cert para Let's Encrypt prod
+
+Standalone usa `letsencrypt-staging` durante a Fase 4–6 (90d, browser warning aceitável para validação). Após smoke test completo (Fase 6 — login real do portal), promover para certificado válido:
+
+1. Em `environments/standalone/values.yaml`, alterar a key real consumida pelo chart:
+
+   ```yaml
+   keycloak:
+     ingress:
+       tls:
+         certManager:
+           clusterIssuer: letsencrypt-prod   # antes: letsencrypt-staging
+   ```
+
+2. Commit + PR. O ArgoCD reconcilia o Certificate; cert-manager renova o Secret apontado por `keycloak.ingress.tls.secretName` automaticamente (HTTP-01 via Traefik).
+3. Confirmar no cluster:
+
+   ```bash
+   kc get certificate -n uniplus keycloak-replica-uniplus-standalone -o yaml \
+     | grep -E "issuerRef|status:"
+   # Esperado: issuerRef.name=letsencrypt-prod e status.conditions.Ready=True
+   ```
+
+### 10.7 Troubleshooting
+
+| Sintoma | Diagnóstico | Fix |
+|---|---|---|
+| Pod em `CreateContainerConfigError: secret X not found` | ESO ainda não sincronizou | `kc describe externalsecret -n uniplus`; conferir Vault unsealed e `vault-default` Ready |
+| Pod Running mas `curl /auth/...` retorna 404 | `KC_HTTP_RELATIVE_PATH=/auth` faltando ou `KC_HOSTNAME` sem `/auth` no final | Validar env vars no Pod; ajustar `keycloak.hostname.url` e `keycloak.http.relativePath` no values |
+| Login redireciona pra HTTP em vez de HTTPS | `KC_PROXY_HEADERS=xforwarded` faltando ou `KC_HTTP_ENABLED=false` | Conferir env vars; Traefik deve passar `X-Forwarded-{Proto,Host,Port,Prefix}` (default em IngressRoute) |
+| Realm import falha com `Could not parse JSON` | Erro de sintaxe no `uniplus-realm.json` ou `${VAR}` referenciando env var não setada | Validar JSON localmente (`jq . files/uniplus-realm.json`); conferir se todos os `UNIPLUS_PORTAL_*` env vars existem no Pod |
+| Pod startupProbe falha após 10min | Postgres lento na 1ª conexão (cold start) ou DB inacessível | `kc logs ... --previous`; conferir `nc -zv 10.0.2.87 5432` do Pod (sem hostNetwork) |
+
 ---
 
 *Documento mantido pelo CTIC/UNIFESSPA. Atualizações via Pull Request.*

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -380,9 +380,6 @@ keycloak:
       vaultPath: secret/standalone/keycloak/admin
       usernameKey: username
       passwordKey: password
-    portalClientSecret:
-      vaultPath: secret/standalone/keycloak/clients/uniplus-portal
-      secretKey: client_secret
 
   ingress:
     enabled: true
@@ -406,7 +403,6 @@ keycloak:
     enabled: true
     traefikNamespace: traefik
     monitoringNamespace: observability-prometheus
-    vaultNamespace: vault
     # CIDR /32 do data-host. Cluster-specific — em outro standalone OCI
     # com data-host em outro IP/subnet, ajustar este valor (ver
     # environments/standalone/README.md, seção provider-specifics).

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -329,10 +329,92 @@ traefik:
 # 1 réplica, valida apenas o contrato OIDC/JWT entre frontends e APIs.
 # Federação Gov.br fica fora do escopo standalone (depende de cadastro
 # institucional do client OIDC; demos podem usar usuários locais).
+#
+# DB persiste no Postgres systemd do data-host (10.0.2.87:5432, base
+# `keycloak`, role `keycloak`) — empacotado pelo PR #127 em
+# scripts/bootstrap-standalone.sh::step_data_setup_postgres. Senha em
+# Vault `secret/standalone/postgres/keycloak`. Bootstrap admin do
+# Keycloak e client_secret do uniplus-portal também em Vault.
+#
+# Exposição: `https://standalone.portaluni.com.br/auth/*` via Traefik
+# IngressRoute (cert TLS emitido pelo cert-manager — issuer staging por
+# enquanto; trocar para `letsencrypt-prod` após smoke test pós-Fase 6).
 # ----------------------------------------------------------------------------
 keycloak:
   enabled: true
   govbr:
+    enabled: false
+
+  hostname:
+    url: https://standalone.portaluni.com.br/auth
+    strict: true
+
+  database:
+    vendor: postgres
+    host: 10.0.2.87
+    port: 5432
+    name: keycloak
+
+  realmImport:
+    enabled: true
+    realmName: uniplus
+    portalClient:
+      clientId: uniplus-portal
+      rootUrl: https://standalone.portaluni.com.br
+      redirectUris:
+        - https://standalone.portaluni.com.br/*
+      webOrigins:
+        - "+"
+
+  externalSecrets:
+    enabled: true
+    refreshInterval: "1h"
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: vault-default
+    db:
+      vaultPath: secret/standalone/postgres/keycloak
+      usernameKey: username
+      passwordKey: password
+    bootstrapAdmin:
+      vaultPath: secret/standalone/keycloak/admin
+      usernameKey: username
+      passwordKey: password
+    portalClientSecret:
+      vaultPath: secret/standalone/keycloak/clients/uniplus-portal
+      secretKey: client_secret
+
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    host: standalone.portaluni.com.br
+    pathPrefix: /auth
+    tls:
+      enabled: true
+      # Secret TLS emitido pelo cert-manager via Certificate criado pelo
+      # próprio chart (template certificate.yaml). cert-manager preenche o
+      # Secret automaticamente após HTTP-01 challenge contra o Traefik.
+      secretName: keycloak-replica-tls
+      certManager:
+        enabled: true
+        # Em standalone usamos LE staging durante validação (Fase 4-6).
+        # Promover para `letsencrypt-prod` após smoke test completo
+        # (procedimento em docs/RUNBOOKS.md §10.6).
+        clusterIssuer: letsencrypt-staging
+
+  networkPolicy:
+    enabled: true
+    traefikNamespace: traefik
+    monitoringNamespace: observability-prometheus
+    vaultNamespace: vault
+    # CIDR /32 do data-host. Cluster-specific — em outro standalone OCI
+    # com data-host em outro IP/subnet, ajustar este valor (ver
+    # environments/standalone/README.md, seção provider-specifics).
+    dataHostCIDR: 10.0.2.87/32
+    dataHostPort: 5432
+
+  # ServiceMonitor desligado até platform/observability/prometheus/ subir.
+  serviceMonitor:
     enabled: false
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Resumo

Implementa o chart Helm `apps/keycloak-replica/` (até então placeholder) como **Keycloak 26.6.1** apontando pra Postgres systemd no data-host (PR #127, Fase 3.1) e expondo `https://standalone.portaluni.com.br/auth/*` via Traefik IngressRoute.

Desbloqueia Fase 5 (apps reais consumindo OIDC) e Fase 6 (smoke test login no portal) do plano-pai, e a issue #34 (Vault UI via OIDC).

Closes #130
Refs #129, #40, #42

## O que mudou

5 commits atômicos:

1. **`feat(keycloak-replica): chart skeleton 26.6.x`** — Chart.yaml bump (`appVersion: 26.6.1`), `values.yaml` expandido com bloco `keycloak.*` (image, db, hostname/proxy, http, health/metrics, realm import, externalSecrets, ingress, networkPolicy, serviceMonitor, probes), `values.schema.json` para validação, README detalhado.
2. **`feat(keycloak-replica): Deployment + Service + ExternalSecret + realm uniplus`** — templates do core: Pod com `start --import-realm`, Service ClusterIP (8080+9000), 3 ExternalSecrets consumindo `vault-default` ClusterSecretStore (DB / bootstrap admin / client secret), ConfigMap com realm `uniplus` + client OIDC `uniplus-portal` (Authorization Code + PKCE).
3. **`feat(keycloak-replica): IngressRoute + NetworkPolicy + ServiceMonitor`** — Traefik IngressRoute em `/auth/*` com TLS via cert-manager (Certificate criado pelo próprio chart quando `ingress.tls.certManager.enabled=true`), NetworkPolicy ingress (Traefik 8080 + Prometheus 9000) + egress (data-host:5432, vault, DNS), ServiceMonitor opcional.
4. **`feat(standalone): wire Keycloak chart`** — overrides em `environments/standalone/values.yaml`: hostname URL com path, db host 10.0.2.87:5432, realm import config, ExternalSecrets paths (`secret/standalone/postgres/keycloak`, `secret/standalone/keycloak/admin`, `secret/standalone/keycloak/clients/uniplus-portal`), IngressRoute + Certificate cert-manager via `letsencrypt-staging`, NetworkPolicy CIDR 10.0.2.87/32.
5. **`docs(runbooks): §10 Keycloak standalone`** — pré-flight (gerar admin + client_secret e custodiar no Vault), verificar pod e ESO, smoke test, rotação de client secret via kcadm, re-import forçado, promoção de cert LE staging→prod, troubleshooting com 5 sintomas.

## Decisões arquiteturais

Todas pesquisadas em fontes oficiais Keycloak 26.6 (`keycloak.org/server/*`) — major refactor 25.x→26.x renomeou várias configs.

| Decisão | Escolha | Motivo |
|---|---|---|
| Imagem | `quay.io/keycloak/keycloak:26.6.1` | Última 26.x estável (abr/2026); pré-built; sem Bitnami / jboss legados |
| Comando | `start --import-realm` | Stock image faz auto-build na 1ª inicialização — `startupProbe.failureThreshold: 60` (10min) absorve a janela. `--optimized` exigiria rebuild custom da imagem |
| Bootstrap admin | `KC_BOOTSTRAP_ADMIN_USERNAME/PASSWORD` (envFrom) | Substitui `KEYCLOAK_ADMIN/_PASSWORD` deprecados em 26.x |
| Hostname | URL completa com path (`https://standalone.portaluni.com.br/auth`) + `KC_HOSTNAME_STRICT=true` + `KC_HTTP_RELATIVE_PATH=/auth` + `KC_PROXY_HEADERS=xforwarded` | Recomendado pela doc 26.x para proxy com path-based routing |
| Health/metrics | Management port 9000 (default 26.x); livenessProbe/readinessProbe/startupProbe via httpGet em `/health/{live,ready,started}` | Padrão 26.x: management interface separada da port HTTP de aplicação |
| Realm import | `--import-realm` + ConfigMap mount em `/opt/keycloak/data/import/`. Client secret via `${UNIPLUS_PORTAL_CLIENT_SECRET}` substitution (env var de ExternalSecret) | Idempotente em 26.x (skip se realm existir → preserva mudanças via Admin UI). Sem hardcode no Git |
| TLS | Certificate cert-manager.io/v1 emitido pelo chart (gateado por `tls.certManager.enabled`) | Self-contained, idempotente, renovação automática 30d antes do expiry |
| `hostNetwork` | `false` por padrão | Workaround #123 não é mais necessário após PR #125. Flag fica disponível para fallback se houver regressão |
| PV | Sem PV — state vive no Postgres; `/tmp` em emptyDir | Standalone single-replica; sem necessidade de cache durável |
| Replica strategy | `Recreate` | Single-replica; evita 2 pods escrevendo no mesmo Postgres durante rolling update |

## Validação local

```bash
make lint              # yaml-lint + helm-lint + markdownlint — 0 erros
make schema-validate   # 6 envs × 12 charts — 0 falhas
make helm-template     # render contra todos — 0 falhas

# Manifest-validate equivalente ao CI (kubeconform + RFC 1123)
for env in lab-sp1 lab-sp2 lab-pa1 prod-sp1 prod-sp2 prod-pa1 standalone; do
  helm template keycloak-replica apps/keycloak-replica/ \
    -f environments/$env/values.yaml > /tmp/r.yaml && \
  kubeconform -strict -ignore-missing-schemas /tmp/r.yaml >/dev/null && \
  python3 scripts/validate-rfc1123.py /tmp/r.yaml >/dev/null && \
  echo "✓ $env"
done
# 7/7 ✓
```

Render contra **standalone**: 10 manifests (1 ServiceAccount, 1 ConfigMap, 3 ExternalSecret, 1 Service, 1 Deployment, 1 IngressRoute, 1 NetworkPolicy, 1 Certificate). Render contra **lab/prod-{sp1,sp2,pa1}**: 0 manifests (chart `keycloak.enabled: false` por padrão).

## Test plan (cluster, pós-merge)

- [ ] Custódia: rodar `docs/RUNBOOKS.md §10.1` para popular `secret/standalone/keycloak/{admin,clients/uniplus-portal}` no Vault
- [ ] ArgoCD sync da Application `keycloak-replica-uniplus-standalone` Synced+Healthy
- [ ] 3 ExternalSecrets STATUS=SecretSynced READY=True
- [ ] Pod Running 1/1; logs limpos (sem erros DB connection, sem realm-import error)
- [ ] `kubectl exec ... -- curl -sf http://localhost:9000/health/ready` retorna 200
- [ ] `curl -sk https://standalone.portaluni.com.br/auth/realms/uniplus/.well-known/openid-configuration` retorna JSON válido com `issuer: https://standalone.portaluni.com.br/auth/realms/uniplus`
- [ ] Browser → `https://standalone.portaluni.com.br/auth/admin/` carrega login screen + admin credentials funcionam
- [ ] Realm `uniplus` + client `uniplus-portal` visíveis no Admin Console

## Riscos

- **Cert LE staging**: browser warning aceitável durante validação (Fase 4-6); promover para prod só após smoke test completo (`docs/RUNBOOKS.md §10.6`)
- **Idempotência do realm import**: `--import-realm` em 26.x **não re-importa** se realm existir, preservando mudanças via Admin UI. Mudanças no `uniplus-realm.json` que precisem ser aplicadas em realm já criado exigem `kc.sh import --override=true` (procedimento §10.5)
- **Postgres lento na 1ª conexão**: `startupProbe.failureThreshold: 60` × `periodSeconds: 10` = 10min absorvem cold-start + auto-build do Keycloak

Não toca `environments/prod-*` — política de revisão padrão (1 aprovação humana + Codex).
