### PR TITLE
feat(standalone): MinIO 2025-09 systemd no data-host

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1666,6 +1666,247 @@ unset NEW_PW
 | AOF cresce indefinidamente | `auto-aof-rewrite-percentage 100` não dispara (default mas pode ter sido desligado em config customizada) | `redis-cli BGREWRITEAOF`; revisar `redis.conf` |
 | OOM kills do container | `maxmemory 2gb` excedido ou cgroup limit do host menor | `redis-cli INFO memory`; ajustar `maxmemory` em `redis.conf` ou liberar memória no host |
 
+## 12. MinIO (standalone)
+
+Object storage AGPL community release `RELEASE.2025-09-07T16-13-09Z` — container Docker gerenciado por systemd no data-host (`10.0.2.87:9000` API + `:9001` Console). Single-node single-drive (SNSD), única topologia suportada em standalone single-host. Pré-requisito: §9 Postgres + §11 Redis ativos no data-host (mesmo padrão systemd).
+
+> ⚠️ **Aviso community vs enterprise:** este é o **último release AGPL** antes do split MinIO/AIStor (2025-09). Security fixes pós-Setembro/2025 só estão disponíveis em AIStor enterprise. Aceitável em standalone (validação) mas decisão arquitetural pra hml/prod precisa avaliar alternativas (Garage, SeaweedFS, build próprio do source) — backlog Story futura.
+
+### 12.1 MinIO 2025-09 — bootstrap automatizado
+
+A função `step_data_setup_minio` em `scripts/bootstrap-standalone.sh` provisiona, na ordem:
+
+1. Diretório `/var/lib/uniplus/minio/data` (mode `750`, owner `1000:1000` — uid `minio` criado dinamicamente pelo entrypoint via `chroot --userspec`).
+2. `.bootstrap-creds` (root:root 600) em `/var/lib/uniplus/minio/.bootstrap-creds` com `root_user` (16 bytes hex via `openssl rand -hex 16`) + `root_pw` (32 bytes hex via `openssl rand -hex 32`) — gerado **somente na primeira execução**. **Username NÃO é literal `admin`/`minioadmin`** — randomização reduz tentativas de chute.
+3. EnvironmentFile `/etc/uniplus-minio.env` (root:root 600) com `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD` (lidos do `.bootstrap-creds`), `MINIO_USERNAME=minio`, `MINIO_GROUPNAME=minio`, `MINIO_UID=1000`, `MINIO_GID=1000` (instruções para o entrypoint criar o user e fazer chroot).
+4. `systemd` unit `/etc/systemd/system/uniplus-minio.service` com `Restart=always`, container em `--network host`, server `--address 10.0.2.87:9000 --console-address 10.0.2.87:9001`, data dir `/data` mounted via volume.
+5. `step_data_bootstrap_minio_buckets` cria 4 buckets baseline idempotentemente via `mc mb --ignore-existing` em job one-shot (`quay.io/minio/mc:latest`):
+   - `keycloak-backups` — destino de pg_dump
+   - `loki-chunks` — chunks de log (observability)
+   - `tempo-traces` — traces (idem)
+   - `app-uploads` — bucket genérico para apps Uni+ (Fase 5)
+
+**Idempotência:**
+
+- `.bootstrap-creds`: preserva se existe; gera se ausente; aborta se `data/.minio.sys/` já formatado sem `.bootstrap-creds` (regenerar produziria mismatch entre MinIO runtime e Vault).
+- EnvironmentFile + systemd unit: sempre re-aplicados.
+- Buckets: `mc mb --ignore-existing` skip se já criados.
+- Serviço já ativo: bootstrap não reinicia (evita downtime).
+
+**Verificação imediata pós-bootstrap (no data-host):**
+
+```bash
+sudo systemctl status uniplus-minio
+curl -sf http://10.0.2.87:9000/minio/health/live -o /dev/null -w "%{http_code}\n"
+# Esperado: 200
+
+# Listar buckets via mc one-shot (lê creds do .bootstrap-creds via stdin)
+sudo docker run --rm -i --network host --entrypoint sh \
+  quay.io/minio/mc:latest -c '
+    read -r U; read -r P
+    mc --quiet alias set local http://10.0.2.87:9000 "$U" "$P"
+    mc ls local
+  ' <<EOF
+$(sudo grep ^root_user= /var/lib/uniplus/minio/.bootstrap-creds | cut -d= -f2)
+$(sudo grep ^root_pw= /var/lib/uniplus/minio/.bootstrap-creds | cut -d= -f2)
+EOF
+# Esperado: 4 buckets (app-uploads/, keycloak-backups/, loki-chunks/, tempo-traces/)
+```
+
+### 12.2 Custódia das credenciais iniciais
+
+> ⚠️ **CRÍTICO.** O `.bootstrap-creds` é o único rastro em disco do `root_user` + `root_pw`. Custodiar imediatamente em gestor institucional + Vault standalone, depois `shred -u`.
+
+**Passo 1 — Ler credenciais no data-host:**
+
+```bash
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87
+sudo cat /var/lib/uniplus/minio/.bootstrap-creds
+# root_user=<32 hex>
+# root_pw=<64 hex>
+```
+
+**Passo 2 — Salvar no Vault standalone (executar do k8s-host):**
+
+> Mesmo padrão de higiene das §9.2/§11.2 (port-forward + token via env, nunca argv).
+
+```bash
+read -rsp "Cole root_user (do passo 1): " MIN_USER; echo
+read -rsp "Cole root_pw (do passo 1): " MIN_PW; echo
+
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault port-forward platform-vault-uniplus-standalone-0 8200:8200 \
+  > /tmp/vault-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null; unset MIN_USER MIN_PW VAULT_TOKEN VAULT_ADDR' EXIT
+export VAULT_ADDR=http://127.0.0.1:8200
+until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
+
+read -rsp "Root token: " VAULT_TOKEN; echo
+export VAULT_TOKEN
+
+vault kv put secret/standalone/minio/root \
+  endpoint=http://10.0.2.87:9000 \
+  region=us-east-1 \
+  username="$MIN_USER" \
+  password="$MIN_PW"
+
+vault kv get secret/standalone/minio/root
+# Esperado: campos endpoint/region/username/password presentes
+```
+
+**Passo 3 — Limpar `.bootstrap-creds` no data-host:**
+
+```bash
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87
+sudo shred -u /var/lib/uniplus/minio/.bootstrap-creds
+```
+
+> ⚠️ Após `shred -u`, re-execução do bootstrap **abortaria** com mensagem apontando §12.4 (data dir já formatado, sem fonte da senha em disco). Restaurar `.bootstrap-creds` a partir do Vault antes.
+
+### 12.3 Validação end-to-end (pod K8s → MinIO)
+
+Confirma que pods do cluster K3s alcançam MinIO no data-host via flannel→VCN. Pré-requisito: PR #125 aplicado (iptables FORWARD ACCEPT entre flannel CIDR e VCN).
+
+**Executar no k8s-host:**
+
+```bash
+# 1) Conectividade TCP bruta (host → data-host)
+nc -zv 10.0.2.87 9000   # API
+nc -zv 10.0.2.87 9001   # Console
+# Esperado: succeeded em ambas
+
+# 2) Ler credenciais — fail fast se não disponíveis
+MIN_USER=$(ssh ubuntu@10.0.2.87 \
+  "sudo grep ^root_user= /var/lib/uniplus/minio/.bootstrap-creds 2>/dev/null | cut -d= -f2")
+MIN_PW=$(ssh ubuntu@10.0.2.87 \
+  "sudo grep ^root_pw= /var/lib/uniplus/minio/.bootstrap-creds 2>/dev/null | cut -d= -f2")
+if [ -z "$MIN_USER" ] || [ -z "$MIN_PW" ]; then
+  echo "ERRO: creds não encontradas. Se shredded (§12.2), restaure via §12.4." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# 3) Pod ad-hoc com mc (sem hostNetwork — usa flannel)
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml run minio-validation \
+  --image=quay.io/minio/mc:latest --restart=Never --rm -i --command -- \
+  sh -c '
+    read -r U; read -r P
+    mc --quiet alias set s http://10.0.2.87:9000 "$U" "$P"
+    mc ls s
+  ' <<EOF
+$MIN_USER
+$MIN_PW
+EOF
+# Esperado: app-uploads/ keycloak-backups/ loki-chunks/ tempo-traces/
+unset MIN_USER MIN_PW
+```
+
+### 12.4 Restore: re-criar `.bootstrap-creds` a partir do Vault
+
+```bash
+# k8s-host — port-forward Vault (mesmo pattern §11.4)
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault port-forward platform-vault-uniplus-standalone-0 8200:8200 \
+  > /tmp/vault-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null; unset MIN_USER MIN_PW VAULT_TOKEN VAULT_ADDR' EXIT
+export VAULT_ADDR=http://127.0.0.1:8200
+until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
+
+read -rsp "Root token: " VAULT_TOKEN; echo
+export VAULT_TOKEN
+
+MIN_USER=$(vault kv get -field=username secret/standalone/minio/root)
+MIN_PW=$(vault kv get -field=password secret/standalone/minio/root)
+
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87 \
+  "sudo tee /var/lib/uniplus/minio/.bootstrap-creds > /dev/null && \
+   sudo chmod 600 /var/lib/uniplus/minio/.bootstrap-creds && \
+   sudo chown root:root /var/lib/uniplus/minio/.bootstrap-creds" <<EOF
+root_user=$MIN_USER
+root_pw=$MIN_PW
+EOF
+```
+
+### 12.5 Re-rodar bucket bootstrap manualmente
+
+Se quiser pré-criar buckets adicionais sem rerunnar todo o bootstrap, ou se `step_data_bootstrap_minio_buckets` pulou por `.bootstrap-creds` ausente:
+
+```bash
+ssh ubuntu@10.0.2.87
+# Substitua a lista de buckets conforme necessário
+sudo docker run --rm -i --network host --entrypoint sh \
+  quay.io/minio/mc:latest -c '
+    set -e
+    read -r U; read -r P
+    mc --quiet alias set local http://10.0.2.87:9000 "$U" "$P"
+    for b in keycloak-backups loki-chunks tempo-traces app-uploads; do
+      mc mb --ignore-existing "local/$b"
+    done
+    mc ls local
+  ' <<EOF
+$(sudo grep ^root_user= /var/lib/uniplus/minio/.bootstrap-creds | cut -d= -f2)
+$(sudo grep ^root_pw= /var/lib/uniplus/minio/.bootstrap-creds | cut -d= -f2)
+EOF
+```
+
+### 12.6 Acesso ao Console UI (porta 9001)
+
+Console NÃO está exposto externamente (sem IngressRoute em standalone). Acesso via SSH tunnel:
+
+```bash
+# Do laptop (cria tunnel local 9001 → k8s-host:9001 → data-host:9001 via VCN)
+ssh -L 9001:10.0.2.87:9001 ubuntu@164.152.53.29
+# Em outro terminal: xdg-open http://localhost:9001
+# Login com root_user / root_pw do Vault
+```
+
+### 12.7 Rotacionar `root_pw`
+
+```bash
+# 1) Gerar nova senha + atualizar Vault
+NEW_PW=$(openssl rand -hex 32)
+vault kv put secret/standalone/minio/root \
+  endpoint=http://10.0.2.87:9000 region=us-east-1 \
+  username="$(vault kv get -field=username secret/standalone/minio/root)" \
+  password="$NEW_PW"
+
+# 2) Reconstituir .bootstrap-creds via §12.4 com NEW_PW
+
+# 3) Re-rodar bootstrap (re-aplica EnvironmentFile com NEW_PW)
+ssh ubuntu@10.0.2.87 "cd ~/uniplus-infra && ./scripts/bootstrap-standalone.sh --role=standalone-data"
+
+# 4) Restart do MinIO para que MINIO_ROOT_PASSWORD reflita o novo valor
+ssh ubuntu@10.0.2.87 "sudo systemctl restart uniplus-minio"
+
+# 5) Validar — `mc admin info` deve aceitar a nova senha
+unset NEW_PW
+```
+
+> Apps consumidoras (Fase 5) que cacheiem credenciais em ConfigMap/env precisam restart após rotação. ESO refresh é assíncrono — forçar sync via annotation se aplicável.
+
+### 12.8 Backup e Restore
+
+> Procedimento detalhado em sub-task da Story #118. Resumo:
+>
+> - **Backup:** snapshot LVM (`vg-minio/lv-minio`) + cópia dos chunks via `mc mirror local/<bucket> remote/...` para destino externo (institucional UNIFESSPA quando rede chegar).
+> - **Restore:** parar `uniplus-minio`, restaurar volume via LVM snapshot ou re-importar via `mc mirror`, ajustar ownership `1000:1000`, iniciar serviço.
+>
+> **Em standalone, perda de MinIO afeta:** keycloak backups (recuperáveis via re-bootstrap do KC com data fresca), uploads de apps (perda de dados de usuário). Aceitável em validação; produção exige replicação cross-DC (não disponível em SNSD).
+
+### 12.9 Troubleshooting
+
+| Sintoma | Diagnóstico | Fix |
+|---|---|---|
+| `Access Denied` ao chamar `mc admin info` | `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` no env do container desatualizados ou typo no creds | Conferir `.bootstrap-creds` vs Vault; re-rodar §12.7 |
+| Container falha startup com `Permission denied` em `/data` | Ownership do data dir ≠ `1000:1000` ou mode ≠ `750` | `sudo chown -R 1000:1000 /var/lib/uniplus/minio/data && sudo chmod 750 /var/lib/uniplus/minio/data` |
+| `/minio/health/live` retorna 503 | MinIO ainda inicializando (1ª run formata `.minio.sys/`) ou drive corrupto | `sudo journalctl -u uniplus-minio -n 100`; aguardar até 90s |
+| Console em `:9001` não responde | `--console-address 10.0.2.87:9001` não bind (porta em uso?) | `sudo ss -tlnp \| grep 9001`; se libre, restart `uniplus-minio` |
+| `mc mb` retorna `BucketAlreadyOwnedByYou` | Bucket já existe (idempotência funcionando) | Sem ação — `--ignore-existing` evita o erro; se aparecer fora do flag, é OK |
+| OOM kills do container | Workload excede heap default da JVM ausente (MinIO é Go, sem JVM); cgroup limit do host muito baixo | `docker stats uniplus-minio`; ajustar limits do systemd unit ou liberar memória |
+| `mc alias set` retorna `Unable to verify SSL certificate` | TLS-mismatch ou endpoint errado | Confirmar endpoint `http://` (NÃO `https://`) — standalone usa PLAINTEXT |
+| Disk full em `vg-minio` | Buckets crescem além do volume | `df -h /var/lib/uniplus/minio`; `mc admin info local` para uso por bucket; expandir LVM ou aplicar lifecycle/quota |
+
 ---
 
 *Documento mantido pelo CTIC/UNIFESSPA. Atualizações via Pull Request.*

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -1077,6 +1077,248 @@ UNIT
     fi
 }
 
