### PR TITLE
feat(standalone): Redis 8.6.3 systemd no data-host

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1473,6 +1473,199 @@ Standalone usa `letsencrypt-staging` durante a Fase 4–6 (90d, browser warning 
 | Realm import falha com `Could not parse JSON` | Erro de sintaxe no `uniplus-realm.json` ou `${VAR}` referenciando env var não setada | Validar JSON localmente (`jq . files/uniplus-realm.json`); conferir se todos os `UNIPLUS_PORTAL_*` env vars existem no Pod |
 | Pod startupProbe falha após 10min | Postgres lento na 1ª conexão (cold start) ou DB inacessível | `kc logs ... --previous`; conferir `nc -zv 10.0.2.87 5432` do Pod (sem hostNetwork) |
 
+## 11. Redis (standalone)
+
+Cache local — `redis:8.6.3-alpine` em container Docker gerenciado por systemd no data-host (`10.0.2.87:6379`). Pré-requisito: §9 Postgres systemd ativo (mesmo data-host) + Vault unsealed para custódia da senha.
+
+### 11.1 Redis 8.6.3 — bootstrap automatizado
+
+A função `step_data_setup_redis` em `scripts/bootstrap-standalone.sh` provisiona, na ordem:
+
+1. Diretórios `/var/lib/uniplus/redis/data` (mode `750`, owner `999:1000` — uid `redis` no container `redis:8.6.3-alpine`) e `/etc/uniplus-redis/` (mode `755`, owner `root:root` — traversável pelo uid 999 do container; confidencialidade dos arquivos é via mode dos próprios files).
+2. `.bootstrap-creds` (root:root 600) em `/var/lib/uniplus/redis/.bootstrap-creds` com `default_pw` (256 bits via `openssl rand -hex 32`) — gerado **somente na primeira execução**.
+3. ACL file `/etc/uniplus-redis/users.acl` (mode `600`, owner `999:1000`) — sempre regerado a partir de `default_pw` lido do `.bootstrap-creds`. Conteúdo: `user default on >$pw ~* &* +@all`.
+4. Config `/etc/uniplus-redis/redis.conf` (mode `644`, owner `root:root` — sem segredos, conf é legível para auditoria) com `bind 10.0.2.87 127.0.0.1 -::1`, `protected-mode yes`, `aclfile /usr/local/etc/redis/users.acl`, AOF (`appendfsync everysec`) + RDB (`save 3600 1 300 100 60 10000`), `maxmemory 2gb` `allkeys-lru`.
+5. `systemd` unit `/etc/systemd/system/uniplus-redis.service` com `Restart=always`, container em `--network host` (Redis listen em `10.0.2.87:6379`), config dir mounted **read-only** (`-v /etc/uniplus-redis:/usr/local/etc/redis:ro`).
+
+**Diferença vs Postgres (§9.1):** o ACL file **persiste** entre runs (redis-server lê em todo startup), enquanto o init SQL do Postgres é efêmero (executado uma vez pelo entrypoint, depois shredded). O ACL contém o cleartext da senha — proteção é via mode `600` + owner uid do container; visibilidade limitada a quem tem `sudo` no data-host. `ACL SAVE` / `CONFIG REWRITE` no container são noop por o mount ser read-only — fonte da verdade da senha continua sendo `.bootstrap-creds` + Vault.
+
+**Idempotência:**
+
+- `.bootstrap-creds`: preserva se existe; gera se ausente; aborta se ACL file já existe sem `.bootstrap-creds` (regenerar produziria mismatch entre ACL ativo e Vault — apps autenticando via Vault falhariam).
+- ACL file + redis.conf: sempre re-aplicados (cheap; redis-server faz reload na próxima inicialização).
+- systemd unit: sempre re-aplicado.
+- Serviço já ativo: bootstrap não reinicia (evita downtime).
+
+**Verificação imediata pós-bootstrap (no data-host):**
+
+```bash
+sudo systemctl status uniplus-redis
+sudo docker exec -i uniplus-redis sh -c 'read -r P; REDISCLI_AUTH="$P" redis-cli ping' \
+  <<<"$(sudo grep ^default_pw= /var/lib/uniplus/redis/.bootstrap-creds | cut -d= -f2)"
+# Esperado: PONG
+sudo docker exec -i uniplus-redis sh -c \
+  'read -r P; REDISCLI_AUTH="$P" redis-cli info persistence' \
+  <<<"$(sudo grep ^default_pw= /var/lib/uniplus/redis/.bootstrap-creds | cut -d= -f2)" \
+  | grep -E '^(aof_enabled|rdb_last_save_time):'
+# Esperado: aof_enabled:1
+```
+
+### 11.2 Custódia da senha inicial
+
+> ⚠️ **CRÍTICO.** O `.bootstrap-creds` é o **único rastro fora do ACL file** da senha gerada. Custodiar imediatamente em gestor institucional + Vault standalone, depois `shred -u` o arquivo.
+
+**Passo 1 — Ler senha no data-host:**
+
+```bash
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87
+sudo cat /var/lib/uniplus/redis/.bootstrap-creds
+# default_pw=<64 hex>
+```
+
+**Passo 2 — Salvar `default_pw` no Vault standalone (executar do k8s-host):**
+
+> Mesmo padrão de higiene da §9.2 (port-forward + token via env do shell, não argv).
+
+```bash
+read -rsp "Cole default_pw (do passo 1): " RED_PW; echo
+
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault port-forward platform-vault-uniplus-standalone-0 8200:8200 \
+  > /tmp/vault-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null; unset RED_PW VAULT_TOKEN VAULT_ADDR' EXIT
+export VAULT_ADDR=http://127.0.0.1:8200
+until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
+
+read -rsp "Root token: " VAULT_TOKEN; echo
+export VAULT_TOKEN
+
+vault kv put secret/standalone/redis/default \
+  host=10.0.2.87 \
+  port=6379 \
+  username=default \
+  password="$RED_PW"
+
+vault kv get secret/standalone/redis/default
+# Esperado: campos host/port/username/password presentes
+```
+
+**Passo 3 — Limpar `.bootstrap-creds` no data-host:**
+
+```bash
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87
+sudo shred -u /var/lib/uniplus/redis/.bootstrap-creds
+```
+
+> ⚠️ Após `shred -u`, re-execução do bootstrap **abortaria** com mensagem apontando §11.4 (ACL file persiste, mas não há mais como regenerá-lo sem fonte da senha). Restaurar `.bootstrap-creds` a partir do Vault antes de re-executar.
+
+### 11.3 Validação end-to-end (pod K8s → Redis)
+
+Confirma que pods do cluster K3s alcançam o Redis no data-host via TCP. Pré-requisito: PR #125 aplicado (iptables FORWARD ACCEPT entre flannel CIDR e VCN).
+
+**Executar no k8s-host:**
+
+```bash
+# 1) Conectividade TCP bruta
+nc -zv 10.0.2.87 6379
+# Esperado: succeeded
+
+# 2) Ler senha — fail fast se não disponível
+REDIS_PW=$(ssh ubuntu@10.0.2.87 \
+  "sudo grep default_pw= /var/lib/uniplus/redis/.bootstrap-creds 2>/dev/null | cut -d= -f2")
+if [ -z "$REDIS_PW" ]; then
+  echo "ERRO: default_pw não encontrado em .bootstrap-creds no data-host." >&2
+  echo "  - Se .bootstrap-creds foi shredded (§11.2), restaure via §11.4 antes" >&2
+  echo "    OU cole a senha manualmente: read -rsp 'default_pw: ' REDIS_PW; echo" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# 3) Pod ad-hoc com redis-cli (sem hostNetwork — usa flannel).
+#    Senha via stdin → REDISCLI_AUTH (mesmo padrão §9.3 com PGPASSWORD)
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml run redis-validation \
+  --image=redis:8.6.3-alpine --restart=Never --rm -i --command -- \
+  sh -c 'read -r PW; REDISCLI_AUTH="$PW" redis-cli -h 10.0.2.87 ping' \
+  <<<"$REDIS_PW"
+# Esperado: PONG
+unset REDIS_PW
+```
+
+Se o pod fica preso em `Pending` ou retorna `Connection refused`: revisar §8.6/§8.7 do plano-pai (#123) e confirmar que `iptables -L FORWARD` no k8s-host mostra os ACCEPTs flannel↔VCN antes do `REJECT --reject-with icmp-host-prohibited`.
+
+### 11.4 Restore: re-criar `.bootstrap-creds` a partir do Vault
+
+Caso o operador tenha rodado `shred -u` (§11.2) e precise re-executar o bootstrap (ou recuperar a senha localmente para troubleshooting), recriar o arquivo a partir do Vault:
+
+```bash
+# No k8s-host — port-forward + leitura do secret (mesmo pattern §9.4)
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault port-forward platform-vault-uniplus-standalone-0 8200:8200 \
+  > /tmp/vault-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null; unset RED_PW VAULT_TOKEN VAULT_ADDR' EXIT
+export VAULT_ADDR=http://127.0.0.1:8200
+until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
+
+read -rsp "Root token: " VAULT_TOKEN; echo
+export VAULT_TOKEN
+
+RED_PW=$(vault kv get -field=password secret/standalone/redis/default)
+
+# Transmitir para o data-host via stdin do ssh — não cruza argv
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87 \
+  "sudo tee /var/lib/uniplus/redis/.bootstrap-creds > /dev/null && \
+   sudo chmod 600 /var/lib/uniplus/redis/.bootstrap-creds && \
+   sudo chown root:root /var/lib/uniplus/redis/.bootstrap-creds" <<EOF
+default_pw=$RED_PW
+EOF
+```
+
+**Após reconstituir `.bootstrap-creds`:** rodar `./scripts/bootstrap-standalone.sh --role=standalone-data` no data-host. O bootstrap regenera o ACL file a partir do `default_pw` recém-restaurado e re-aplica config/unit. Se o serviço estava ativo, não reinicia — o ACL novo só passa a valer no próximo restart manual (`sudo systemctl restart uniplus-redis`) ou após `redis-cli ACL LOAD` via container.
+
+### 11.5 Rotacionar `default_pw`
+
+```bash
+# 1) Gerar nova senha + atualizar Vault (k8s-host)
+NEW_PW=$(openssl rand -hex 32)
+vault kv put secret/standalone/redis/default \
+  host=10.0.2.87 port=6379 username=default password="$NEW_PW"
+
+# 2) Reconstituir .bootstrap-creds via §11.4 com o NEW_PW
+
+# 3) Re-rodar bootstrap (regenera ACL file)
+ssh ubuntu@10.0.2.87 "cd ~/uniplus-infra && ./scripts/bootstrap-standalone.sh --role=standalone-data"
+
+# 4) Aplicar a nova ACL no Redis em runtime (sem restart):
+ssh ubuntu@10.0.2.87 "sudo docker exec -i uniplus-redis sh -c \
+  'read -r P; REDISCLI_AUTH=\"\$P\" redis-cli ACL LOAD' \
+  <<<\"\$(sudo grep ^default_pw= /var/lib/uniplus/redis/.bootstrap-creds | cut -d= -f2)\""
+# Esperado: OK
+
+unset NEW_PW
+```
+
+> ⚠️ Apps consumidoras (Fase 5) que cacheiem a senha em ConfigMap/env precisam restart após rotação — o ESO refresh é assíncrono (default `refreshInterval=1h`); forçar via `kc annotate externalsecret ... force-sync="$(date +%s)" --overwrite`.
+
+### 11.6 Backup e Restore
+
+> Procedimento detalhado em sub-task da Story #118 (paralelo aos backups Postgres). Resumo:
+>
+> - **Backup:** AOF rewrite + cópia do `appendonlydir/` para bucket MinIO (`s3://backups/redis/<timestamp>/`) via systemd timer no data-host.
+> - **Restore:** parar `uniplus-redis`, restaurar `appendonlydir/` em `$DATA_BASE/redis/data/`, ajustar ownership `999:1000`, iniciar serviço.
+>
+> Em standalone, perda de Redis é **aceitável** — cache, não fonte da verdade. Aplicações reconstroem state a partir do Postgres no próximo cold path.
+
+### 11.7 Troubleshooting
+
+| Sintoma | Diagnóstico | Fix |
+|---|---|---|
+| `WRONGPASS invalid username-password` no log do app | Senha no app desatualizada vs Vault, ou ACL file e Vault desincronizados | Conferir `vault kv get secret/standalone/redis/default` vs `default_pw` em `.bootstrap-creds`; se mismatch, executar §11.5 |
+| Container reinicia em loop com `Configuration loading: ACL file not readable` | Ownership do `users.acl` ≠ `999:1000` ou mode ≠ `600` (uid 999 do container precisa ser owner) | `sudo chown 999:1000 /etc/uniplus-redis/users.acl && sudo chmod 600 /etc/uniplus-redis/users.acl` |
+| `DENIED Redis is running in protected mode` | `bind` ausente em `redis.conf` ou ACL file vazio | Validar `redis.conf` mounted contém `bind` + `aclfile`; re-executar bootstrap |
+| `nc -zv 10.0.2.87 6379` succeeded mas `redis-cli` retorna `Could not connect to Redis: Connection reset` | iptables FORWARD ainda dropando flannel→VCN ou app pod usa IP errado | `kc exec` no pod e testar `nc -zv 10.0.2.87 6379` direto; conferir resultado do bloco §11.3 |
+| AOF cresce indefinidamente | `auto-aof-rewrite-percentage 100` não dispara (default mas pode ter sido desligado em config customizada) | `redis-cli BGREWRITEAOF`; revisar `redis.conf` |
+| OOM kills do container | `maxmemory 2gb` excedido ou cgroup limit do host menor | `redis-cli INFO memory`; ajustar `maxmemory` em `redis.conf` ou liberar memória no host |
+
 ---
 
 *Documento mantido pelo CTIC/UNIFESSPA. Atualizações via Pull Request.*

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -846,6 +846,237 @@ UNIT
     fi
 }
 
+# Configura Redis 8.6.3 como container Docker gerenciado por systemd no data-host.
+#
+# UID/GID do container: 999:1000 (redis:8.6.3-alpine — confirmado por
+# `docker run --rm redis:8.6.3-alpine id redis`). Diferente do Postgres alpine
+# (uid 70), e diferente da convenção 999:999 das imagens Debian-based.
+#
+# Auth: ACL file (`user default on >password ~* &* +@all`) montado read-only
+# em `/usr/local/etc/redis/users.acl`. Senha 256 bits (openssl rand -hex 32),
+# custodiada via .bootstrap-creds + Vault (mesmo padrão Postgres §9.2).
+#
+# Idempotência (decisões independentes):
+#   - .bootstrap-creds: preserva se existe, gera se ausente, aborta se ACL file
+#     já existe sem .bootstrap-creds (regenerar produziria mismatch entre ACL
+#     file e Vault).
+#   - ACL file + redis.conf: sempre re-aplicados (redis-server lê em startup).
+#   - systemd unit: sempre re-aplicado (cheap, corrige drift).
+#   - Serviço já ativo: não reinicia (evita downtime em re-runs).
+#
+# Persistência híbrida AOF (appendfsync everysec) + RDB snapshots — pattern
+# recomendado em 8.x para balance latência/durabilidade.
+step_data_setup_redis() {
+    # Honra --skip-docker (mesmo guard de step_data_setup_postgres). Sem este,
+    # --skip-docker mutaria diretórios e EnvironmentFile e falharia tarde aqui.
+    if $SKIP_DOCKER && ! command -v docker &>/dev/null; then
+        log_warn "Docker indisponível e --skip-docker ativo — pulando setup do Redis."
+        return
+    fi
+
+    log_info "Configurando Redis 8.6.3 systemd..."
+
+    local creds_file="$DATA_BASE/redis/.bootstrap-creds"
+    local conf_dir="/etc/uniplus-redis"
+    local redis_conf="$conf_dir/redis.conf"
+    local acl_file="$conf_dir/users.acl"
+    local unit_file="/etc/systemd/system/uniplus-redis.service"
+
+    # Diretórios + ownership:
+    #   - $DATA_BASE/redis/data: 999:1000 mode 750 (data dir do container,
+    #     contém AOF + RDB). O entrypoint do redis:8-alpine roda como root
+    #     inicialmente, faz fix_data_dir_perms (chown redis + chmod u+rw nos
+    #     RDB/appendonlydir), e dropa privs para uid 999 via setpriv. Pré-set
+    #     999:1000 evita warnings do entrypoint.
+    #   - /etc/uniplus-redis/: 755 root:root (config dir no host). Precisa ser
+    #     traversável pelo uid 999 para que o redis-server (após drop de privs
+    #     via setpriv no entrypoint) consiga abrir os arquivos mounted em
+    #     /usr/local/etc/redis/. Mode 700 root:root bloqueia traverse e quebra
+    #     o startup (Codex P1 round 1). A confidencialidade vem do mode dos
+    #     próprios arquivos: redis.conf 644 root:root (sem segredos, legível
+    #     para auditoria) e users.acl 600 chown 999:1000 (cleartext da senha
+    #     legível apenas pelo redis-server). Mounted read-only no container,
+    #     então ACL SAVE / CONFIG REWRITE NÃO funcionam (acl_file é regenerado
+    #     pelo bootstrap a partir do .bootstrap-creds — fonte da verdade).
+    run "sudo mkdir -p $DATA_BASE/redis/data $conf_dir"
+    run "sudo chown 999:1000 $DATA_BASE/redis/data"
+    run "sudo chmod 750 $DATA_BASE/redis/data"
+    run "sudo chown root:root $conf_dir"
+    run "sudo chmod 755 $conf_dir"
+
+    # Detectar inicialização prévia: presença do ACL file no host indica que
+    # um run anterior gerou credenciais. AOF/RDB no data dir são proxy mais
+    # fraco — em um restore com data dir vazio + ACL file ainda presente, o
+    # ACL é o que define a senha aceita pelo Redis em startup.
+    local already_initialized=false
+    if ! $DRY_RUN && sudo test -f "$acl_file" 2>/dev/null; then
+        already_initialized=true
+    fi
+
+    # ---- Decisão 1: .bootstrap-creds (preservar / gerar / abortar) ----
+    if sudo test -f "$creds_file" 2>/dev/null; then
+        log_success "Bootstrap creds Redis já existentes — preservando senha."
+    elif $DRY_RUN; then
+        log_warn "Dry-run: senha Redis seria gerada em $creds_file"
+    elif $already_initialized; then
+        # Guard: ACL file existe mas .bootstrap-creds foi shredded sem custódia.
+        # Regenerar agora produziria senha nova no Vault diferente da senha
+        # ativa no ACL file — apps consumidoras (Fase 5) leriam Vault e
+        # falhariam autenticando.
+        log_error "$creds_file ausente, mas $acl_file já existe."
+        log_error "Regenerar senha agora produziria mismatch entre ACL file e Vault."
+        log_error "Restaure $creds_file a partir do Vault — ver docs/RUNBOOKS.md §11.4."
+        exit 1
+    else
+        log_info "Gerando senha Redis (256 bits)..."
+        local default_pw
+        default_pw=$(openssl rand -hex 32)
+        sudo tee "$creds_file" >/dev/null <<EOF
+default_pw=$default_pw
+EOF
+        sudo chown root:root "$creds_file"
+        sudo chmod 600 "$creds_file"
+        log_warn "Senha gerada em $creds_file. Custódia obrigatória — ver runbook §11.2."
+    fi
+
+    # ---- Decisão 2: ACL file (sempre regerado a partir da senha custodiada) ----
+    # Diferente do Postgres init SQL (efêmero, shredded após primeira inicialização),
+    # o ACL file PERSISTE — redis-server lê em todo startup e reload. Não há
+    # rastro extra: a senha vive em .bootstrap-creds (até custódia + shred) e no
+    # ACL file (cifrada como hash SHA256 internamente, mas o file contém o
+    # cleartext até o redis re-escrever em ACL SAVE — que aqui é noop por mount
+    # read-only). Trade-off aceito: ACL file é root:root 600 no filesystem
+    # do host; visibilidade limitada a quem tem sudo no data-host.
+    if $DRY_RUN; then
+        log_warn "Dry-run: ACL file seria escrito em $acl_file"
+    elif sudo test -f "$creds_file" 2>/dev/null; then
+        local pw
+        pw=$(sudo grep '^default_pw=' "$creds_file" | cut -d= -f2)
+        if [[ -z "$pw" ]]; then
+            log_error "default_pw vazio em $creds_file — não posso (re)gerar ACL file."
+            exit 1
+        fi
+        # Heredoc unquoted permite expansão de $pw. Senha hex-only (openssl
+        # rand -hex 32), sem metacaracteres ACL — segura na linha do user.
+        sudo tee "$acl_file" >/dev/null <<EOF
+user default on >$pw ~* &* +@all
+EOF
+        sudo chown 999:1000 "$acl_file"
+        sudo chmod 600 "$acl_file"
+        unset pw
+    fi
+
+    # redis.conf (sempre re-aplicado). Heredoc single-quoted preserva conteúdo
+    # literal — paths são hardcoded para alinhar com $DATA_BASE/$conf_dir.
+    # Permissão 644 root:root: o conf NÃO contém segredos (a senha vive no
+    # users.acl). Manter o conf legível pelo grupo geral simplifica auditoria
+    # operacional sem leak. Diverge intencionalmente do users.acl, que continua
+    # 600 chown 999:1000 — defesa em camadas (owner restrito + mode restrito)
+    # apropriada quando o arquivo carrega cleartext da senha.
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Escreveria $redis_conf"
+    else
+        sudo tee "$redis_conf" >/dev/null <<'CONF'
+# Listeners — bind explícito (protected-mode default `yes` em 7+ exige
+# bind + auth; sem bind o redis recusa conexões não-loopback)
+bind 10.0.2.87 127.0.0.1 -::1
+port 6379
+protected-mode yes
+
+# Auth via ACL file (mounted read-only no container)
+aclfile /usr/local/etc/redis/users.acl
+
+# Persistência híbrida AOF + RDB
+appendonly yes
+appendfsync everysec
+appendfilename "appendonly.aof"
+# RDB snapshots: dump se ≥ 1 chave em 1h, ≥ 100 em 5min, ≥ 10000 em 1min
+save 3600 1 300 100 60 10000
+
+# Memory cap — data-host tem 16GB; deixa margem para Postgres + futuros services
+maxmemory 2gb
+maxmemory-policy allkeys-lru
+
+# Data dir (mount /data dentro do container)
+dir /data
+
+# Logging para stdout (capturado por journalctl via systemd)
+logfile ""
+loglevel notice
+CONF
+        sudo chown root:root "$redis_conf"
+        sudo chmod 644 "$redis_conf"
+    fi
+
+    # systemd unit (sempre re-aplicado). Heredoc single-quoted: paths hardcoded.
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Escreveria $unit_file"
+    else
+        sudo tee "$unit_file" >/dev/null <<'UNIT'
+[Unit]
+Description=Uni+ Redis 8.6.3 (standalone data-host)
+Documentation=https://github.com/unifesspa-edu-br/uniplus-infra/blob/main/docs/RUNBOOKS.md
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10
+TimeoutStartSec=120
+
+ExecStartPre=-/usr/bin/docker rm -f uniplus-redis
+ExecStart=/usr/bin/docker run --rm --name uniplus-redis \
+  --network host \
+  -v /var/lib/uniplus/redis/data:/data \
+  -v /etc/uniplus-redis:/usr/local/etc/redis:ro \
+  redis:8.6.3-alpine \
+  redis-server /usr/local/etc/redis/redis.conf
+
+ExecStop=/usr/bin/docker stop -t 30 uniplus-redis
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+    fi
+
+    run "sudo systemctl daemon-reload"
+    run "sudo systemctl enable uniplus-redis"
+
+    if $DRY_RUN; then
+        echo "[DRY-RUN] systemctl start uniplus-redis + smoke test PING/PONG"
+    elif sudo systemctl is-active --quiet uniplus-redis; then
+        log_success "uniplus-redis já ativo — preservando state (sem restart)."
+    else
+        sudo systemctl start uniplus-redis
+        log_info "Aguardando Redis aceitar conexões..."
+        local pw
+        pw=$(sudo grep '^default_pw=' "$creds_file" | cut -d= -f2)
+        if [[ -z "$pw" ]]; then
+            log_error "default_pw vazio em $creds_file — não consigo validar PING."
+            exit 1
+        fi
+        # Senha via stdin (`<<<` + `read -r` no shell do container) — NÃO em
+        # argv. `docker exec -i` conecta stdin local ao stdin do processo
+        # remoto; REDISCLI_AUTH é env var do redis-cli (forma oficial de
+        # passar senha sem cmdline exposure). Mesmo padrão de §9.3 do runbook.
+        local attempts=0
+        until sudo docker exec -i uniplus-redis sh -c \
+                'read -r PW; REDISCLI_AUTH="$PW" redis-cli ping' \
+                <<<"$pw" 2>/dev/null | grep -q PONG; do
+            attempts=$(( attempts + 1 ))
+            if (( attempts >= 12 )); then
+                log_error "Redis não respondeu PONG em 60s. Ver: sudo journalctl -u uniplus-redis -n 50"
+                exit 1
+            fi
+            sleep 5
+        done
+        log_success "uniplus-redis ativo + PING/PONG OK."
+        unset pw
+    fi
+}
+
 summary_data() {
     echo ""
     echo "============================================"
@@ -859,23 +1090,30 @@ summary_data() {
     echo "  $DATA_BASE/vault     ← $DISK_VAULT    (LVM vg-vault)"
     echo "  $DATA_BASE/redis     (disco local)"
     echo ""
-    echo "Postgres 18 systemd:"
+    echo "Data services systemd:"
     echo "  systemctl status uniplus-postgres"
+    echo "  systemctl status uniplus-redis"
     echo ""
-    echo "Custódia das senhas iniciais (PRIMEIRA EXECUÇÃO — ver runbook §9.2):"
-    echo "  1. Ler senhas:    sudo cat $DATA_BASE/postgres/.bootstrap-creds"
-    echo "  2. Salvar no gestor institucional + Vault standalone"
-    echo "     (kubectl exec no k8s-host → vault kv put secret/standalone/postgres/keycloak)"
-    echo "  3. Após custódia: sudo shred -u $DATA_BASE/postgres/.bootstrap-creds"
+    echo "Custódia das senhas iniciais (PRIMEIRA EXECUÇÃO):"
+    echo "  Postgres — runbook §9.2:"
+    echo "    1. Ler:        sudo cat $DATA_BASE/postgres/.bootstrap-creds"
+    echo "    2. Custodiar:  Vault (secret/standalone/postgres/keycloak) + gestor institucional"
+    echo "    3. Limpar:     sudo shred -u $DATA_BASE/postgres/.bootstrap-creds"
+    echo "  Redis — runbook §11.2:"
+    echo "    1. Ler:        sudo cat $DATA_BASE/redis/.bootstrap-creds"
+    echo "    2. Custodiar:  Vault (secret/standalone/redis/default) + gestor institucional"
+    echo "    3. Limpar:     sudo shred -u $DATA_BASE/redis/.bootstrap-creds"
     echo ""
     echo "Próximos passos (Epic data/*):"
-    echo "  Os serviços Kafka, MinIO e Redis serão provisionados em sub-tasks futuras"
-    echo "  (mesmo padrão do Postgres: container Docker via systemd nos mounts dedicados)."
+    echo "  Os serviços Kafka e MinIO serão provisionados em sub-tasks futuras"
+    echo "  (mesmo padrão de Postgres/Redis: container Docker via systemd nos mounts dedicados)."
     echo ""
     echo "Validar:"
     echo "  df -h $DATA_BASE/*"
     echo "  sudo vgs && sudo lvs"
     echo "  sudo docker exec uniplus-postgres pg_isready -U postgres"
+    echo "  sudo docker exec -i uniplus-redis sh -c 'read -r P; REDISCLI_AUTH=\$P redis-cli ping' \\"
+    echo "    <<<\"\$(sudo grep ^default_pw= $DATA_BASE/redis/.bootstrap-creds | cut -d= -f2)\""
 }
 
 # ============================================================================
@@ -905,6 +1143,7 @@ case "$ROLE" in
         step_setup_lvm
         step_create_placeholder_dirs
         step_data_setup_postgres
+        step_data_setup_redis
         summary_data
         ;;
 esac


### PR DESCRIPTION
## Summary

- Adiciona `step_data_setup_redis` em `scripts/bootstrap-standalone.sh` — provisiona `redis:8.6.3-alpine` como container Docker gerenciado por systemd no data-host (`10.0.2.87:6379`), mesmo padrão do Postgres (PR #127).
- Auth via ACL file (user `default` + senha 256 bits), persistência híbrida AOF+RDB, `maxmemory 2gb` allkeys-lru, `--network host`, config dir mounted read-only.
- Documenta operações em `docs/RUNBOOKS.md` §11: bootstrap, custódia (Vault `secret/standalone/redis/default`), validação end-to-end, restore, rotação, troubleshooting.

## Test plan

- [x] `bash -n scripts/bootstrap-standalone.sh` ✅
- [x] `shellcheck scripts/bootstrap-standalone.sh` ✅ (via koalaman/shellcheck:stable container)
- [x] `markdownlint-cli2 docs/RUNBOOKS.md` ✅
- [x] code-reviewer subagent pré-PR (lição PR #131) — 2 P1 endereçados (perm `redis.conf` 644 root:root sem segredos; ACL file mantém 600 chown 999:1000 dual-layer)
- [ ] CI verde (7 jobs)
- [ ] Codex review sem findings remanescentes
- [ ] Smoke test pós-merge no cluster: `systemctl status uniplus-redis` Active + PING/PONG via pod ad-hoc do k8s-host

## Notas técnicas

- **UID/GID do container:** `999:1000` (confirmado por `docker run --rm redis:8.6.3-alpine id redis`). Diverge da convenção 999:999 das imagens Debian-based.
- **ACL file persiste** (diferente do init SQL Postgres que é efêmero) — redis-server lê em todo startup. Cleartext da senha vive no `users.acl` mode 600 owner uid container; visibilidade limitada a quem tem sudo no data-host.
- **`--skip-docker` honrado** — guard inicial pula a função se Docker indisponível.
- **Idempotência:** preserva `.bootstrap-creds` em re-runs; aborta se ACL file existe sem creds (mismatch ACL ↔ Vault); `--dry-run` honrado.
- **Smoke test sem senha em argv** — `REDISCLI_AUTH` env via stdin (here-string + `read -r`). Mesmo padrão das §9.3/§10.4 do RUNBOOKS.

Closes #132
Refs #118 (sub-issue), #40 (Epic standalone)