### PR TITLE
feat(standalone): Kafka 4.2.0 KRaft systemd no data-host

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1907,6 +1907,222 @@ unset NEW_PW
 | `mc alias set` retorna `Unable to verify SSL certificate` | TLS-mismatch ou endpoint errado | Confirmar endpoint `http://` (NÃO `https://`) — standalone usa PLAINTEXT |
 | Disk full em `vg-minio` | Buckets crescem além do volume | `df -h /var/lib/uniplus/minio`; `mc admin info local` para uso por bucket; expandir LVM ou aplicar lifecycle/quota |
 
+## 13. Kafka KRaft (standalone)
+
+Mensageria — `apache/kafka:4.2.0` (KRaft only; ZooKeeper removido na 4.0 GA) em container Docker gerenciado por systemd no data-host (`10.0.2.87:9092` para clientes, `:9093` para controller). Single-node combined (`process.roles=broker,controller`) com static quorum.
+
+> ⚠️ **Auth em standalone:** PLAINTEXT — subnet privada VCN + iptables INPUT chain filtrando externos. Acceptable para validação. Para hml/prod migrar para SASL/SCRAM-SHA-512 (ver §13.6 — Pattern de migração).
+
+### 13.1 Kafka 4.2.0 — bootstrap automatizado
+
+A função `step_data_setup_kafka` em `scripts/bootstrap-standalone.sh` provisiona, na ordem:
+
+1. Diretório `/var/lib/uniplus/kafka/data` (mode `750`, owner `1000:1000` — uid `appuser` no container, default user da imagem `apache/kafka:4.2.0` sem drop de privs).
+2. `.bootstrap-creds` (root:root 600) em `/var/lib/uniplus/kafka/.bootstrap-creds` com `cluster_id` (UUID gerado via `kafka-storage.sh random-uuid` em container ad-hoc) — gerado **somente na primeira execução**.
+3. EnvironmentFile `/etc/uniplus-kafka.env` (root:root 600) com `CLUSTER_ID`, `KAFKA_PROCESS_ROLES=broker,controller`, `KAFKA_NODE_ID=1`, `KAFKA_LISTENERS`, `KAFKA_ADVERTISED_LISTENERS`, `KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER`, `KAFKA_CONTROLLER_QUORUM_VOTERS=1@10.0.2.87:9093` (static quorum), `KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT`, `KAFKA_LISTENER_SECURITY_PROTOCOL_MAP`, `KAFKA_LOG_DIRS=/var/lib/kafka/data` (override do default `/tmp/kraft-combined-logs`), `KAFKA_AUTO_CREATE_TOPICS_ENABLE=false`, replication factor 1 em internal topics, `KAFKA_HEAP_OPTS="-Xmx1g -Xms1g"` (aspas obrigatórias — systemd EnvironmentFile parser tokeniza por espaço sem quoting).
+4. `systemd` unit `/etc/systemd/system/uniplus-kafka.service` com `Restart=always`, `TimeoutStartSec=180` (cold start de JVM + KRaft metadata controller bootstrap), container em `--network host`, data dir mounted em `/var/lib/kafka/data` (default do entrypoint).
+
+**Format do storage é AUTOMÁTICO** via `KafkaDockerWrapper setup` no entrypoint do container — chamado em todo startup, mas o wrapper detecta `already formatted` e skip idempotentemente. NÃO há `kafka-storage.sh format` manual no script.
+
+**Idempotência:**
+
+- `.bootstrap-creds`: preserva se existe; gera se ausente; aborta se `data/meta.properties` já formatado sem creds (regenerar `cluster_id` produziria mismatch entre runtime config e storage).
+- EnvironmentFile + systemd unit: sempre re-aplicados.
+- Entrypoint do container: format skip se já formatado.
+- Serviço já ativo: bootstrap não reinicia.
+
+**Verificação imediata pós-bootstrap (no data-host):**
+
+```bash
+sudo systemctl status uniplus-kafka
+sudo docker exec uniplus-kafka /opt/kafka/bin/kafka-broker-api-versions.sh \
+  --bootstrap-server localhost:9092 | head -3
+# Esperado: lista de APIs (Produce, Fetch, ListOffsets, Metadata, ...)
+```
+
+### 13.2 Registrar `cluster_id` no Vault (auditoria)
+
+> O `cluster_id` **NÃO é segredo** — é apenas o identificador único do cluster (previne mistura entre brokers de clusters diferentes). Persistir em Vault é para documentação/auditoria; o arquivo `.bootstrap-creds` permanece no data-host indefinidamente (sem shred — não há cleartext de senha).
+
+```bash
+# Ler cluster_id no data-host
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87
+sudo cat /var/lib/uniplus/kafka/.bootstrap-creds
+# cluster_id=<UUID>
+```
+
+**Registrar no Vault (executar do k8s-host):**
+
+```bash
+read -rsp "Cole cluster_id (do passo anterior): " KAFKA_CID; echo
+
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault port-forward platform-vault-uniplus-standalone-0 8200:8200 \
+  > /tmp/vault-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null; unset KAFKA_CID VAULT_TOKEN VAULT_ADDR' EXIT
+export VAULT_ADDR=http://127.0.0.1:8200
+until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
+
+read -rsp "Root token: " VAULT_TOKEN; echo
+export VAULT_TOKEN
+
+vault kv put secret/standalone/kafka/cluster \
+  bootstrap_servers=10.0.2.87:9092 \
+  cluster_id="$KAFKA_CID"
+
+vault kv get secret/standalone/kafka/cluster
+```
+
+### 13.3 Validação end-to-end (pod K8s → Kafka)
+
+Confirma que pods do cluster K3s alcançam Kafka no data-host via flannel→VCN. Pré-requisito: PR #125 aplicado (iptables FORWARD ACCEPT).
+
+**Executar no k8s-host:**
+
+```bash
+# 1) Conectividade TCP bruta
+nc -zv 10.0.2.87 9092
+# Esperado: succeeded
+
+# 2) Pod ad-hoc com cliente Kafka — produce + consume round-trip
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml run kafka-validation \
+  --image=apache/kafka:4.2.0 --restart=Never --rm -i --command -- bash -c '
+    set -euo pipefail
+    BS=10.0.2.87:9092
+
+    /opt/kafka/bin/kafka-topics.sh --bootstrap-server "$BS" \
+      --create --topic uniplus-smoke --partitions 1 --replication-factor 1
+
+    echo "hello-uniplus" | /opt/kafka/bin/kafka-console-producer.sh \
+      --bootstrap-server "$BS" --topic uniplus-smoke
+
+    /opt/kafka/bin/kafka-console-consumer.sh \
+      --bootstrap-server "$BS" --topic uniplus-smoke \
+      --from-beginning --max-messages 1 --timeout-ms 10000
+
+    /opt/kafka/bin/kafka-topics.sh --bootstrap-server "$BS" \
+      --delete --topic uniplus-smoke
+  '
+# Esperado: "hello-uniplus" no consumer; topic deletado
+```
+
+### 13.4 Restore: re-criar `.bootstrap-creds` a partir do meta.properties ou Vault
+
+Caso o `.bootstrap-creds` seja perdido mas `meta.properties` exista no data dir, o `cluster_id` está ali (escrito pelo entrypoint na primeira formatação):
+
+```bash
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87
+sudo grep '^cluster.id=' /var/lib/uniplus/kafka/data/meta.properties
+# cluster.id=<UUID>
+
+# Reconstituir .bootstrap-creds
+CID=$(sudo grep '^cluster.id=' /var/lib/uniplus/kafka/data/meta.properties | cut -d= -f2)
+echo "cluster_id=$CID" | sudo tee /var/lib/uniplus/kafka/.bootstrap-creds
+sudo chown root:root /var/lib/uniplus/kafka/.bootstrap-creds
+sudo chmod 600 /var/lib/uniplus/kafka/.bootstrap-creds
+```
+
+Se `meta.properties` também foi perdido (data dir resetado), recuperar do Vault:
+
+```bash
+# k8s-host — kubectl exec no pod Vault para ler o registro
+read -rsp "Root token: " VAULT_TOKEN; echo
+
+CID=$(sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault exec -i platform-vault-uniplus-standalone-0 -- \
+  sh -c 'read -r T; export VAULT_TOKEN="$T"; vault kv get -field=cluster_id secret/standalone/kafka/cluster' \
+  <<<"$VAULT_TOKEN")
+
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87 \
+  "sudo tee /var/lib/uniplus/kafka/.bootstrap-creds > /dev/null && \
+   sudo chmod 600 /var/lib/uniplus/kafka/.bootstrap-creds && \
+   sudo chown root:root /var/lib/uniplus/kafka/.bootstrap-creds" <<EOF
+cluster_id=$CID
+EOF
+unset VAULT_TOKEN CID
+```
+
+> ⚠️ Restaurar `cluster_id` SEM `meta.properties` correspondente significa que o cluster perdeu o storage. Re-rodar o bootstrap recriará `meta.properties` a partir do `cluster_id` restaurado, mas **todos os topics e mensagens são perdidos**. Em standalone, mensageria é volátil; produção exige replicação cross-DC.
+
+### 13.5 Operações comuns
+
+**Listar topics:**
+
+```bash
+sudo docker exec uniplus-kafka /opt/kafka/bin/kafka-topics.sh \
+  --bootstrap-server localhost:9092 --list
+```
+
+**Criar topic com partições e retenção customizadas:**
+
+```bash
+sudo docker exec uniplus-kafka /opt/kafka/bin/kafka-topics.sh \
+  --bootstrap-server localhost:9092 \
+  --create --topic uniplus-events \
+  --partitions 3 --replication-factor 1 \
+  --config retention.ms=604800000  # 7 dias
+```
+
+**Inspecionar consumer groups:**
+
+```bash
+sudo docker exec uniplus-kafka /opt/kafka/bin/kafka-consumer-groups.sh \
+  --bootstrap-server localhost:9092 --list
+sudo docker exec uniplus-kafka /opt/kafka/bin/kafka-consumer-groups.sh \
+  --bootstrap-server localhost:9092 --describe --group <group-name>
+```
+
+### 13.6 Pattern de migração para SASL/SCRAM-SHA-512 (hml/prod)
+
+Em standalone PLAINTEXT é aceitável (subnet privada). Para hml/prod, a migração envolve:
+
+1. **Re-format do storage com SCRAM credentials embarcadas:**
+
+   ```bash
+   /opt/kafka/bin/kafka-storage.sh format \
+     --config /opt/kafka/config/server.properties \
+     --cluster-id <UUID> \
+     --add-scram 'SCRAM-SHA-512=[name=admin,password=<senha-forte>]' \
+     --ignore-formatted
+   ```
+
+2. **Atualizar EnvironmentFile** com:
+
+   ```
+   KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:SASL_PLAINTEXT,PLAINTEXT:SASL_PLAINTEXT
+   KAFKA_SASL_ENABLED_MECHANISMS=SCRAM-SHA-512
+   KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=SCRAM-SHA-512
+   KAFKA_SASL_MECHANISM_CONTROLLER_PROTOCOL=SCRAM-SHA-512
+   KAFKA_SUPER_USERS=User:admin
+   ```
+
+3. **Custodiar admin password no Vault** em `secret/standalone/kafka/admin` (`username`+`password`); sub-usuários per-app via `kafka-configs.sh --add-config 'SCRAM-SHA-512=[password=...]'` na Fase 5.
+
+> Não implementar essa migração em standalone — apenas registrar como follow-up para Story de hml.
+
+### 13.7 Backup e Restore
+
+> Procedimento detalhado em sub-task da Story #118. Resumo:
+>
+> - **Backup:** snapshot LVM (`vg-kafka/lv-kafka`) ou cópia do data dir após `systemctl stop uniplus-kafka`. **Backup ao vivo de Kafka NÃO é confiável** — cópia inconsistente entre arquivos de log e índices. Sempre stop antes de copiar.
+> - **Restore:** parar `uniplus-kafka`, restaurar volume via LVM snapshot ou `tar -xz` do backup, ajustar ownership `1000:1000`, iniciar serviço. `cluster_id` em `meta.properties` deve ser preservado.
+>
+> **Em standalone, perda de Kafka afeta:** mensagens em-vôo (perda dependendo do consumer offset). Aceitável em validação; produção exige cluster multi-broker com replication factor ≥ 3.
+
+### 13.8 Troubleshooting
+
+| Sintoma | Diagnóstico | Fix |
+|---|---|---|
+| Container reinicia em loop com `Cluster ID mismatch` | `CLUSTER_ID` no env diferente do `cluster.id` em `meta.properties` | Restaurar `.bootstrap-creds` correto via §13.4; o env é gerado dele |
+| `Connection refused` ao chamar `kafka-broker-api-versions.sh` | Bootstrap ainda inicializando (~30-90s na primeira run) ou listener bind falhou | `sudo journalctl -u uniplus-kafka -n 100`; conferir `KAFKA_LISTENERS` no env |
+| `LEADER_NOT_AVAILABLE` ao produzir | Topic recém-criado; metadata refresh não propagou | Aguardar 1-2s e retry; em standalone com 1 broker, isso é raro mas possível em load alto |
+| `OutOfMemoryError: Java heap space` | `KAFKA_HEAP_OPTS=-Xmx1g` insuficiente para workload | Aumentar `-Xmx` no EnvironmentFile; restart |
+| `nc -zv 10.0.2.87 9092` succeeded mas pod retorna timeout | iptables FORWARD ainda dropping flannel→VCN | Mesma diagnose de §11.3/§12.3 — ver §8.6/§8.7 do plano #123 |
+| `auto.create.topics.enable` desligado mas app cria topic implicitamente | App configurado com `allow.auto.create.topics=true` (client-side) — Kafka 4.x ainda permite isso por default | App deve criar topics explicitamente via API; ou desabilitar client-side allow |
+| Disk full em `vg-kafka` | Logs cresceram além do volume | `df -h /var/lib/uniplus/kafka`; aplicar `retention.ms` ou `retention.bytes` por topic; expandir LVM |
+| `KRaft metadata controller is not yet ready` no startup | Cold start ainda em progresso ou storage corrupto | Aguardar até 180s; se persiste, conferir integridade de `meta.properties` e `__cluster_metadata-0/` |
+
 ---
 
 *Documento mantido pelo CTIC/UNIFESSPA. Atualizações via Pull Request.*

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -1319,6 +1319,217 @@ EOF
     unset root_user root_pw
 }
 