+# Configura MinIO (RELEASE.2025-09-07T16-13-09Z) como container Docker
+# gerenciado por systemd no data-host. Single-node single-drive (SNSD) — única
+# topologia suportada em standalone single-host. Sem erasure coding (precisa
+# ≥4 drives) — zero proteção contra corrupção do drive; backup externo é
+# responsabilidade do operador (Story #118 sub-task).
+#
+# UID/GID do container: 1000:1000 via MINIO_USERNAME/MINIO_GROUPNAME +
+# MINIO_UID/MINIO_GID. O entrypoint cria o user dinamicamente em /etc/passwd
+# e usa `chroot --userspec` para drop de privs (image roda como root by default).
+#
+# Auth: MINIO_ROOT_USER (16 bytes hex aleatório, NÃO `admin`/`minioadmin`) +
+# MINIO_ROOT_PASSWORD (32 bytes hex). Per-app users criados via mc admin user
+# add na Fase 5.
+#
+# Idempotência (decisões independentes):
+#   - .bootstrap-creds: preserva se existe; gera se ausente; aborta se data
+#     dir já contém state (.minio.sys/) sem .bootstrap-creds.
+#   - EnvironmentFile + systemd unit: sempre re-aplicados (cheap, corrige drift).
+#   - Serviço já ativo: não reinicia (evita downtime em re-runs).
+#
+# AGPL community release (último em 2025-09): security fixes pós-Sep só em
+# AIStor enterprise. Aceitável em standalone (validação); decisão arquitetural
+# pra prod (alternativas: Garage, SeaweedFS) fica em backlog (Story futura).
+step_data_setup_minio() {
+    if $SKIP_DOCKER && ! command -v docker &>/dev/null; then
+        log_warn "Docker indisponível e --skip-docker ativo — pulando setup do MinIO."
+        return
+    fi
+
+    log_info "Configurando MinIO 2025-09 systemd..."
+
+    local creds_file="$DATA_BASE/minio/.bootstrap-creds"
+    local env_file="/etc/uniplus-minio.env"
+    local unit_file="/etc/systemd/system/uniplus-minio.service"
+
+    # Diretórios + ownership: $DATA_BASE/minio/data 1000:1000 mode 750.
+    # O entrypoint do MinIO roda como root inicialmente, faz chroot --userspec
+    # para uid 1000 antes de invocar `minio server`. Pré-set 1000:1000 evita
+    # erros "Permission denied" na primeira escrita do .minio.sys/.
+    run "sudo mkdir -p $DATA_BASE/minio/data"
+    run "sudo chown 1000:1000 $DATA_BASE/minio/data"
+    run "sudo chmod 750 $DATA_BASE/minio/data"
+
+    # Detectar inicialização prévia: presença de .minio.sys/ no data dir
+    # indica que MinIO já formatou o drive ao menos uma vez (config + format
+    # marker viram persistentes). Análogo a PG_VERSION em Postgres.
+    local already_initialized=false
+    if ! $DRY_RUN && \
+       sudo test -d "$DATA_BASE/minio/data/.minio.sys" 2>/dev/null; then
+        already_initialized=true
+    fi
+
+    # ---- Decisão 1: .bootstrap-creds (preservar / gerar / abortar) ----
+    if sudo test -f "$creds_file" 2>/dev/null; then
+        log_success "Bootstrap creds MinIO já existentes — preservando credenciais."
+    elif $DRY_RUN; then
+        log_warn "Dry-run: credenciais MinIO seriam geradas em $creds_file"
+    elif $already_initialized; then
+        # Guard: data dir formatado mas .bootstrap-creds shredded sem custódia.
+        # Regenerar criaria root_user/root_pw novos no Vault diferentes dos
+        # que MinIO aceita em runtime — apps (Fase 5) lendo Vault falhariam.
+        log_error "$creds_file ausente, mas $DATA_BASE/minio/data/.minio.sys/ já existe"
+        log_error "Regenerar credenciais agora produziria mismatch entre MinIO e Vault."
+        log_error "Restaure $creds_file a partir do Vault — ver docs/RUNBOOKS.md §12.4."
+        exit 1
+    else
+        log_info "Gerando credenciais MinIO (root_user 16 bytes hex + root_pw 32 bytes hex)..."
+        local root_user root_pw
+        root_user=$(openssl rand -hex 16)
+        root_pw=$(openssl rand -hex 32)
+        sudo tee "$creds_file" >/dev/null <<EOF
+root_user=$root_user
+root_pw=$root_pw
+EOF
+        sudo chown root:root "$creds_file"
+        sudo chmod 600 "$creds_file"
+        log_warn "Credenciais geradas em $creds_file. Custódia obrigatória — ver runbook §12.2."
+    fi
+
+    # EnvironmentFile (sempre re-aplicado). Senhas via env do systemd → docker
+    # `-e VAR` (sem `=value`); cmdline NÃO expõe (`/proc/<pid>/cmdline` puxa
+    # do env de processo, não dos args). MINIO_USERNAME/GROUPNAME/UID/GID
+    # instruem o entrypoint a chroot pro user 1000:1000.
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Escreveria $env_file"
+    else
+        local root_user_current root_pw_current
+        root_user_current=$(sudo grep '^root_user=' "$creds_file" | cut -d= -f2)
+        root_pw_current=$(sudo grep '^root_pw=' "$creds_file" | cut -d= -f2)
+        if [[ -z "$root_user_current" || -z "$root_pw_current" ]]; then
+            log_error "root_user ou root_pw vazio em $creds_file. Abortando."
+            exit 1
+        fi
+        sudo tee "$env_file" >/dev/null <<EOF
+MINIO_ROOT_USER=$root_user_current
+MINIO_ROOT_PASSWORD=$root_pw_current
+MINIO_USERNAME=minio
+MINIO_GROUPNAME=minio
+MINIO_UID=1000
+MINIO_GID=1000
+EOF
+        sudo chown root:root "$env_file"
+        sudo chmod 600 "$env_file"
+        unset root_user_current root_pw_current
+    fi
+
+    # systemd unit (sempre re-aplicado). Heredoc single-quoted: paths hardcoded.
+    # --address e --console-address ligam explicitamente em 10.0.2.87 (subnet
+    # privada VCN). Console em 9001 NÃO está exposto externamente (sem
+    # IngressRoute) — acesso só via kubectl port-forward ou SSH tunnel.
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Escreveria $unit_file"
+    else
+        sudo tee "$unit_file" >/dev/null <<'UNIT'
+[Unit]
+Description=Uni+ MinIO 2025-09 (standalone data-host)
+Documentation=https://github.com/unifesspa-edu-br/uniplus-infra/blob/main/docs/RUNBOOKS.md
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10
+TimeoutStartSec=120
+EnvironmentFile=/etc/uniplus-minio.env
+
+ExecStartPre=-/usr/bin/docker rm -f uniplus-minio
+ExecStart=/usr/bin/docker run --rm --name uniplus-minio \
+  --network host \
+  -e MINIO_ROOT_USER \
+  -e MINIO_ROOT_PASSWORD \
+  -e MINIO_USERNAME \
+  -e MINIO_GROUPNAME \
+  -e MINIO_UID \
+  -e MINIO_GID \
+  -v /var/lib/uniplus/minio/data:/data \
+  quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z \
+  server --address 10.0.2.87:9000 --console-address 10.0.2.87:9001 /data
+
+ExecStop=/usr/bin/docker stop -t 30 uniplus-minio
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+    fi
+
+    run "sudo systemctl daemon-reload"
+    run "sudo systemctl enable uniplus-minio"
+
+    if $DRY_RUN; then
+        echo "[DRY-RUN] systemctl start uniplus-minio + curl /minio/health/live"
+    elif sudo systemctl is-active --quiet uniplus-minio; then
+        log_success "uniplus-minio já ativo — preservando state (sem restart)."
+    else
+        sudo systemctl start uniplus-minio
+        log_info "Aguardando MinIO aceitar conexões..."
+        local attempts=0
+        until curl -sf --max-time 2 http://10.0.2.87:9000/minio/health/live >/dev/null 2>&1; do
+            attempts=$(( attempts + 1 ))
+            if (( attempts >= 18 )); then
+                log_error "MinIO não respondeu /minio/health/live em 90s. Ver: sudo journalctl -u uniplus-minio -n 50"
+                exit 1
+            fi
+            sleep 5
+        done
+        log_success "uniplus-minio ativo + /minio/health/live OK."
+    fi
+}
+
+# Cria buckets baseline em standalone via mc (one-shot job).
+#
+# Idempotente — `mc mb --ignore-existing` skip se bucket já existe. Roda em
+# container ad-hoc da imagem mc:latest, sem persistência. Buckets são
+# pré-cadastros para usos previstos:
+#   - keycloak-backups: destino de pg_dump (Story #118 sub-task)
+#   - loki-chunks: chunks de log (quando observability aterrissar)
+#   - tempo-traces: traces (idem)
+#   - app-uploads: bucket genérico para apps Uni+ (Fase 5)
+#
+# Per-app users + policies são responsabilidade da Fase 5 (cada app PR pede
+# seu user via mc admin user add + policy attach).
+step_data_bootstrap_minio_buckets() {
+    if $SKIP_DOCKER && ! command -v docker &>/dev/null; then
+        log_warn "Docker indisponível e --skip-docker ativo — pulando bucket bootstrap."
+        return
+    fi
+
+    if ! sudo systemctl is-active --quiet uniplus-minio 2>/dev/null && ! $DRY_RUN; then
+        log_warn "uniplus-minio não está ativo — pulando bucket bootstrap."
+        return
+    fi
+
+    log_info "Pré-criando buckets baseline (keycloak-backups, loki-chunks, tempo-traces, app-uploads)..."
+
+    local creds_file="$DATA_BASE/minio/.bootstrap-creds"
+
+    if ! sudo test -f "$creds_file" 2>/dev/null; then
+        if $DRY_RUN; then
+            log_warn "Dry-run: bucket bootstrap precisaria de $creds_file"
+            return
+        fi
+        log_warn "$creds_file ausente — buckets não criados (presume custódia já feita)."
+        log_warn "Para re-rodar manualmente: ver docs/RUNBOOKS.md §12.5."
+        return
+    fi
+
+    if $DRY_RUN; then
+        echo "[DRY-RUN] mc alias set + mc mb keycloak-backups loki-chunks tempo-traces app-uploads"
+        return
+    fi
+
+    local root_user root_pw
+    root_user=$(sudo grep '^root_user=' "$creds_file" | cut -d= -f2)
+    root_pw=$(sudo grep '^root_pw=' "$creds_file" | cut -d= -f2)
+    if [[ -z "$root_user" || -z "$root_pw" ]]; then
+        log_error "root_user ou root_pw vazio em $creds_file — não consigo criar buckets."
+        exit 1
+    fi
+
+    # Credenciais via stdin (here-string + read -r no shell do container).
+    # `mc alias set --quiet` evita echo do password no stdout.
+    sudo docker run --rm -i --network host \
+        --entrypoint sh \
+        quay.io/minio/mc:latest -c '
+            set -e
+            read -r U
+            read -r P
+            mc --quiet alias set local http://10.0.2.87:9000 "$U" "$P"
+            for b in keycloak-backups loki-chunks tempo-traces app-uploads; do
+                mc mb --ignore-existing "local/$b"
+            done
+            mc ls local
+        ' <<EOF
+$root_user
+$root_pw
+EOF
+    log_success "Buckets baseline pré-criados (idempotente)."
+    unset root_user root_pw
+}
+
 summary_data() {
     echo ""
     echo "============================================"
@@ -1093,6 +1335,7 @@ summary_data() {
     echo "Data services systemd:"
     echo "  systemctl status uniplus-postgres"
     echo "  systemctl status uniplus-redis"
+    echo "  systemctl status uniplus-minio"
     echo ""
     echo "Custódia das senhas iniciais (PRIMEIRA EXECUÇÃO):"
     echo "  Postgres — runbook §9.2:"
@@ -1103,10 +1346,14 @@ summary_data() {
     echo "    1. Ler:        sudo cat $DATA_BASE/redis/.bootstrap-creds"
     echo "    2. Custodiar:  Vault (secret/standalone/redis/default) + gestor institucional"
     echo "    3. Limpar:     sudo shred -u $DATA_BASE/redis/.bootstrap-creds"
+    echo "  MinIO — runbook §12.2:"
+    echo "    1. Ler:        sudo cat $DATA_BASE/minio/.bootstrap-creds"
+    echo "    2. Custodiar:  Vault (secret/standalone/minio/root) + gestor institucional"
+    echo "    3. Limpar:     sudo shred -u $DATA_BASE/minio/.bootstrap-creds"
     echo ""
     echo "Próximos passos (Epic data/*):"
-    echo "  Os serviços Kafka e MinIO serão provisionados em sub-tasks futuras"
-    echo "  (mesmo padrão de Postgres/Redis: container Docker via systemd nos mounts dedicados)."
+    echo "  O serviço Kafka será provisionado em sub-task futura"
+    echo "  (mesmo padrão de Postgres/Redis/MinIO: container Docker via systemd)."
     echo ""
     echo "Validar:"
     echo "  df -h $DATA_BASE/*"
@@ -1114,6 +1361,7 @@ summary_data() {
     echo "  sudo docker exec uniplus-postgres pg_isready -U postgres"
     echo "  sudo docker exec -i uniplus-redis sh -c 'read -r P; REDISCLI_AUTH=\$P redis-cli ping' \\"
     echo "    <<<\"\$(sudo grep ^default_pw= $DATA_BASE/redis/.bootstrap-creds | cut -d= -f2)\""
+    echo "  curl -sf http://10.0.2.87:9000/minio/health/live && echo ' — MinIO health OK'"
 }
 
 # ============================================================================
@@ -1144,6 +1392,8 @@ case "$ROLE" in
         step_create_placeholder_dirs
         step_data_setup_postgres
         step_data_setup_redis
+        step_data_setup_minio
+        step_data_bootstrap_minio_buckets
         summary_data
         ;;
 esac


### PR DESCRIPTION
## Summary

- Adiciona `step_data_setup_minio` e `step_data_bootstrap_minio_buckets` em `scripts/bootstrap-standalone.sh` — provisiona `quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` (último community AGPL antes do AIStor split de 2025-09) systemd-managed no data-host. Single-node single-drive (SNSD), única topologia em standalone single-host.
- API em `10.0.2.87:9000`, Console em `:9001` (sem IngressRoute — acesso via SSH tunnel).
- 4 buckets pré-criados idempotentemente (`mc mb --ignore-existing`): `keycloak-backups`, `loki-chunks`, `tempo-traces`, `app-uploads`.
- Documenta operações em `docs/RUNBOOKS.md` §12: bootstrap, custódia (Vault `secret/standalone/minio/root`), validação E2E, restore, console via SSH tunnel, rotação, troubleshooting.

## Test plan

- [x] `bash -n scripts/bootstrap-standalone.sh` ✅
- [x] `shellcheck scripts/bootstrap-standalone.sh` ✅ (via koalaman/shellcheck:stable)
- [x] `markdownlint-cli2 docs/RUNBOOKS.md` ✅
- [x] code-reviewer subagent pré-PR (lição PR #131) — 1 P1 endereçado (§12.7 path `/tmp/bootstrap-standalone.sh` → `cd ~/uniplus-infra && ./scripts/...` consistente com §11.5)
- [x] Validação local de imagem: `docker run` confirmou `--address` + `--console-address`, env vars `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD`, health endpoint `/minio/health/live` HTTP 200
- [ ] CI verde (7 jobs)
- [ ] Codex review sem findings remanescentes
- [ ] Smoke test pós-merge: `systemctl status uniplus-minio` Active + `curl /minio/health/live` 200 + `mc ls` lista 4 buckets via pod ad-hoc do k8s-host

## Notas técnicas

- **UID/GID:** `1000:1000` via env vars `MINIO_USERNAME/GROUPNAME/UID/GID`. Entrypoint do MinIO cria user dinamicamente em `/etc/passwd` e usa `chroot --userspec` (image roda como root by default).
- **Auth:** `MINIO_ROOT_USER` 16 bytes hex aleatório (NÃO `admin`/`minioadmin` — reduz tentativas de chute) + `MINIO_ROOT_PASSWORD` 32 bytes hex. Ambos via `EnvironmentFile` (`-e VAR` sem `=value` → cmdline não expõe).
- **Idempotência:** preserva `.bootstrap-creds` em re-runs; aborta se data dir contém `.minio.sys/` sem creds (mismatch entre MinIO runtime e Vault); `mc mb --ignore-existing` skip buckets já criados.
- **`--skip-docker` honrado** em ambas as funções (`step_data_setup_minio` e `step_data_bootstrap_minio_buckets`).
- **TLS:** PLAINTEXT em standalone (subnet privada VCN + iptables). Decisão para hml/prod e migração community→AIStor enterprise ficam em backlog (ver aviso no §12 do RUNBOOKS).
- **`mc:latest`:** tag não pinada nos snippets do bucket bootstrap. Aceitável no contexto one-shot idempotente; consistência com pattern do projeto pode pinar futuramente.

Closes #134
Refs #118 (sub-issue), #40 (Epic standalone)