+# Configura Apache Kafka 4.2.0 (KRaft only — ZooKeeper removido em 4.0 GA) como
+# container Docker gerenciado por systemd no data-host. Single-node combined
+# (process.roles=broker,controller).
+#
+# UID/GID: 1000:1000 (appuser, default user da imagem apache/kafka:4.2.0).
+#
+# Auth: PLAINTEXT — subnet privada VCN + iptables INPUT chain filtrando
+# externos. Acceptable em standalone (validação). Pattern SASL/SCRAM-SHA-512
+# documentado em RUNBOOKS §13 para hml/prod.
+#
+# Cluster ID: gerado uma vez via `kafka-storage.sh random-uuid`, persistido em
+# .bootstrap-creds (não é segredo — apenas identificador único do cluster, mas
+# preservar é importante: regenerar produziria mismatch com meta.properties já
+# escrito em $DATA_BASE/kafka/data/). Format do storage é AUTOMÁTICO via
+# `KafkaDockerWrapper setup` no entrypoint (idempotente — skip se já formatado).
+#
+# Idempotência:
+#   - .bootstrap-creds: preserva se existe; gera se ausente; aborta se data dir
+#     já tem meta.properties sem .bootstrap-creds (recovery via §13.4).
+#   - EnvironmentFile + systemd unit: sempre re-aplicados.
+#   - Entrypoint do container: format storage skip se já formatado.
+#   - Serviço já ativo: não reinicia.
+step_data_setup_kafka() {
+    if $SKIP_DOCKER && ! command -v docker &>/dev/null; then
+        log_warn "Docker indisponível e --skip-docker ativo — pulando setup do Kafka."
+        return
+    fi
+
+    log_info "Configurando Kafka 4.2.0 KRaft systemd..."
+
+    local creds_file="$DATA_BASE/kafka/.bootstrap-creds"
+    local env_file="/etc/uniplus-kafka.env"
+    local unit_file="/etc/systemd/system/uniplus-kafka.service"
+
+    # Diretórios + ownership: Kafka data dir 1000:1000 mode 750. UID 1000
+    # corresponde ao appuser do container. O entrypoint roda já como appuser
+    # (default User no Dockerfile), então NÃO há drop de privs (diferente de
+    # Postgres/Redis/MinIO que iniciam como root).
+    run "sudo mkdir -p $DATA_BASE/kafka/data"
+    run "sudo chown 1000:1000 $DATA_BASE/kafka/data"
+    run "sudo chmod 750 $DATA_BASE/kafka/data"
+
+    # Detectar inicialização prévia: meta.properties no data dir indica
+    # storage formatado. Análogo a PG_VERSION (Postgres) e .minio.sys/ (MinIO).
+    local already_initialized=false
+    if ! $DRY_RUN && \
+       sudo test -f "$DATA_BASE/kafka/data/meta.properties" 2>/dev/null; then
+        already_initialized=true
+    fi
+
+    # ---- Decisão 1: .bootstrap-creds (preservar / gerar / abortar) ----
+    if sudo test -f "$creds_file" 2>/dev/null; then
+        log_success "Bootstrap creds Kafka já existentes — preservando cluster_id."
+    elif $DRY_RUN; then
+        log_warn "Dry-run: cluster_id Kafka seria gerado em $creds_file"
+    elif $already_initialized; then
+        # Guard: meta.properties existe mas .bootstrap-creds shredded ou
+        # perdido. cluster.id está no meta.properties (é o source-of-truth do
+        # storage); operador deve restaurar via §13.4 (lê do meta.properties
+        # ou do Vault) antes de re-rodar.
+        log_error "$creds_file ausente, mas $DATA_BASE/kafka/data/meta.properties já existe."
+        log_error "Regenerar cluster_id agora produziria mismatch com storage formatado."
+        log_error "Restaure $creds_file a partir do Vault — ver docs/RUNBOOKS.md §13.4."
+        exit 1
+    else
+        log_info "Gerando cluster_id Kafka via kafka-storage.sh random-uuid..."
+        local cluster_id
+        # Container ad-hoc apenas pra random-uuid; sem state, descartável.
+        cluster_id=$(sudo docker run --rm --entrypoint /opt/kafka/bin/kafka-storage.sh \
+            apache/kafka:4.2.0 random-uuid 2>/dev/null | tr -d '\r\n')
+        if [[ -z "$cluster_id" ]]; then
+            log_error "Falha ao gerar cluster_id via kafka-storage.sh."
+            exit 1
+        fi
+        sudo tee "$creds_file" >/dev/null <<EOF
+cluster_id=$cluster_id
+EOF
+        sudo chown root:root "$creds_file"
+        sudo chmod 600 "$creds_file"
+        log_warn "cluster_id gerado em $creds_file. Persistir em Vault — ver runbook §13.2."
+    fi
+
+    # EnvironmentFile (sempre re-aplicado). NOTA: cluster_id NÃO é segredo, mas
+    # passamos via env consistente com pattern dos outros services. Configura
+    # KRaft single-node combined com static quorum (KAFKA_CONTROLLER_QUORUM_VOTERS).
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Escreveria $env_file"
+    else
+        local cluster_id_current
+        cluster_id_current=$(sudo grep '^cluster_id=' "$creds_file" | cut -d= -f2)
+        if [[ -z "$cluster_id_current" ]]; then
+            log_error "cluster_id vazio em $creds_file. Abortando."
+            exit 1
+        fi
+        # KAFKA_LOG_DIRS override do default `/tmp/kraft-combined-logs` da
+        # imagem apache/kafka:4.2.0 — sem isso, o broker escreveria em /tmp
+        # dentro do container (efêmero, NÃO no volume mounted), resultando em
+        # data loss silencioso no primeiro restart (cluster_id mismatch entre
+        # env e meta.properties recriado em /tmp).
+        #
+        # KAFKA_HEAP_OPTS PRECISA de aspas — systemd EnvironmentFile parser
+        # tokeniza por espaço sem quoting; sem aspas, apenas `-Xmx1g` é setado
+        # e `-Xms1g` é descartado silenciosamente.
+        sudo tee "$env_file" >/dev/null <<EOF
+CLUSTER_ID=$cluster_id_current
+KAFKA_PROCESS_ROLES=broker,controller
+KAFKA_NODE_ID=1
+KAFKA_LISTENERS=PLAINTEXT://10.0.2.87:9092,CONTROLLER://10.0.2.87:9093
+KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://10.0.2.87:9092
+KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+KAFKA_CONTROLLER_QUORUM_VOTERS=1@10.0.2.87:9093
+KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+KAFKA_LOG_DIRS=/var/lib/kafka/data
+KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
+KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
+KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR=1
+KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR=1
+KAFKA_HEAP_OPTS="-Xmx1g -Xms1g"
+EOF
+        sudo chown root:root "$env_file"
+        sudo chmod 600 "$env_file"
+        unset cluster_id_current
+    fi
+
+    # systemd unit (sempre re-aplicado). Heredoc single-quoted: paths hardcoded.
+    # Container monta /var/lib/uniplus/kafka/data em /var/lib/kafka/data
+    # (path declarado VOLUME no Dockerfile da imagem oficial). KAFKA_LOG_DIRS
+    # explicitamente override do default `/tmp/kraft-combined-logs` para esse
+    # mesmo path — ver heredoc do EnvironmentFile acima. Network host pra
+    # listener bind direto na VCN privada.
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Escreveria $unit_file"
+    else
+        sudo tee "$unit_file" >/dev/null <<'UNIT'
+[Unit]
+Description=Uni+ Apache Kafka 4.2.0 KRaft (standalone data-host)
+Documentation=https://github.com/unifesspa-edu-br/uniplus-infra/blob/main/docs/RUNBOOKS.md
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10
+TimeoutStartSec=180
+EnvironmentFile=/etc/uniplus-kafka.env
+
+ExecStartPre=-/usr/bin/docker rm -f uniplus-kafka
+ExecStart=/usr/bin/docker run --rm --name uniplus-kafka \
+  --network host \
+  -e CLUSTER_ID \
+  -e KAFKA_PROCESS_ROLES \
+  -e KAFKA_NODE_ID \
+  -e KAFKA_LISTENERS \
+  -e KAFKA_ADVERTISED_LISTENERS \
+  -e KAFKA_CONTROLLER_LISTENER_NAMES \
+  -e KAFKA_CONTROLLER_QUORUM_VOTERS \
+  -e KAFKA_INTER_BROKER_LISTENER_NAME \
+  -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP \
+  -e KAFKA_LOG_DIRS \
+  -e KAFKA_AUTO_CREATE_TOPICS_ENABLE \
+  -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR \
+  -e KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR \
+  -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR \
+  -e KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR \
+  -e KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR \
+  -e KAFKA_HEAP_OPTS \
+  -v /var/lib/uniplus/kafka/data:/var/lib/kafka/data \
+  apache/kafka:4.2.0
+
+ExecStop=/usr/bin/docker stop -t 30 uniplus-kafka
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+    fi
+
+    run "sudo systemctl daemon-reload"
+    run "sudo systemctl enable uniplus-kafka"
+
+    if $DRY_RUN; then
+        echo "[DRY-RUN] systemctl start uniplus-kafka + broker-api-versions probe"
+    elif sudo systemctl is-active --quiet uniplus-kafka; then
+        log_success "uniplus-kafka já ativo — preservando state (sem restart)."
+    else
+        sudo systemctl start uniplus-kafka
+        log_info "Aguardando Kafka aceitar conexões (cold start ~30-90s)..."
+        local attempts=0
+        # broker-api-versions é o probe canônico — retorna lista de APIs
+        # quando o broker está ready (post-format + ISR estabilizada). Timeout
+        # mais largo (180s) que Postgres/Redis pelo cold start de JVM + KRaft
+        # metadata controller bootstrap.
+        until sudo docker exec uniplus-kafka \
+                /opt/kafka/bin/kafka-broker-api-versions.sh \
+                --bootstrap-server localhost:9092 &>/dev/null; do
+            attempts=$(( attempts + 1 ))
+            if (( attempts >= 36 )); then
+                log_error "Kafka não respondeu broker-api-versions em 180s."
+                log_error "Ver: sudo journalctl -u uniplus-kafka -n 100"
+                exit 1
+            fi
+            sleep 5
+        done
+        log_success "uniplus-kafka ativo + broker-api-versions OK."
+    fi
+}
+
 summary_data() {
     echo ""
     echo "============================================"
@@ -1336,6 +1547,7 @@ summary_data() {
     echo "  systemctl status uniplus-postgres"
     echo "  systemctl status uniplus-redis"
     echo "  systemctl status uniplus-minio"
+    echo "  systemctl status uniplus-kafka"
     echo ""
     echo "Custódia das senhas iniciais (PRIMEIRA EXECUÇÃO):"
     echo "  Postgres — runbook §9.2:"
@@ -1350,10 +1562,10 @@ summary_data() {
     echo "    1. Ler:        sudo cat $DATA_BASE/minio/.bootstrap-creds"
     echo "    2. Custodiar:  Vault (secret/standalone/minio/root) + gestor institucional"
     echo "    3. Limpar:     sudo shred -u $DATA_BASE/minio/.bootstrap-creds"
-    echo ""
-    echo "Próximos passos (Epic data/*):"
-    echo "  O serviço Kafka será provisionado em sub-task futura"
-    echo "  (mesmo padrão de Postgres/Redis/MinIO: container Docker via systemd)."
+    echo "  Kafka — runbook §13.2 (cluster_id NÃO é segredo):"
+    echo "    1. Ler:        sudo cat $DATA_BASE/kafka/.bootstrap-creds"
+    echo "    2. Registrar:  Vault (secret/standalone/kafka/cluster) — auditoria"
+    echo "    3. .bootstrap-creds permanece (não há shred — sem cleartext de senha)"
     echo ""
     echo "Validar:"
     echo "  df -h $DATA_BASE/*"
@@ -1362,6 +1574,8 @@ summary_data() {
     echo "  sudo docker exec -i uniplus-redis sh -c 'read -r P; REDISCLI_AUTH=\$P redis-cli ping' \\"
     echo "    <<<\"\$(sudo grep ^default_pw= $DATA_BASE/redis/.bootstrap-creds | cut -d= -f2)\""
     echo "  curl -sf http://10.0.2.87:9000/minio/health/live && echo ' — MinIO health OK'"
+    echo "  sudo docker exec uniplus-kafka /opt/kafka/bin/kafka-broker-api-versions.sh \\"
+    echo "    --bootstrap-server localhost:9092 | head -3"
 }
 
 # ============================================================================
@@ -1394,6 +1608,7 @@ case "$ROLE" in
         step_data_setup_redis
         step_data_setup_minio
         step_data_bootstrap_minio_buckets
+        step_data_setup_kafka
         summary_data
         ;;
 esac


### PR DESCRIPTION
## Summary

- Adiciona `step_data_setup_kafka` em `scripts/bootstrap-standalone.sh` — provisiona `apache/kafka:4.2.0` (KRaft only; ZooKeeper removido em 4.0 GA) systemd-managed no data-host, single-node combined (`process.roles=broker,controller`) com static quorum.
- Listeners explícitos: `PLAINTEXT://10.0.2.87:9092` (broker↔client) + `CONTROLLER://10.0.2.87:9093`.
- Auth PLAINTEXT em standalone (subnet privada VCN + iptables); pattern SASL/SCRAM-SHA-512 documentado em §13.6 do RUNBOOKS para hml/prod.
- `cluster_id` gerado via `kafka-storage.sh random-uuid` em container ad-hoc, persistido em `.bootstrap-creds` (NÃO é segredo — sem shred). Format do storage é AUTOMÁTICO via `KafkaDockerWrapper setup` no entrypoint (idempotente).
- Documenta operações em `docs/RUNBOOKS.md` §13: bootstrap, registro Vault (auditoria), validação E2E (produce/consume round-trip), restore, operações comuns, pattern migração SASL, backup, troubleshooting.

## Test plan

- [x] `bash -n scripts/bootstrap-standalone.sh` ✅
- [x] `shellcheck scripts/bootstrap-standalone.sh` ✅ (via koalaman/shellcheck:stable)
- [x] `markdownlint-cli2 docs/RUNBOOKS.md` ✅
- [x] code-reviewer subagent pré-PR (lição PR #131) — **2 P0 endereçados**:
  - **P0.1 mount path:** `KAFKA_LOG_DIRS=/var/lib/kafka/data` adicionado ao EnvironmentFile (override do default `/tmp/kraft-combined-logs`). Sem isso, broker escreveria em `/tmp` dentro do container (efêmero) → data loss silencioso no primeiro restart com `Cluster ID mismatch`.
  - **P0.2 KAFKA_HEAP_OPTS:** aspas obrigatórias (`"-Xmx1g -Xms1g"`) — systemd EnvironmentFile parser tokeniza por espaço sem quoting; sem aspas só `-Xmx1g` é setado. Validado localmente com `bash source` reproduzindo o bug.
- [x] Validação local: `docker run apache/kafka:4.2.0` com static quorum sobe e responde a `kafka-broker-api-versions.sh`; produce/consume round-trip OK
- [ ] CI verde (7 jobs)
- [ ] Codex review sem findings remanescentes
- [ ] Smoke test pós-merge: `systemctl status uniplus-kafka` Active + produce/consume via pod ad-hoc do k8s-host

## Notas técnicas

- **UID/GID:** `1000:1000` (`appuser`, default User no Dockerfile — entrypoint roda já como appuser, sem drop de privs).
- **Static vs dynamic quorum:** static (`KAFKA_CONTROLLER_QUORUM_VOTERS=1@...`) é a escolha correta para single-node combined em 4.2.0 — dynamic exigiria `--standalone` no format command, que o entrypoint do container não aceita sem intervenção manual.
- **Auto-create topics off** — apps criam topics explicitamente (evita typos virando topics fantasma).
- **Wait loop 180s** — cold start de JVM + KRaft metadata controller bootstrap (mais largo que outros services).
- **Idempotência:** preserva `cluster_id` em re-runs; aborta se `meta.properties` existe sem creds; entrypoint do container handle format skip automaticamente.
- **Sem custódia tradicional** — `cluster_id` NÃO é segredo (apenas identificador). Vault registra para auditoria, `.bootstrap-creds` permanece indefinidamente sem shred.

Closes #136
Refs #118 (sub-issue), #40 (Epic standalone)