### PR TITLE
feat(standalone): Kafka SASL_SSL + SCRAM-SHA-512 hardening (ADR-009)

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1907,221 +1907,437 @@ unset NEW_PW
 | `mc alias set` retorna `Unable to verify SSL certificate` | TLS-mismatch ou endpoint errado | Confirmar endpoint `http://` (NÃO `https://`) — standalone usa PLAINTEXT |
 | Disk full em `vg-minio` | Buckets crescem além do volume | `df -h /var/lib/uniplus/minio`; `mc admin info local` para uso por bucket; expandir LVM ou aplicar lifecycle/quota |
 
-## 13. Kafka KRaft (standalone)
+## 13. Kafka KRaft + SASL_SSL + SCRAM-SHA-512 (standalone)
 
-Mensageria — `apache/kafka:4.2.0` (KRaft only; ZooKeeper removido na 4.0 GA) em container Docker gerenciado por systemd no data-host (`10.0.2.87:9092` para clientes, `:9093` para controller). Single-node combined (`process.roles=broker,controller`) com static quorum.
-
-> ⚠️ **Auth em standalone:** PLAINTEXT — subnet privada VCN + iptables INPUT chain filtrando externos. Acceptable para validação. Para hml/prod migrar para SASL/SCRAM-SHA-512 (ver §13.6 — Pattern de migração).
+Mensageria — `apache/kafka:4.2.0` (KRaft only; ZooKeeper removido na 4.0 GA) em container Docker gerenciado por systemd no data-host (`10.0.2.87:9092` para clientes, `:9093` para controller). Single-node combined (`process.roles=broker,controller`) com **SASL_SSL + SCRAM-SHA-512 + StandardAuthorizer** (ADR-009).
 
 ### 13.1 Kafka 4.2.0 — bootstrap automatizado
 
 A função `step_data_setup_kafka` em `scripts/bootstrap-standalone.sh` provisiona, na ordem:
 
-1. Diretório `/var/lib/uniplus/kafka/data` (mode `750`, owner `1000:1000` — uid `appuser` no container, default user da imagem `apache/kafka:4.2.0` sem drop de privs).
-2. `.bootstrap-creds` (root:root 600) em `/var/lib/uniplus/kafka/.bootstrap-creds` com `cluster_id` (UUID gerado via `kafka-storage.sh random-uuid` em container ad-hoc) — gerado **somente na primeira execução**.
-3. EnvironmentFile `/etc/uniplus-kafka.env` (root:root 600) com `CLUSTER_ID`, `KAFKA_PROCESS_ROLES=broker,controller`, `KAFKA_NODE_ID=1`, `KAFKA_LISTENERS`, `KAFKA_ADVERTISED_LISTENERS`, `KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER`, `KAFKA_CONTROLLER_QUORUM_VOTERS=1@10.0.2.87:9093` (static quorum), `KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT`, `KAFKA_LISTENER_SECURITY_PROTOCOL_MAP`, `KAFKA_LOG_DIRS=/var/lib/kafka/data` (override do default `/tmp/kraft-combined-logs`), `KAFKA_AUTO_CREATE_TOPICS_ENABLE=false`, replication factor 1 em internal topics, `KAFKA_HEAP_OPTS="-Xmx1g -Xms1g"` (aspas obrigatórias — systemd EnvironmentFile parser tokeniza por espaço sem quoting).
-4. `systemd` unit `/etc/systemd/system/uniplus-kafka.service` com `Restart=always`, `TimeoutStartSec=180` (cold start de JVM + KRaft metadata controller bootstrap), container em `--network host`, data dir mounted em `/var/lib/kafka/data` (default do entrypoint).
+1. Diretórios:
+   - `/var/lib/uniplus/kafka/data` (mode `750`, owner `1000:1000` — uid `appuser` no container, default user sem drop de privs)
+   - `/etc/uniplus-kafka/certs/` (mode `755`, owner `root:root` — uid 1000 traverse para abrir PEMs)
+   - `/etc/uniplus-kafka/config/` (mesmo padrão; contém `server.properties`)
+2. `.bootstrap-creds` (root:root 600) em `/var/lib/uniplus/kafka/.bootstrap-creds` com `cluster_id` (UUID via `kafka-storage.sh random-uuid`) **e `admin_pw`** (32 bytes hex via `openssl rand`) — gerados **somente na primeira execução**. Mais robusto que o formato pré-ADR-009 que só tinha `cluster_id`.
+3. **Cert PEM self-signed** em `/etc/uniplus-kafka/certs/` (validade **10 anos**), gerado por `openssl req` com SAN multi-tipo (`DNS:kafka.standalone.portaluni.com.br`, `DNS:localhost`, `IP:10.0.2.87`, `IP:127.0.0.1`). Auto-assinado → `ca.crt = server.crt` (cadeia de 1 nível). Bootstrap produz 4 arquivos:
+   - `server.crt` (chown 1000:1000 mode 644) — cert isolado
+   - `server.key` (chown 1000:1000 mode 600) — chave privada isolada
+   - `ca.crt` (chown 1000:1000 mode 644) — CA pra distribuição a clients
+   - `server.pem` (chown 1000:1000 mode 600) — **cert + key concatenados**, apontado por `ssl.keystore.location` no `server.properties`. Kafka 4.x exige bundle PEM (cert+key) para `ssl.keystore.type=PEM`; não há propriedade `*.key.location` separada — o broker lê o bundle e extrai cert/chave internamente.
 
-**Format do storage é AUTOMÁTICO** via `KafkaDockerWrapper setup` no entrypoint do container — chamado em todo startup, mas o wrapper detecta `already formatted` e skip idempotentemente. NÃO há `kafka-storage.sh format` manual no script.
+   cert-manager fica para hml/prod com secret-sync para data-host (extensão K8s não atinge container fora do cluster).
+4. **Format inicial do storage** via container ad-hoc com `--add-scram "SCRAM-SHA-512=[name=admin,password=$ADMIN_PW]"` — embarca admin SCRAM no `__cluster_metadata` log antes do primeiro start. Crítico: `--add-scram` só vale na 1ª formatação; re-format depois NÃO adiciona credenciais. Por isso o script roda format ANTES do `systemctl start`. Subsequentes runs: entrypoint do uniplus-kafka vê "already formatted" e skip.
+5. `server.properties` em `/etc/uniplus-kafka/config/server.properties` (mode `600`, owner `1000:1000` — contém SCRAM password em cleartext na `listener.name.*.sasl.jaas.config`; broker uid 1000 lê, outros não). Inclui:
+   - KRaft topology: `process.roles=broker,controller`, `node.id=1`, `controller.quorum.voters=1@10.0.2.87:9093`
+   - Listeners: `SASL_SSL://10.0.2.87:9092` + `CONTROLLER://10.0.2.87:9093`; `inter.broker.listener.name=SASL_SSL`
+   - SASL: `sasl.enabled.mechanisms=SCRAM-SHA-512`, JAAS inline para os 2 listeners
+   - TLS: `ssl.keystore.type=PEM`, `ssl.keystore.location=/etc/kafka/secrets/server.pem` (bundle cert+key concatenados — Kafka 4.x não tem propriedade `*.key.location` separada), `ssl.truststore.type=PEM`, `ssl.truststore.location=/etc/kafka/secrets/ca.crt`, `ssl.client.auth=none`
+   - AuthZ: `authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer`, `super.users=User:admin`, `allow.everyone.if.no.acl.found=false` (fail-closed)
+6. `admin.properties` em `/var/lib/uniplus/kafka/admin.properties` (root:root 600) — client config para `kafka-topics.sh`/`kafka-acls.sh`/`kafka-configs.sh`/`kafka-broker-api-versions.sh` rodando como admin via `--command-config`.
+7. EnvironmentFile minimizado `/etc/uniplus-kafka.env` (root:root 600) com `CLUSTER_ID` (entrypoint exige) + `KAFKA_HEAP_OPTS="-Xmx1g -Xms1g"` (aspas obrigatórias — systemd EnvironmentFile parser tokeniza por espaço sem quoting).
+8. `systemd` unit `/etc/systemd/system/uniplus-kafka.service` (`Restart=always`, `TimeoutStartSec=180`, `--network host`). Mount `config_dir → /mnt/shared/config:ro`; `KafkaDockerWrapper setup` do entrypoint pega o `server.properties` dali. Mount `certs_dir → /etc/kafka/secrets:ro`. Data dir → `/var/lib/kafka/data`.
+
+**Por que `server.properties` em vez de env vars `KAFKA_*`:** a imagem `apache/kafka:4.2.0` traduz env vars `KAFKA_FOO_BAR_BAZ` → `foo.bar.baz`, mas a transformação não preserva hyphens. Properties como `listener.name.sasl_ssl.scram-sha-512.sasl.jaas.config` não podem ser representadas como env var. Solução oficial: `--mounted-configs-dir`.
 
 **Idempotência:**
 
-- `.bootstrap-creds`: preserva se existe; gera se ausente; aborta se `data/meta.properties` já formatado sem creds (regenerar `cluster_id` produziria mismatch entre runtime config e storage).
-- EnvironmentFile + systemd unit: sempre re-aplicados.
-- Entrypoint do container: format skip se já formatado.
+- `.bootstrap-creds`: preserva (validando que tem `admin_pw` — formato pré-ADR-009 falha com instrução); gera se ausente; aborta se `data/meta.properties` formatado sem creds.
+- Certs: regenerados se ausentes; preservados em re-runs (clients podem ter cacheado o CA).
+- Format: explícito em container ad-hoc com `--add-scram` na 1ª run; entrypoint do uniplus-kafka subsequente vê "already formatted" e skip.
+- `server.properties` + `admin.properties` + EnvironmentFile + systemd unit: sempre re-aplicados.
 - Serviço já ativo: bootstrap não reinicia.
 
 **Verificação imediata pós-bootstrap (no data-host):**
 
 ```bash
 sudo systemctl status uniplus-kafka
-sudo docker exec uniplus-kafka /opt/kafka/bin/kafka-broker-api-versions.sh \
-  --bootstrap-server localhost:9092 | head -3
+
+# kafka-broker-api-versions.sh agora exige cliente SASL_SSL — usar
+# admin.properties (gerado pelo bootstrap) via container ad-hoc.
+sudo docker run --rm --network host \
+  -v /var/lib/uniplus/kafka/admin.properties:/tmp/admin.properties:ro \
+  -v /etc/uniplus-kafka/certs/ca.crt:/etc/uniplus-kafka/certs/ca.crt:ro \
+  --entrypoint /opt/kafka/bin/kafka-broker-api-versions.sh \
+  apache/kafka:4.2.0 \
+  --bootstrap-server 10.0.2.87:9092 \
+  --command-config /tmp/admin.properties | head -3
 # Esperado: lista de APIs (Produce, Fetch, ListOffsets, Metadata, ...)
 ```
 
-### 13.2 Registrar `cluster_id` no Vault (auditoria)
+### 13.1.1 Migração: PLAINTEXT (PR #137) → SASL_SSL (ADR-009)
 
-> O `cluster_id` **NÃO é segredo** — é apenas o identificador único do cluster (previne mistura entre brokers de clusters diferentes). Persistir em Vault é para documentação/auditoria; o arquivo `.bootstrap-creds` permanece no data-host indefinidamente (sem shred — não há cleartext de senha).
+Operadores com Kafka standalone deployado em PLAINTEXT (PR #137) — `.bootstrap-creds` contém só `cluster_id` sem `admin_pw` — precisam fazer **reset completo do storage** antes de re-rodar o bootstrap. Não há migração in-place porque:
+
+- `--add-scram` só é honrado durante format inicial — re-format de storage existente NÃO adiciona credenciais
+- Apagar e re-formatar com mesmo `cluster_id` exige data dir vazio (Kafka recusa format se houver `meta.properties`)
+- Standalone é validação — perda de mensagens não é blocker
+
+Procedimento (executar no data-host):
 
 ```bash
-# Ler cluster_id no data-host
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87
+
+# 1) Parar o serviço PLAINTEXT
+sudo systemctl stop uniplus-kafka
+
+# 2) Backup do .bootstrap-creds antigo (auditoria)
+sudo cp /var/lib/uniplus/kafka/.bootstrap-creds \
+        /var/lib/uniplus/kafka/.bootstrap-creds.pre-sasl.bak
+sudo chmod 600 /var/lib/uniplus/kafka/.bootstrap-creds.pre-sasl.bak
+
+# 3) Shred do creds atual + reset do data dir (perde tópicos + mensagens; standalone não usa)
+sudo shred -u /var/lib/uniplus/kafka/.bootstrap-creds
+sudo find /var/lib/uniplus/kafka/data/ -mindepth 1 -delete
+
+# 4) Re-rodar bootstrap (gera novo cluster_id + admin_pw + cert + format com --add-scram)
+cd ~/uniplus-infra && git pull --ff-only
+./scripts/bootstrap-standalone.sh --role=standalone-data
+```
+
+Após o bootstrap concluir com sucesso, completar:
+
+- Custodiar as **novas** credenciais via §13.2 (admin_pw em `secret/standalone/kafka/admin`, cluster_id em `secret/standalone/kafka/cluster` — o `cluster_id` antigo persiste no path antigo do Vault e pode ser deletado: `vault kv delete secret/standalone/kafka/cluster` antes do `kv put` novo, ou `vault kv metadata delete` para purge completo)
+- Distribuir o novo `ca.crt` para qualquer cliente que tenha cacheado o antigo (em standalone single-host, normalmente apenas AKHQ futuro — não há clientes ativos hoje)
+- Validar via §13.3
+
+> Em hml/prod com mensagens reais, esse pattern não se aplica — exige procedimento de migração com reset gradual (broker novo SASL_SSL em paralelo, mirror via MirrorMaker 2, switchover de clients). Standalone aceita o reset porque não há state real.
+
+### 13.2 Custódia das credenciais iniciais
+
+> ⚠️ **CRÍTICO.** O `.bootstrap-creds` contém `admin_pw` (32 bytes hex) que é o segredo de acesso ao cluster. Custodiar no Vault + gestor institucional. `cluster_id` continua não-segredo (apenas identificador) — registrado em path separado para auditoria.
+
+**Passo 1 — Ler creds no data-host:**
+
+```bash
 ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87
 sudo cat /var/lib/uniplus/kafka/.bootstrap-creds
 # cluster_id=<UUID>
+# admin_pw=<64 hex>
 ```
 
-**Registrar no Vault (executar do k8s-host):**
+**Passo 2 — Salvar no Vault (executar do k8s-host):**
 
 ```bash
-read -rsp "Cole cluster_id (do passo anterior): " KAFKA_CID; echo
+read -rsp "Cole admin_pw (do passo 1): " KAFKA_ADMIN_PW; echo
+read -rsp "Cole cluster_id (do passo 1): " KAFKA_CID; echo
 
 sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
   -n vault port-forward platform-vault-uniplus-standalone-0 8200:8200 \
   > /tmp/vault-pf.log 2>&1 &
 PF_PID=$!
-trap 'kill "$PF_PID" 2>/dev/null; unset KAFKA_CID VAULT_TOKEN VAULT_ADDR' EXIT
+trap 'kill "$PF_PID" 2>/dev/null; unset KAFKA_ADMIN_PW KAFKA_CID VAULT_TOKEN VAULT_ADDR' EXIT
 export VAULT_ADDR=http://127.0.0.1:8200
 until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
 
 read -rsp "Root token: " VAULT_TOKEN; echo
 export VAULT_TOKEN
 
+# Admin SCRAM (segredo + CA cert para clients)
+CA_CERT=$(ssh ubuntu@10.0.2.87 "sudo cat /etc/uniplus-kafka/certs/ca.crt")
+vault kv put secret/standalone/kafka/admin \
+  username=admin \
+  password="$KAFKA_ADMIN_PW" \
+  bootstrap_servers=10.0.2.87:9092 \
+  mechanism=SCRAM-SHA-512 \
+  ca_cert="$CA_CERT"
+
+# Cluster info (auditoria, não-segredo)
 vault kv put secret/standalone/kafka/cluster \
   bootstrap_servers=10.0.2.87:9092 \
   cluster_id="$KAFKA_CID"
 
+vault kv get secret/standalone/kafka/admin
 vault kv get secret/standalone/kafka/cluster
+unset CA_CERT
 ```
+
+> Com `admin_pw` no Vault, considerar `shred -u .bootstrap-creds` no data-host. Trade-off: re-execução do bootstrap aborta (storage formatado sem creds); restauração via §13.4. Em standalone, manter o file é defensável — apenas `root` no data-host lê.
 
 ### 13.3 Validação end-to-end (pod K8s → Kafka)
 
-Confirma que pods do cluster K3s alcançam Kafka no data-host via flannel→VCN. Pré-requisito: PR #125 aplicado (iptables FORWARD ACCEPT).
+Confirma que pods do cluster K3s alcançam Kafka SASL_SSL no data-host. Pré-requisito: PR #125 aplicado (iptables FORWARD ACCEPT) + CA cert distribuível (de `secret/standalone/kafka/admin` ou direto do data-host).
 
 **Executar no k8s-host:**
 
 ```bash
 # 1) Conectividade TCP bruta
 nc -zv 10.0.2.87 9092
-# Esperado: succeeded
+# Esperado: succeeded (mas TCP succeeded != auth ok — segue passo 2)
 
-# 2) Pod ad-hoc com cliente Kafka — produce + consume round-trip
+# 2) Pod ad-hoc com cliente Kafka — produce + consume round-trip via SASL_SSL.
+#    admin_pw lido do Vault via kubectl exec (não argv); admin.properties
+#    montado via configmap efêmero criado just-in-time.
+read -rsp "Root token: " TKN; echo
+
+ADMIN_PW=$(sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault exec -i platform-vault-uniplus-standalone-0 -- \
+  sh -c 'read -r T; export VAULT_TOKEN="$T"; vault kv get -field=password secret/standalone/kafka/admin' \
+  <<<"$TKN")
+CA_CERT=$(sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault exec -i platform-vault-uniplus-standalone-0 -- \
+  sh -c 'read -r T; export VAULT_TOKEN="$T"; vault kv get -field=ca_cert secret/standalone/kafka/admin' \
+  <<<"$TKN")
+unset TKN
+
+# Gera ConfigMap com client.properties + ca.crt (resource scoped ao smoke test)
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml create configmap kafka-smoke-client \
+  --from-literal=client.properties="security.protocol=SASL_SSL
+sasl.mechanism=SCRAM-SHA-512
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"admin\" password=\"$ADMIN_PW\";
+ssl.truststore.type=PEM
+ssl.truststore.location=/tmp/cm/ca.crt
+ssl.endpoint.identification.algorithm=" \
+  --from-literal=ca.crt="$CA_CERT" \
+  --dry-run=client -o yaml | sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml apply -f -
+unset ADMIN_PW CA_CERT
+
 sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml run kafka-validation \
-  --image=apache/kafka:4.2.0 --restart=Never --rm -i --command -- bash -c '
-    set -euo pipefail
-    BS=10.0.2.87:9092
+  --image=apache/kafka:4.2.0 --restart=Never --rm -i \
+  --overrides='{"spec":{"containers":[{"name":"kafka-validation","image":"apache/kafka:4.2.0","command":["bash","-c","set -euo pipefail; BS=10.0.2.87:9092; CC=/tmp/cm/client.properties; /opt/kafka/bin/kafka-topics.sh --bootstrap-server $BS --command-config $CC --create --topic uniplus-smoke --partitions 1 --replication-factor 1; echo hello-uniplus | /opt/kafka/bin/kafka-console-producer.sh --bootstrap-server $BS --producer.config $CC --topic uniplus-smoke; /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server $BS --consumer.config $CC --topic uniplus-smoke --from-beginning --max-messages 1 --timeout-ms 10000; /opt/kafka/bin/kafka-topics.sh --bootstrap-server $BS --command-config $CC --delete --topic uniplus-smoke"],"volumeMounts":[{"name":"cm","mountPath":"/tmp/cm","readOnly":true}]}],"volumes":[{"name":"cm","configMap":{"name":"kafka-smoke-client"}}]}}'
 
-    /opt/kafka/bin/kafka-topics.sh --bootstrap-server "$BS" \
-      --create --topic uniplus-smoke --partitions 1 --replication-factor 1
-
-    echo "hello-uniplus" | /opt/kafka/bin/kafka-console-producer.sh \
-      --bootstrap-server "$BS" --topic uniplus-smoke
-
-    /opt/kafka/bin/kafka-console-consumer.sh \
-      --bootstrap-server "$BS" --topic uniplus-smoke \
-      --from-beginning --max-messages 1 --timeout-ms 10000
-
-    /opt/kafka/bin/kafka-topics.sh --bootstrap-server "$BS" \
-      --delete --topic uniplus-smoke
-  '
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml delete configmap kafka-smoke-client
 # Esperado: "hello-uniplus" no consumer; topic deletado
 ```
 
-### 13.4 Restore: re-criar `.bootstrap-creds` a partir do meta.properties ou Vault
+> O pattern com ConfigMap é necessário porque `kubectl run` simples não monta secrets. Em produção (Fase 5), apps consomem `kafka-credentials-<app>` via ESO — secret K8s direto, sem ConfigMap.
 
-Caso o `.bootstrap-creds` seja perdido mas `meta.properties` exista no data dir, o `cluster_id` está ali (escrito pelo entrypoint na primeira formatação):
+### 13.4 Restore: re-criar `.bootstrap-creds` a partir do Vault
 
-```bash
-ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87
-sudo grep '^cluster.id=' /var/lib/uniplus/kafka/data/meta.properties
-# cluster.id=<UUID>
-
-# Reconstituir .bootstrap-creds
-CID=$(sudo grep '^cluster.id=' /var/lib/uniplus/kafka/data/meta.properties | cut -d= -f2)
-echo "cluster_id=$CID" | sudo tee /var/lib/uniplus/kafka/.bootstrap-creds
-sudo chown root:root /var/lib/uniplus/kafka/.bootstrap-creds
-sudo chmod 600 /var/lib/uniplus/kafka/.bootstrap-creds
-```
-
-Se `meta.properties` também foi perdido (data dir resetado), recuperar do Vault:
+Se `.bootstrap-creds` foi shredded ou perdido, recuperar `cluster_id` (de `meta.properties` no data dir OU do Vault) e `admin_pw` (do Vault):
 
 ```bash
-# k8s-host — kubectl exec no pod Vault para ler o registro
+# k8s-host — port-forward + leitura dos secrets
 read -rsp "Root token: " VAULT_TOKEN; echo
 
 CID=$(sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
   -n vault exec -i platform-vault-uniplus-standalone-0 -- \
   sh -c 'read -r T; export VAULT_TOKEN="$T"; vault kv get -field=cluster_id secret/standalone/kafka/cluster' \
   <<<"$VAULT_TOKEN")
+APW=$(sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault exec -i platform-vault-uniplus-standalone-0 -- \
+  sh -c 'read -r T; export VAULT_TOKEN="$T"; vault kv get -field=password secret/standalone/kafka/admin' \
+  <<<"$VAULT_TOKEN")
 
+# Sanidade: cluster_id do Vault deve bater com meta.properties (se existir)
+META_CID=$(ssh ubuntu@10.0.2.87 \
+  "sudo grep '^cluster.id=' /var/lib/uniplus/kafka/data/meta.properties 2>/dev/null | cut -d= -f2")
+if [[ -n "$META_CID" && "$META_CID" != "$CID" ]]; then
+  echo "ERRO: cluster_id do Vault ($CID) ≠ meta.properties ($META_CID)" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# Reconstituir
 ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87 \
   "sudo tee /var/lib/uniplus/kafka/.bootstrap-creds > /dev/null && \
    sudo chmod 600 /var/lib/uniplus/kafka/.bootstrap-creds && \
    sudo chown root:root /var/lib/uniplus/kafka/.bootstrap-creds" <<EOF
 cluster_id=$CID
+admin_pw=$APW
 EOF
-unset VAULT_TOKEN CID
+unset VAULT_TOKEN CID APW META_CID
 ```
 
-> ⚠️ Restaurar `cluster_id` SEM `meta.properties` correspondente significa que o cluster perdeu o storage. Re-rodar o bootstrap recriará `meta.properties` a partir do `cluster_id` restaurado, mas **todos os topics e mensagens são perdidos**. Em standalone, mensageria é volátil; produção exige replicação cross-DC.
+> ⚠️ Restaurar `cluster_id` **sem** `meta.properties` correspondente significa storage perdido. Re-rodar bootstrap recriará `meta.properties`, mas **todos os tópicos e mensagens são perdidos**. Em standalone, mensageria é volátil (single-broker, sem replicação).
 
-### 13.5 Operações comuns
+### 13.5 Operações comuns (admin)
+
+Todos os exemplos rodam o cliente em container ad-hoc com mount do `admin.properties`. Substituir pelo CA cert no path do truststore.
 
 **Listar topics:**
 
 ```bash
-sudo docker exec uniplus-kafka /opt/kafka/bin/kafka-topics.sh \
-  --bootstrap-server localhost:9092 --list
+sudo docker run --rm --network host \
+  -v /var/lib/uniplus/kafka/admin.properties:/tmp/admin.properties:ro \
+  -v /etc/uniplus-kafka/certs/ca.crt:/etc/uniplus-kafka/certs/ca.crt:ro \
+  --entrypoint /opt/kafka/bin/kafka-topics.sh \
+  apache/kafka:4.2.0 \
+  --bootstrap-server 10.0.2.87:9092 --command-config /tmp/admin.properties --list
 ```
 
-**Criar topic com partições e retenção customizadas:**
+**Criar tópico com partições e retenção customizadas:**
 
 ```bash
-sudo docker exec uniplus-kafka /opt/kafka/bin/kafka-topics.sh \
-  --bootstrap-server localhost:9092 \
-  --create --topic uniplus-events \
+sudo docker run --rm --network host \
+  -v /var/lib/uniplus/kafka/admin.properties:/tmp/admin.properties:ro \
+  -v /etc/uniplus-kafka/certs/ca.crt:/etc/uniplus-kafka/certs/ca.crt:ro \
+  --entrypoint /opt/kafka/bin/kafka-topics.sh \
+  apache/kafka:4.2.0 \
+  --bootstrap-server 10.0.2.87:9092 --command-config /tmp/admin.properties \
+  --create --topic uniplus.events.candidato.inscrito \
   --partitions 3 --replication-factor 1 \
   --config retention.ms=604800000  # 7 dias
+```
+
+**Criar user SCRAM per-app (Fase 5):**
+
+```bash
+APP_PW=$(openssl rand -hex 32)
+
+sudo docker run --rm --network host \
+  -v /var/lib/uniplus/kafka/admin.properties:/tmp/admin.properties:ro \
+  -v /etc/uniplus-kafka/certs/ca.crt:/etc/uniplus-kafka/certs/ca.crt:ro \
+  --entrypoint /opt/kafka/bin/kafka-configs.sh \
+  apache/kafka:4.2.0 \
+  --bootstrap-server 10.0.2.87:9092 --command-config /tmp/admin.properties \
+  --alter --add-config "SCRAM-SHA-512=[password=$APP_PW]" \
+  --entity-type users --entity-name uniplus-portal-svc
+
+# Custodiar APP_PW em secret/standalone/kafka/uniplus-portal-svc
+unset APP_PW
+```
+
+**Adicionar ACLs (producer + consumer prefixed):**
+
+```bash
+sudo docker run --rm --network host \
+  -v /var/lib/uniplus/kafka/admin.properties:/tmp/admin.properties:ro \
+  -v /etc/uniplus-kafka/certs/ca.crt:/etc/uniplus-kafka/certs/ca.crt:ro \
+  --entrypoint /opt/kafka/bin/kafka-acls.sh \
+  apache/kafka:4.2.0 \
+  --bootstrap-server 10.0.2.87:9092 --command-config /tmp/admin.properties \
+  --add --allow-principal User:uniplus-portal-svc \
+  --producer --topic uniplus.events. --resource-pattern-type prefixed
+
+sudo docker run --rm --network host \
+  -v /var/lib/uniplus/kafka/admin.properties:/tmp/admin.properties:ro \
+  -v /etc/uniplus-kafka/certs/ca.crt:/etc/uniplus-kafka/certs/ca.crt:ro \
+  --entrypoint /opt/kafka/bin/kafka-acls.sh \
+  apache/kafka:4.2.0 \
+  --bootstrap-server 10.0.2.87:9092 --command-config /tmp/admin.properties \
+  --add --allow-principal User:uniplus-portal-svc \
+  --consumer --topic uniplus.events. --resource-pattern-type prefixed \
+  --group uniplus-portal.
 ```
 
 **Inspecionar consumer groups:**
 
 ```bash
-sudo docker exec uniplus-kafka /opt/kafka/bin/kafka-consumer-groups.sh \
-  --bootstrap-server localhost:9092 --list
-sudo docker exec uniplus-kafka /opt/kafka/bin/kafka-consumer-groups.sh \
-  --bootstrap-server localhost:9092 --describe --group <group-name>
+sudo docker run --rm --network host \
+  -v /var/lib/uniplus/kafka/admin.properties:/tmp/admin.properties:ro \
+  -v /etc/uniplus-kafka/certs/ca.crt:/etc/uniplus-kafka/certs/ca.crt:ro \
+  --entrypoint /opt/kafka/bin/kafka-consumer-groups.sh \
+  apache/kafka:4.2.0 \
+  --bootstrap-server 10.0.2.87:9092 --command-config /tmp/admin.properties \
+  --describe --group uniplus-portal-consumer
 ```
 
-### 13.6 Pattern de migração para SASL/SCRAM-SHA-512 (hml/prod)
+### 13.6 Rotacionar admin password
 
-Em standalone PLAINTEXT é aceitável (subnet privada). Para hml/prod, a migração envolve:
+Operação não-trivial — admin SCRAM está embarcada no `__cluster_metadata` log via `--add-scram` da formatação inicial. Rotação demanda `ALTER USER` no Kafka + atualização do `server.properties` + restart do broker.
 
-1. **Re-format do storage com SCRAM credentials embarcadas:**
+> ⚠️ **Trade-off de segurança:** o passo 1 expõe `$NEW_PW` em `/proc/<pid>/cmdline` durante ~1s — `kafka-configs.sh --add-config` exige password inline (Kafka 4.x não aceita stdin/arquivo para esse parâmetro), mesmo trade-off do `--add-scram` durante format inicial documentado no script bootstrap. Janela curta + namespace de container descartável + acesso restrito ao data-host (root/ubuntu via SSH key) tornam aceitável em standalone. Para hml/prod considerar: (a) rolling restart com novo broker SASL_SSL e migração de users, ou (b) ferramentas de admin com `kafka-storage.sh format` em data dir limpo (downtime + perda de ACLs).
 
-   ```bash
-   /opt/kafka/bin/kafka-storage.sh format \
-     --config /opt/kafka/config/server.properties \
-     --cluster-id <UUID> \
-     --add-scram 'SCRAM-SHA-512=[name=admin,password=<senha-forte>]' \
-     --ignore-formatted
-   ```
+```bash
+# 1) Gerar nova senha + ALTER user no Kafka
+NEW_PW=$(openssl rand -hex 32)
 
-2. **Atualizar EnvironmentFile** com:
+ssh ubuntu@10.0.2.87 "sudo docker run --rm --network host \
+  -v /var/lib/uniplus/kafka/admin.properties:/tmp/admin.properties:ro \
+  -v /etc/uniplus-kafka/certs/ca.crt:/etc/uniplus-kafka/certs/ca.crt:ro \
+  --entrypoint /opt/kafka/bin/kafka-configs.sh \
+  apache/kafka:4.2.0 \
+  --bootstrap-server 10.0.2.87:9092 --command-config /tmp/admin.properties \
+  --alter --add-config 'SCRAM-SHA-512=[password=$NEW_PW]' \
+  --entity-type users --entity-name admin"
 
-   ```
-   KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:SASL_PLAINTEXT,PLAINTEXT:SASL_PLAINTEXT
-   KAFKA_SASL_ENABLED_MECHANISMS=SCRAM-SHA-512
-   KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=SCRAM-SHA-512
-   KAFKA_SASL_MECHANISM_CONTROLLER_PROTOCOL=SCRAM-SHA-512
-   KAFKA_SUPER_USERS=User:admin
-   ```
+# 2) Atualizar Vault
+read -rsp "Root token: " TKN; echo
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault exec -i platform-vault-uniplus-standalone-0 -- \
+  sh -c 'read -r T; read -r P; export VAULT_TOKEN="$T"; vault kv patch secret/standalone/kafka/admin password="$P"' \
+  <<EOF
+$TKN
+$NEW_PW
+EOF
 
-3. **Custodiar admin password no Vault** em `secret/standalone/kafka/admin` (`username`+`password`); sub-usuários per-app via `kafka-configs.sh --add-config 'SCRAM-SHA-512=[password=...]'` na Fase 5.
+# 3) Atualizar .bootstrap-creds + re-rodar bootstrap (regera server.properties
+#    + admin.properties com a nova senha)
+ssh ubuntu@10.0.2.87 "sudo sed -i 's/^admin_pw=.*$/admin_pw=$NEW_PW/' /var/lib/uniplus/kafka/.bootstrap-creds"
+ssh ubuntu@10.0.2.87 "cd ~/uniplus-infra && ./scripts/bootstrap-standalone.sh --role=standalone-data"
 
-> Não implementar essa migração em standalone — apenas registrar como follow-up para Story de hml.
+# 4) Restart do broker para que o JAAS inline em server.properties recarregue
+ssh ubuntu@10.0.2.87 "sudo systemctl restart uniplus-kafka"
 
-### 13.7 Backup e Restore
+# 5) Validar com nova senha (admin.properties já regenerado)
+ssh ubuntu@10.0.2.87 "sudo docker run --rm --network host \
+  -v /var/lib/uniplus/kafka/admin.properties:/tmp/admin.properties:ro \
+  -v /etc/uniplus-kafka/certs/ca.crt:/etc/uniplus-kafka/certs/ca.crt:ro \
+  --entrypoint /opt/kafka/bin/kafka-broker-api-versions.sh \
+  apache/kafka:4.2.0 \
+  --bootstrap-server 10.0.2.87:9092 --command-config /tmp/admin.properties | head -1"
+
+unset NEW_PW TKN
+```
+
+> Apps consumidoras (Fase 5) usando user `admin` precisam restart com a nova senha. Apps com user dedicado (recomendado) não são afetadas.
+
+### 13.7 Rotacionar cert TLS
+
+Self-signed estático com validade 10 anos — rotação programática não está prevista em standalone. Se necessário (compromisso de chave, expiração antecipada):
+
+```bash
+# 1) Backup do cert antigo
+ssh ubuntu@10.0.2.87 "sudo cp /etc/uniplus-kafka/certs/server.crt /etc/uniplus-kafka/certs/server.crt.bak.$(date +%s)"
+
+# 2) Apagar para forçar regeneração no próximo bootstrap
+ssh ubuntu@10.0.2.87 "sudo rm /etc/uniplus-kafka/certs/server.{crt,key} /etc/uniplus-kafka/certs/ca.crt"
+
+# 3) Re-rodar bootstrap (gera novo cert)
+ssh ubuntu@10.0.2.87 "cd ~/uniplus-infra && ./scripts/bootstrap-standalone.sh --role=standalone-data"
+
+# 4) Atualizar ca_cert no Vault
+NEW_CA=$(ssh ubuntu@10.0.2.87 "sudo cat /etc/uniplus-kafka/certs/ca.crt")
+read -rsp "Root token: " TKN; echo
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+  -n vault exec -i platform-vault-uniplus-standalone-0 -- \
+  sh -c 'read -r T; CERT=$(cat); export VAULT_TOKEN="$T"; vault kv patch secret/standalone/kafka/admin ca_cert="$CERT"' <<EOF
+$TKN
+$NEW_CA
+EOF
+
+# 5) Restart broker (carrega novo cert)
+ssh ubuntu@10.0.2.87 "sudo systemctl restart uniplus-kafka"
+
+# 6) Apps consumidoras (Fase 5) precisam refresh do CA via ESO/configmap
+unset NEW_CA TKN
+```
+
+### 13.8 Backup e Restore
 
 > Procedimento detalhado em sub-task da Story #118. Resumo:
 >
-> - **Backup:** snapshot LVM (`vg-kafka/lv-kafka`) ou cópia do data dir após `systemctl stop uniplus-kafka`. **Backup ao vivo de Kafka NÃO é confiável** — cópia inconsistente entre arquivos de log e índices. Sempre stop antes de copiar.
-> - **Restore:** parar `uniplus-kafka`, restaurar volume via LVM snapshot ou `tar -xz` do backup, ajustar ownership `1000:1000`, iniciar serviço. `cluster_id` em `meta.properties` deve ser preservado.
+> - **Backup:** snapshot LVM (`vg-kafka/lv-kafka`) ou cópia do data dir após `systemctl stop uniplus-kafka`. **Backup ao vivo de Kafka NÃO é confiável** — cópia inconsistente entre arquivos de log e índices. Sempre stop antes de copiar. **Incluir `/etc/uniplus-kafka/certs/` e `/etc/uniplus-kafka/config/server.properties` no backup** — `cluster_id` em `meta.properties` é pareado com cert que validou clients existentes.
+> - **Restore:** parar `uniplus-kafka`, restaurar volume + certs + server.properties, ajustar ownership (data 1000:1000, certs 1000:1000, server.properties 1000:1000 mode 600), iniciar serviço.
 >
-> **Em standalone, perda de Kafka afeta:** mensagens em-vôo (perda dependendo do consumer offset). Aceitável em validação; produção exige cluster multi-broker com replication factor ≥ 3.
+> **Em standalone, perda de Kafka afeta:** mensagens em-vôo (perda dependendo do consumer offset) + ACLs/users SCRAM (recriáveis se admin password preservado). Aceitável em validação.
 
-### 13.8 Troubleshooting
+### 13.9 Pattern de migração para hml/prod
+
+ADR-009 documenta os deltas previstos:
+
+- **Cert:** self-signed → cert-manager Issuer (interno ou Let's Encrypt) + secret-sync para data-host (CronJob extrai cert renovado a cada 30 dias e SCP para `/etc/uniplus-kafka/certs/`)
+- **Cluster:** single-node → 3 brokers HA com `replication.factor=3`, `min.insync.replicas=2`
+- **Auth:** SASL/SCRAM-SHA-512 mantém-se; mTLS opcional adicionado em listener separado para inter-broker
+- **AuthZ:** ACLs persistem no `__cluster_metadata` log; só copiar; verificar com `kafka-acls.sh --list`
+
+> Não implementar em standalone — apenas registrar como follow-up para Story HA.
+
+### 13.10 Troubleshooting
 
 | Sintoma | Diagnóstico | Fix |
 |---|---|---|
-| Container reinicia em loop com `Cluster ID mismatch` | `CLUSTER_ID` no env diferente do `cluster.id` em `meta.properties` | Restaurar `.bootstrap-creds` correto via §13.4; o env é gerado dele |
-| `Connection refused` ao chamar `kafka-broker-api-versions.sh` | Bootstrap ainda inicializando (~30-90s na primeira run) ou listener bind falhou | `sudo journalctl -u uniplus-kafka -n 100`; conferir `KAFKA_LISTENERS` no env |
-| `LEADER_NOT_AVAILABLE` ao produzir | Topic recém-criado; metadata refresh não propagou | Aguardar 1-2s e retry; em standalone com 1 broker, isso é raro mas possível em load alto |
-| `OutOfMemoryError: Java heap space` | `KAFKA_HEAP_OPTS=-Xmx1g` insuficiente para workload | Aumentar `-Xmx` no EnvironmentFile; restart |
-| `nc -zv 10.0.2.87 9092` succeeded mas pod retorna timeout | iptables FORWARD ainda dropping flannel→VCN | Mesma diagnose de §11.3/§12.3 — ver §8.6/§8.7 do plano #123 |
-| `auto.create.topics.enable` desligado mas app cria topic implicitamente | App configurado com `allow.auto.create.topics=true` (client-side) — Kafka 4.x ainda permite isso por default | App deve criar topics explicitamente via API; ou desabilitar client-side allow |
-| Disk full em `vg-kafka` | Logs cresceram além do volume | `df -h /var/lib/uniplus/kafka`; aplicar `retention.ms` ou `retention.bytes` por topic; expandir LVM |
-| `KRaft metadata controller is not yet ready` no startup | Cold start ainda em progresso ou storage corrupto | Aguardar até 180s; se persiste, conferir integridade de `meta.properties` e `__cluster_metadata-0/` |
+| Container reinicia em loop com `Cluster ID mismatch` | `CLUSTER_ID` no env diferente do `cluster.id` em `meta.properties` | Restaurar `.bootstrap-creds` correto via §13.4 |
+| `Authentication failed during authentication` | Senha SCRAM no `server.properties`/admin.properties dessincronizada do `__cluster_metadata` | Conferir `vault kv get` vs `.bootstrap-creds`; se mismatch, rotacionar via §13.6 |
+| `SSL handshake failed: PKIX path building failed` | Cliente não tem o CA no truststore | Distribuir `/etc/uniplus-kafka/certs/ca.crt` para o cliente; conferir `ssl.truststore.location` no client.properties |
+| `Connection to node -1 failed` em smoke test | Faltou `--command-config` (cliente tentando PLAINTEXT contra listener SASL_SSL) | Sempre passar `--command-config admin.properties` em CLI tools |
+| `ACL DENIED` para user existente | ACL não criada ou pattern errado (literal vs prefixed) | `kafka-acls.sh --list` filtrando por principal; recriar ACL com `--resource-pattern-type prefixed` se aplicável |
+| `endpoint identification algorithm` failure no client | Cliente verificando hostname no cert; standalone usa SAN IP/DNS específicos | `ssl.endpoint.identification.algorithm=` (vazio) no client.properties |
+| `OutOfMemoryError: Java heap space` | `KAFKA_HEAP_OPTS=-Xmx1g` insuficiente | Aumentar `-Xmx` no EnvironmentFile (manter aspas); restart |
+| `nc -zv 10.0.2.87 9092` succeeded mas SASL_SSL falha | TCP OK, mas auth/cert problem | `journalctl -u uniplus-kafka -n 100`; conferir `server.properties` perms (600 chown 1000:1000); conferir `ca.crt` legível pelo client |
+| Cert expirado (ano 2036+) | Validade self-signed esgotou | Rotacionar via §13.7; alertar em monitoring quando < 30 dias |
+| `KRaft metadata controller is not yet ready` | Cold start ou storage corrupto | Aguardar até 180s; se persiste, conferir `__cluster_metadata-0/` |
+| Disk full em `vg-kafka` | Logs cresceram além do volume | `df -h /var/lib/uniplus/kafka`; aplicar `retention.ms`/`retention.bytes` por topic; expandir LVM |
 
 ---
 

--- a/docs/adrs/ADR-009-kafka-sasl-ssl-scram-standalone.md
+++ b/docs/adrs/ADR-009-kafka-sasl-ssl-scram-standalone.md
@@ -1,0 +1,160 @@
+# ADR-009: Kafka standalone com SASL_SSL + SCRAM-SHA-512 + StandardAuthorizer
+
+- **Status:** 🟡 Proposta
+- **Data:** 2026-05-07
+- **Relacionado:** [Issue #138](https://github.com/unifesspa-edu-br/uniplus-infra/issues/138) · [Story #118 (fechada)](https://github.com/unifesspa-edu-br/uniplus-infra/issues/118) · [Epic #40](https://github.com/unifesspa-edu-br/uniplus-infra/issues/40) · [ADR-005](ADR-005-stateful-em-containers-via-systemd.md) · [ADR-008](ADR-008-topologia-standalone.md)
+
+## Contexto
+
+A Story #118 entregou Kafka 4.2.0 KRaft (PR #137) em **PLAINTEXT** sem autenticação. Defesa baseada apenas em segregação de rede: subnet privada VCN do OCI + iptables INPUT chain filtrando externos. Aceitável para validação inicial pelas razões originais:
+
+1. Standalone é monolocal, não modela resiliência (ADR-008)
+2. Sem apps consumidoras ainda — Fase 5 ainda não entregou imagens GHCR
+3. PR #137 já era complexo (KRaft format, listener config, idempotência) — adicionar SASL_SSL no mesmo PR teria explodido em rounds Codex
+
+Com a Fase 5 se aproximando, o débito técnico ficou explícito:
+
+- **Apps reais (uniplus-portal, uniplus-api-selecao, etc.) precisam de auth** — produzir/consumir tópicos sem credentials viola o pattern dos demais services (Postgres, Redis, MinIO usam password auth via Vault/ESO).
+- **Promoção a hml/prod requer auth + cifra** — adiar significa refactor maior depois, com apps já dependendo do contrato PLAINTEXT.
+- **Compliance LGPD** — eventos publicados podem conter PII (CPF, nome social do candidato). Cleartext intra-VCN ainda é cleartext: snapshots do data-host, logs verbose de aplicação, captura de pacotes em troubleshooting podem expor dados regulados.
+- **Princípio "produção desde o início"** — apps consomem o pattern seguro desde o primeiro PR de Fase 5; nada de "depois a gente endurece".
+
+## Alternativas consideradas
+
+### 1. Manter PLAINTEXT, hardenar só na promoção a hml
+
+- ❌ Rejeitada. Refactor depois é mais caro: apps Fase 5 já implementadas com `security.protocol=PLAINTEXT` precisariam atualizar config + redeployar; cada app cliente vira um ponto de falha de migração; ADRs e RUNBOOKS ficam dessincronizados entre standalone e hml.
+
+### 2. SASL/SCRAM-SHA-512 sobre PLAINTEXT (`SASL_PLAINTEXT`)
+
+- ❌ Rejeitada. Auth sem cifra: a senha SCRAM **em si** não trafega (SCRAM faz challenge-response com salted hash), mas o **payload das mensagens** trafega em clear — exatamente o que LGPD pede pra cifrar. Ganho parcial não justifica complexidade igual ao SASL_SSL.
+
+### 3. mTLS puro (`SSL` com `ssl.client.auth=required`)
+
+- ❌ Rejeitada para MVP. Auth via client certificate tem propriedades superiores (zero-trust, sem shared secrets em Vault), mas:
+  - **Lifecycle de certs por aplicação** — cada app precisa cert provisionado via cert-manager + CSR via SPIFFE/SPIRE ou via injection sidecar; complexidade alta
+  - **Rotação automática** demanda cert-manager-csi-driver-spiffe ou equivalente — exagero pra MVP single-host
+  - Mantemos como **caminho de evolução** quando 3-DC + apps maduras justificarem
+
+### 4. SASL/OAUTHBEARER (JWT do Keycloak)
+
+- ❌ Rejeitada para MVP. Atrativo arquiteturalmente — unifica AuthN com o resto da stack via realm `uniplus`. Mas:
+  - **Kafka 4.x OAUTHBEARER ainda exige config customizada** (`org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler` próprio) — não é plug-and-play como SCRAM
+  - **Validação de JWT no broker** demanda library customizada ou JWKS endpoint config; menos rodado em single-node
+  - Aplicações .NET 10 / Angular 21 não consomem Kafka diretamente do browser — backend é o único cliente; SCRAM password em Vault é tão seguro quanto JWT do mesmo backend
+  - Mantemos como **caminho de evolução** quando schema registry, audit logs e MIM federada justificarem
+
+### 5. SASL_SSL + SCRAM-SHA-512 + StandardAuthorizer ⭐
+
+- ✅ **Escolhida.**
+- Auth: SCRAM-SHA-512 — challenge-response com salted hash, NIST-aprovado, sem rainbow tables
+- Cifra: TLS 1.2/1.3 — protege payload em wire
+- Authorization: `StandardAuthorizer` (KRaft-native, substitui o `AclAuthorizer` da era ZK), com `ALLOW_EVERYONE_IF_NO_ACL_FOUND=false` — fail-closed
+- Pattern alinhado com Postgres/Redis/MinIO (password auth via Vault → ESO → app)
+- Apps Fase 5 consomem o modelo seguro **desde o primeiro PR**
+
+## Decisão
+
+Migrar Kafka standalone para **SASL_SSL + SCRAM-SHA-512 + StandardAuthorizer**, com as seguintes premissas:
+
+### Encryption (TLS)
+
+| Item | Standalone | hml/prod (futuro) |
+|---|---|---|
+| Geração de cert | Self-signed estático via `openssl req` no bootstrap (validade 10 anos, regenerado só se ausente) | cert-manager Issuer (interno ou Let's Encrypt) com rotação automática + sync para o broker via secret-sync |
+| Formato | PEM (`KAFKA_SSL_KEYSTORE_TYPE=PEM`) — Kafka 3.0+ aceita PEM nativo; sem conversão para JKS | Idem |
+| CA | Self-signed = CA = cert (cadeia de 1 nível) | Cadeia real (Let's Encrypt root → intermediate → cert) |
+| Path no host | `/etc/uniplus-kafka/certs/{server.crt,server.key,ca.crt}` (root:root, key 600, crt 644) | Idem, mas populado via cron-sync de cert-manager |
+| Validade | 10 anos (validação intencional) | 90 dias com rotação automática |
+
+**Por que self-signed estático em standalone:** Kafka roda como container Docker via systemd no `data-host`, **fora do cluster K8s** (ADR-005). cert-manager é uma extensão K8s e **não atinge o data-host nativamente**. Para hml/prod, padrão será cert-manager + secret-sync (job no K8s exporta o cert renovado para um path acessível ao data-host via SSH ou volume compartilhado). Implementar esse pipeline em standalone, com 1 broker e 0 apps consumindo, é overengineering. Self-signed estático com validade longa cobre toda a janela de validação.
+
+### Authentication (SASL/SCRAM-SHA-512)
+
+| Item | Detalhe |
+|---|---|
+| Mecanismo | `SCRAM-SHA-512` exclusivamente (`SCRAM-SHA-256` legado não é habilitado) |
+| Admin user | `admin`, password 32 bytes hex (`openssl rand -hex 32`), embarcada via `kafka-storage.sh format --add-scram "SCRAM-SHA-512=[name=admin,password=<PW>]"` no bootstrap inicial |
+| Inter-broker | Mesmo `admin` user (single-node combined) — config via `listener.name.<NAME>.scram-sha-512.sasl.jaas.config` |
+| Per-app users | Criados na Fase 5 via `kafka-configs.sh --alter --add-config 'SCRAM-SHA-512=[password=...]' --entity-type users --entity-name <app>-svc`. Custódia em `secret/standalone/kafka/<app>-svc` (ESO sintetiza secret K8s) |
+| Custódia | `secret/standalone/kafka/admin` no Vault: `username`, `password`, `mechanism=SCRAM-SHA-512`, `bootstrap_servers`, `ca_cert` (PEM da CA) |
+
+### Authorization (ACLs via StandardAuthorizer)
+
+| Item | Detalhe |
+|---|---|
+| Implementação | `org.apache.kafka.metadata.authorizer.StandardAuthorizer` (KRaft-native; substitui `kafka.security.authorizer.AclAuthorizer` da era ZK) |
+| Default | `allow.everyone.if.no.acl.found=false` — **fail-closed**. Apps sem ACL explícita são negadas |
+| Super users | `super.users=User:admin` — admin tem permissão total sem ACLs |
+| Pattern por app | ACL prefixed pra topics e consumer groups; sem wildcards globais |
+
+Exemplo de ACL pattern (Fase 5):
+
+```bash
+# uniplus-portal-svc pode produzir e consumir em uniplus.events.*
+kafka-acls.sh --bootstrap-server kafka.standalone.portaluni.com.br:9092 \
+  --command-config /etc/kafka/admin.properties \
+  --add --allow-principal User:uniplus-portal-svc \
+  --producer --topic 'uniplus.events.' --resource-pattern-type prefixed
+
+kafka-acls.sh --bootstrap-server kafka.standalone.portaluni.com.br:9092 \
+  --command-config /etc/kafka/admin.properties \
+  --add --allow-principal User:uniplus-portal-svc \
+  --consumer --topic 'uniplus.events.' --resource-pattern-type prefixed \
+  --group 'uniplus-portal.'
+```
+
+### Listener configuration
+
+```
+KAFKA_LISTENERS=SASL_SSL://10.0.2.87:9092,CONTROLLER://10.0.2.87:9093
+KAFKA_ADVERTISED_LISTENERS=SASL_SSL://10.0.2.87:9092
+KAFKA_INTER_BROKER_LISTENER_NAME=SASL_SSL
+KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:SASL_SSL,SASL_SSL:SASL_SSL
+KAFKA_SASL_ENABLED_MECHANISMS=SCRAM-SHA-512
+KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=SCRAM-SHA-512
+KAFKA_SASL_MECHANISM_CONTROLLER_PROTOCOL=SCRAM-SHA-512
+```
+
+> Nota: o `advertised.listeners` continua usando IP `10.0.2.87` em vez de hostname pelo cert ter SAN cobrindo IP + DNS via `subjectAltName`. Self-signed gerado com ambos os SANs.
+
+## Justificativa
+
+A escolha por SASL_SSL + SCRAM se sustenta em três eixos:
+
+1. **Pattern padrão da stack Uni+** — Postgres, Redis, MinIO já usam password auth com TLS terminal (no caso do Postgres/Redis/MinIO em standalone PLAINTEXT, mas TLS é o pattern de produção quando promovem). Kafka adotando o mesmo modelo simplifica o mental model dos devs e reusa o procedimento operacional (custódia em Vault, ESO sintetiza secret K8s, app consome via env).
+2. **`StandardAuthorizer` é KRaft-native** — desde Kafka 3.3 GA, é a implementação canônica para clusters KRaft. `AclAuthorizer` (era ZK) está deprecated em 4.x; usar `StandardAuthorizer` é decisão de presente, não débito.
+3. **Migração futura para mTLS ou OAUTHBEARER é aditiva**, não destrutiva — basta adicionar listener novo (`MTLS://...:9094`) ou config OAUTHBEARER em paralelo ao SASL_SSL existente. Apps continuam funcionando enquanto a migração roda.
+
+## Consequências
+
+### Positivas
+
+- Apps Fase 5 já chegam com auth+cifra desde o primeiro PR (sem refactor de migração)
+- Compliance LGPD endereçada (cifra em wire)
+- Pattern alinhado a hml/prod (mesmo modelo, só muda CA self-signed → CA institucional)
+- ACLs fail-closed previnem expansão acidental de privilégio (e.g., dev cria topic novo sem ACL, app não consegue produzir → erro óbvio em vez de comportamento aleatório)
+- Custódia em Vault unifica gestão de secrets de todos os data services
+
+### Negativas
+
+- Bootstrap mais complexo: passa a ter cert + SCRAM + ACLs além do que tinha; aumenta superfície de erro inicial
+- Self-signed gera browser warning quando AKHQ (Web UI, #139) tentar conectar — mitigado distribuindo o CA via configmap
+- `kafka-broker-api-versions.sh` e demais ferramentas precisam de `--command-config` apontando pro client.properties — mais ergonômico esquecer flag e ver `Authorization failed`
+- Rotação de admin password vira operação não-trivial (precisa ALTER user no Kafka + atualizar Vault + reiniciar broker para refresh do JAAS) — documentar em runbook §13.6 atualizado
+- `super.users=User:admin` em hml/prod precisa virar role-based (admin ops vs admin platform) — débito documentado para Story HA
+
+### Neutras
+
+- Self-signed estático com validade 10 anos significa **sem rotação** durante a vida do standalone — aceitável porque o cert nunca trafega externamente (subnet privada VCN). Quando promover, cert-manager assume.
+- `cluster_id` continua sendo identificador, não segredo — registro em Vault é só auditoria (já implementado em PR #137; ADR mantém)
+
+## Caminho de migração
+
+1. **Este ADR** — formaliza a decisão
+2. **PR refator `step_data_setup_kafka`** — bootstrap script gera cert self-signed + SCRAM + StandardAuthorizer + custódia
+3. **RUNBOOKS §13 atualizado** — operações reflectindo SASL_SSL (cliente properties, criar user per-app, rotação admin, troubleshooting cert/ACL)
+4. **Issue #139 (AKHQ)** — Web UI consome SCRAM admin via ESO + CA via configmap
+5. **Fase 5 (apps reais)** — cada app tem sua Story criando user SCRAM + ACLs prefixed
+6. **Story HA futura** — migrar self-signed → cert-manager com secret-sync para data-host; introduzir mTLS opcionalmente

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -20,3 +20,4 @@ Este diretório contém as decisões arquiteturais da infraestrutura da platafor
 | 006 | [GitOps com ArgoCD](ADR-006-gitops-com-argocd.md) | ✅ Aceito | 2026-04-20 | [#16](https://github.com/unifesspa-edu-br/uniplus-infra/issues/16) |
 | 007 | [Vault HA com auto-unseal Transit centralizado em PA1](ADR-007-vault-ha-storage-unseal.md) | ✅ Aceito | 2026-05-03 | [#13](https://github.com/unifesspa-edu-br/uniplus-infra/issues/13) |
 | 008 | [Topologia `standalone` como modelo paralelo provider-agnostic](ADR-008-topologia-standalone.md) | 🟡 Proposta | 2026-05-03 | [#47](https://github.com/unifesspa-edu-br/uniplus-infra/issues/47) |
+| 009 | [Kafka standalone com SASL_SSL + SCRAM-SHA-512 + StandardAuthorizer](ADR-009-kafka-sasl-ssl-scram-standalone.md) | 🟡 Proposta | 2026-05-07 | [#138](https://github.com/unifesspa-edu-br/uniplus-infra/issues/138) |

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -1321,25 +1321,46 @@ EOF
 
 # Configura Apache Kafka 4.2.0 (KRaft only — ZooKeeper removido em 4.0 GA) como
 # container Docker gerenciado por systemd no data-host. Single-node combined
-# (process.roles=broker,controller).
+# (process.roles=broker,controller) com SASL_SSL + SCRAM-SHA-512 + StandardAuthorizer.
+# Ver ADR-009 para a decisão de modelo de segurança.
 #
 # UID/GID: 1000:1000 (appuser, default user da imagem apache/kafka:4.2.0).
 #
-# Auth: PLAINTEXT — subnet privada VCN + iptables INPUT chain filtrando
-# externos. Acceptable em standalone (validação). Pattern SASL/SCRAM-SHA-512
-# documentado em RUNBOOKS §13 para hml/prod.
+# Encryption: TLS 1.2/1.3 via cert PEM self-signed estático (validade 10 anos)
+# gerado pelo bootstrap. Self-signed deliberado em standalone — cert-manager
+# fica para hml/prod com secret-sync para data-host (extensão K8s não atinge
+# nativamente container fora do cluster). Cert tem SAN cobrindo IP da subnet
+# privada (10.0.2.87) + DNS interno (kafka.standalone.portaluni.com.br).
 #
-# Cluster ID: gerado uma vez via `kafka-storage.sh random-uuid`, persistido em
-# .bootstrap-creds (não é segredo — apenas identificador único do cluster, mas
-# preservar é importante: regenerar produziria mismatch com meta.properties já
-# escrito em $DATA_BASE/kafka/data/). Format do storage é AUTOMÁTICO via
-# `KafkaDockerWrapper setup` no entrypoint (idempotente — skip se já formatado).
+# Authentication: SCRAM-SHA-512 exclusivo (256 NIST-deprecated). Admin user
+# `admin` embarcada via `kafka-storage.sh format --add-scram` no bootstrap
+# inicial — sem isso há catch-22 (precisa autenticar pra criar usuário, mas
+# não há usuário ainda). Per-app users criados na Fase 5 via kafka-configs.sh.
+#
+# Authorization: StandardAuthorizer (KRaft-native; AclAuthorizer da era ZK
+# está deprecated em 4.x). `allow.everyone.if.no.acl.found=false` fail-closed;
+# `super.users=User:admin` para ops sem ACL.
+#
+# Por que server.properties em vez de env vars: a imagem apache/kafka:4.2.0
+# tem KafkaDockerWrapper que renderiza server.properties a partir de env vars
+# `KAFKA_*`, mas a transformação não preserva hyphens — `SCRAM-SHA-512` em
+# nome de listener fica inviável via env. Solução: gerar server.properties
+# completo no bootstrap e montar via `--mounted-configs-dir` do entrypoint
+# (mecanismo já existente para esse caso).
+#
+# Cluster ID + admin_pw persistidos em .bootstrap-creds (cluster_id NÃO é
+# segredo; admin_pw É — custódia em Vault + shred opcional, mas se shredded
+# regerar exige re-format do storage que destrói tópicos/mensagens).
 #
 # Idempotência:
-#   - .bootstrap-creds: preserva se existe; gera se ausente; aborta se data dir
-#     já tem meta.properties sem .bootstrap-creds (recovery via §13.4).
-#   - EnvironmentFile + systemd unit: sempre re-aplicados.
-#   - Entrypoint do container: format storage skip se já formatado.
+#   - .bootstrap-creds: preserva (validando que tem ambos os campos novos);
+#     gera se ausente; aborta se data dir formatado sem creds (mismatch).
+#   - Certs: regenerados se ausentes; preservados em re-runs.
+#   - Format do storage: roda explicitamente em container ad-hoc com --add-scram
+#     ANTES do systemctl start na primeira run; entrypoint do uniplus-kafka
+#     vê "already formatted" e skip nas runs subsequentes.
+#   - server.properties + admin.properties + EnvironmentFile + systemd unit:
+#     sempre re-aplicados (cheap, corrige drift).
 #   - Serviço já ativo: não reinicia.
 step_data_setup_kafka() {
     if $SKIP_DOCKER && ! command -v docker &>/dev/null; then
@@ -1347,22 +1368,30 @@ step_data_setup_kafka() {
         return
     fi
 
-    log_info "Configurando Kafka 4.2.0 KRaft systemd..."
+    log_info "Configurando Kafka 4.2.0 KRaft + SASL_SSL + SCRAM-SHA-512 systemd..."
 
     local creds_file="$DATA_BASE/kafka/.bootstrap-creds"
+    local certs_dir="/etc/uniplus-kafka/certs"
+    local config_dir="/etc/uniplus-kafka/config"
+    local server_props="$config_dir/server.properties"
+    local admin_props="$DATA_BASE/kafka/admin.properties"
     local env_file="/etc/uniplus-kafka.env"
     local unit_file="/etc/systemd/system/uniplus-kafka.service"
 
-    # Diretórios + ownership: Kafka data dir 1000:1000 mode 750. UID 1000
-    # corresponde ao appuser do container. O entrypoint roda já como appuser
-    # (default User no Dockerfile), então NÃO há drop de privs (diferente de
-    # Postgres/Redis/MinIO que iniciam como root).
-    run "sudo mkdir -p $DATA_BASE/kafka/data"
+    # Diretórios + ownership.
+    # data dir 750 chown 1000:1000 (appuser do container).
+    # certs_dir e config_dir 755 root:root — uid 1000 do container precisa
+    # traverse para abrir os PEMs e o server.properties (lição PR #133 round 1).
+    # Os files dentro têm mode próprio (PEMs 644, server.properties 600 chown
+    # 1000:1000 pois contém SCRAM password em cleartext).
+    run "sudo mkdir -p $DATA_BASE/kafka/data $certs_dir $config_dir"
     run "sudo chown 1000:1000 $DATA_BASE/kafka/data"
     run "sudo chmod 750 $DATA_BASE/kafka/data"
+    run "sudo chown root:root $certs_dir $config_dir"
+    run "sudo chmod 755 $certs_dir $config_dir"
 
-    # Detectar inicialização prévia: meta.properties no data dir indica
-    # storage formatado. Análogo a PG_VERSION (Postgres) e .minio.sys/ (MinIO).
+    # Detectar inicialização prévia: meta.properties no data dir indica storage
+    # formatado. Análogo a PG_VERSION (Postgres) e .minio.sys/ (MinIO).
     local already_initialized=false
     if ! $DRY_RUN && \
        sudo test -f "$DATA_BASE/kafka/data/meta.properties" 2>/dev/null; then
@@ -1370,94 +1399,273 @@ step_data_setup_kafka() {
     fi
 
     # ---- Decisão 1: .bootstrap-creds (preservar / gerar / abortar) ----
+    # Formato novo (ADR-009): cluster_id + admin_pw. PR #137 originalmente só
+    # tinha cluster_id; bootstrap antigo precisa migração explícita pelo
+    # operador (ver §13.4 — backup do antigo, decidir nova admin pw, restore).
     if sudo test -f "$creds_file" 2>/dev/null; then
-        log_success "Bootstrap creds Kafka já existentes — preservando cluster_id."
+        # `grep -q` é robusto a multi-linha: retorna apenas exit code (0 se
+        # encontra, 1 se não). Pattern anterior `grep -c | echo 0` quebrava
+        # quando admin_pw ausente — grep imprime `0\n` E falha, `|| echo 0`
+        # acrescenta `0\n`, valor final vira `"0\n0"` e o `[[ == "0" ]]`
+        # não dispara, pulando a mensagem de migração explícita (Codex P2).
+        if ! sudo grep -q '^admin_pw=' "$creds_file" 2>/dev/null; then
+            log_error "$creds_file existe mas não contém admin_pw (formato pré-SASL/PR #137)."
+            log_error "Migração ADR-009 exige reset do storage + novo .bootstrap-creds."
+            log_error "Procedimento completo: docs/RUNBOOKS.md §13.1.1 (Migração PLAINTEXT → SASL_SSL)."
+            exit 1
+        fi
+        log_success "Bootstrap creds Kafka já existentes (cluster_id + admin_pw) — preservando."
     elif $DRY_RUN; then
-        log_warn "Dry-run: cluster_id Kafka seria gerado em $creds_file"
+        log_warn "Dry-run: cluster_id + admin_pw seriam gerados em $creds_file"
     elif $already_initialized; then
-        # Guard: meta.properties existe mas .bootstrap-creds shredded ou
-        # perdido. cluster.id está no meta.properties (é o source-of-truth do
-        # storage); operador deve restaurar via §13.4 (lê do meta.properties
-        # ou do Vault) antes de re-rodar.
         log_error "$creds_file ausente, mas $DATA_BASE/kafka/data/meta.properties já existe."
-        log_error "Regenerar cluster_id agora produziria mismatch com storage formatado."
-        log_error "Restaure $creds_file a partir do Vault — ver docs/RUNBOOKS.md §13.4."
+        log_error "Storage formatado mas creds shredded — restaure via docs/RUNBOOKS.md §13.4."
         exit 1
     else
-        log_info "Gerando cluster_id Kafka via kafka-storage.sh random-uuid..."
-        local cluster_id
-        # Container ad-hoc apenas pra random-uuid; sem state, descartável.
+        log_info "Gerando cluster_id + admin SCRAM-SHA-512 password..."
+        local cluster_id admin_pw
         cluster_id=$(sudo docker run --rm --entrypoint /opt/kafka/bin/kafka-storage.sh \
             apache/kafka:4.2.0 random-uuid 2>/dev/null | tr -d '\r\n')
         if [[ -z "$cluster_id" ]]; then
             log_error "Falha ao gerar cluster_id via kafka-storage.sh."
             exit 1
         fi
+        admin_pw=$(openssl rand -hex 32)
         sudo tee "$creds_file" >/dev/null <<EOF
 cluster_id=$cluster_id
+admin_pw=$admin_pw
 EOF
         sudo chown root:root "$creds_file"
         sudo chmod 600 "$creds_file"
-        log_warn "cluster_id gerado em $creds_file. Persistir em Vault — ver runbook §13.2."
+        log_warn "cluster_id + admin_pw gerados em $creds_file. Custódia obrigatória — ver §13.2."
     fi
 
-    # EnvironmentFile (sempre re-aplicado). NOTA: cluster_id NÃO é segredo, mas
-    # passamos via env consistente com pattern dos outros services. Configura
-    # KRaft single-node combined com static quorum (KAFKA_CONTROLLER_QUORUM_VOTERS).
+    # ---- Decisão 2: Certs PEM (self-signed, 10 anos) ----
+    # Preservados se TODOS os 4 arquivos PEM existem (server.crt, server.key,
+    # ca.crt, server.pem bundle). Verificar só server.crt seria insuficiente:
+    # bootstrap interrompido entre `openssl req` e `cat ... > server.pem`
+    # deixaria server.crt presente mas server.pem ausente; re-run pularia a
+    # geração e o broker falharia em startup (ssl.keystore.location aponta
+    # pra arquivo inexistente). Codex P2 round 3.
+    if sudo test -f "$certs_dir/server.crt" 2>/dev/null && \
+       sudo test -f "$certs_dir/server.key" 2>/dev/null && \
+       sudo test -f "$certs_dir/ca.crt" 2>/dev/null && \
+       sudo test -f "$certs_dir/server.pem" 2>/dev/null; then
+        log_success "Certs Kafka completos (crt/key/ca/pem) — preservando."
+    elif $DRY_RUN; then
+        log_warn "Dry-run: cert self-signed seria gerado em $certs_dir/"
+    else
+        log_info "Gerando cert self-signed PEM (10 anos, SAN: 10.0.2.87 + kafka.standalone.portaluni.com.br)..."
+        # OpenSSL config inline com SAN multi-tipo (DNS + IP). Self-signed →
+        # CA = cert (cadeia de 1 nível); ca.crt é cópia do server.crt.
+        local ssl_cnf="$certs_dir/openssl.cnf"
+        sudo tee "$ssl_cnf" >/dev/null <<'CNF'
+[req]
+distinguished_name = req_distinguished_name
+prompt = no
+req_extensions = v3_req
+
+[req_distinguished_name]
+CN = kafka.standalone.portaluni.com.br
+
+[v3_req]
+basicConstraints = CA:TRUE
+keyUsage = digitalSignature, keyEncipherment, keyCertSign
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = kafka.standalone.portaluni.com.br
+DNS.2 = localhost
+IP.1 = 10.0.2.87
+IP.2 = 127.0.0.1
+CNF
+        sudo openssl req -x509 -newkey rsa:2048 \
+            -keyout "$certs_dir/server.key" \
+            -out "$certs_dir/server.crt" \
+            -days 3650 -nodes \
+            -config "$ssl_cnf" \
+            -extensions v3_req >/dev/null 2>&1
+        sudo cp "$certs_dir/server.crt" "$certs_dir/ca.crt"
+        # PEM keystore para Kafka 4.x exige cert + key concatenados num único
+        # arquivo apontado por `ssl.keystore.location` (ou usar
+        # `ssl.keystore.key` inline no server.properties — deixaria a private
+        # key cleartext no config). Gerar `server.pem` concatenado é a forma
+        # canônica documentada (Kafka KIP-651). NOTA: `ssl.keystore.key.location`
+        # NÃO é uma propriedade válida — não confundir com truststore que tem
+        # `location` para cert isolado.
+        sudo bash -c "cat $certs_dir/server.crt $certs_dir/server.key > $certs_dir/server.pem"
+        # uid 1000 do container precisa ler PEMs em startup.
+        sudo chown 1000:1000 "$certs_dir/server.crt" "$certs_dir/server.key" \
+                              "$certs_dir/ca.crt" "$certs_dir/server.pem"
+        sudo chmod 644 "$certs_dir/server.crt" "$certs_dir/ca.crt"
+        sudo chmod 600 "$certs_dir/server.key" "$certs_dir/server.pem"
+        sudo rm -f "$ssl_cnf"
+        log_warn "Cert self-signed gerado em $certs_dir/server.{crt,pem} (validade 10 anos)."
+        log_warn "ca.crt deve ser distribuído pra clientes (apps Fase 5, AKHQ)."
+    fi
+
+    # ---- Decisão 3: Format inicial com --add-scram ----
+    # Crítico: --add-scram só é honrado durante format inicial. Re-format
+    # após formatação NÃO adiciona credenciais. Por isso fazemos format
+    # explícito ANTES do systemctl start na 1ª run, em container ad-hoc.
+    # O entrypoint do uniplus-kafka subsequente vê "already formatted" e skip.
+    if ! $DRY_RUN && ! $already_initialized && sudo test -f "$creds_file"; then
+        log_info "Format do storage com --add-scram (admin SCRAM-SHA-512 embarcada)..."
+        local cluster_id_init admin_pw_init
+        cluster_id_init=$(sudo grep '^cluster_id=' "$creds_file" | cut -d= -f2)
+        admin_pw_init=$(sudo grep '^admin_pw=' "$creds_file" | cut -d= -f2)
+
+        # server.properties mínimo só pra format (validar topology). NÃO usar
+        # o $server_props final — ele tem JAAS/SCRAM cleartext que ainda não
+        # foi gerado neste ponto da função (geração logo abaixo).
+        local fmt_props
+        fmt_props=$(sudo mktemp)
+        sudo tee "$fmt_props" >/dev/null <<EOF
+process.roles=broker,controller
+node.id=1
+controller.quorum.voters=1@10.0.2.87:9093
+listeners=SASL_SSL://10.0.2.87:9092,CONTROLLER://10.0.2.87:9093
+controller.listener.names=CONTROLLER
+listener.security.protocol.map=CONTROLLER:SASL_SSL,SASL_SSL:SASL_SSL
+log.dirs=/var/lib/kafka/data
+EOF
+        sudo chmod 644 "$fmt_props"
+
+        # admin_pw_init aparece em /proc/<pid>/cmdline DO CONTAINER por ~1s
+        # (--add-scram exige formato inline). Trade-off: container é
+        # descartável, processo curto, namespace isolado. Se for dealbreaker
+        # futuro: format manual + ALTER user via kafka-configs.sh.
+        if ! sudo docker run --rm \
+            -v "$DATA_BASE/kafka/data:/var/lib/kafka/data" \
+            -v "$fmt_props:/opt/kafka/config/format.properties:ro" \
+            --entrypoint /opt/kafka/bin/kafka-storage.sh \
+            apache/kafka:4.2.0 \
+            format --config /opt/kafka/config/format.properties \
+                   --cluster-id "$cluster_id_init" \
+                   --add-scram "SCRAM-SHA-512=[name=admin,password=$admin_pw_init]" \
+                   --ignore-formatted >/dev/null 2>&1; then
+            log_error "Format do storage falhou. Re-rode manualmente em verbose: docker run ... format ..."
+            sudo rm -f "$fmt_props"
+            exit 1
+        fi
+        sudo rm -f "$fmt_props"
+        unset cluster_id_init admin_pw_init
+        log_success "Storage formatado com admin SCRAM-SHA-512 embarcada."
+    fi
+
+    # ---- Decisão 4: server.properties (sempre re-aplicado) ----
+    # Contém admin SCRAM password em cleartext em listener.name.*.sasl.jaas.config
+    # (Kafka 4.x exige inline; não há mecanismo file-based para JAAS de listener
+    # nessa versão). Mode 600 chown 1000:1000 — broker (uid 1000) lê; outros não.
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Escreveria $server_props com SASL_SSL + SCRAM + StandardAuthorizer"
+    else
+        local admin_pw_curr
+        admin_pw_curr=$(sudo grep '^admin_pw=' "$creds_file" | cut -d= -f2)
+        if [[ -z "$admin_pw_curr" ]]; then
+            log_error "admin_pw vazio em $creds_file. Abortando."
+            exit 1
+        fi
+        sudo tee "$server_props" >/dev/null <<EOF
+# === KRaft topology (single-node combined) ===
+process.roles=broker,controller
+node.id=1
+controller.quorum.voters=1@10.0.2.87:9093
+listeners=SASL_SSL://10.0.2.87:9092,CONTROLLER://10.0.2.87:9093
+advertised.listeners=SASL_SSL://10.0.2.87:9092
+controller.listener.names=CONTROLLER
+inter.broker.listener.name=SASL_SSL
+listener.security.protocol.map=CONTROLLER:SASL_SSL,SASL_SSL:SASL_SSL
+
+# === Storage ===
+log.dirs=/var/lib/kafka/data
+auto.create.topics.enable=false
+
+# === Replication factor 1 (single-node, sem replicação) ===
+offsets.topic.replication.factor=1
+transaction.state.log.replication.factor=1
+transaction.state.log.min.isr=1
+share.coordinator.state.topic.replication.factor=1
+share.coordinator.state.topic.min.isr=1
+
+# === SASL/SCRAM-SHA-512 (admin embarcada via --add-scram no format) ===
+sasl.enabled.mechanisms=SCRAM-SHA-512
+sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
+sasl.mechanism.controller.protocol=SCRAM-SHA-512
+listener.name.sasl_ssl.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="admin" password="$admin_pw_curr";
+listener.name.controller.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="admin" password="$admin_pw_curr";
+
+# === TLS (PEM keystore + truststore; self-signed = ca = cert) ===
+# server.pem: cert + private key concatenados (formato PEM bundle padrão Kafka 4.x).
+# ssl.keystore.location aponta para o bundle; broker lê o PEM e separa
+# internamente. NÃO há propriedade ssl.keystore.key.location válida — usar
+# bundle ou ssl.keystore.key inline (rejeitado: cleartext no server.properties).
+ssl.keystore.type=PEM
+ssl.keystore.location=/etc/kafka/secrets/server.pem
+ssl.truststore.type=PEM
+ssl.truststore.location=/etc/kafka/secrets/ca.crt
+ssl.client.auth=none
+
+# === StandardAuthorizer (KRaft-native; fail-closed) ===
+authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer
+super.users=User:admin
+allow.everyone.if.no.acl.found=false
+EOF
+        sudo chown 1000:1000 "$server_props"
+        sudo chmod 600 "$server_props"
+        unset admin_pw_curr
+    fi
+
+    # ---- Decisão 5: admin.properties (CLI tools como admin) ----
+    # Padrão para `kafka-topics.sh --command-config admin.properties`,
+    # `kafka-acls.sh --command-config ...`, `kafka-configs.sh --command-config ...`.
+    # Mode 600 root:root; tools rodam via sudo no host data-host ou via
+    # docker run com mount.
+    if ! $DRY_RUN; then
+        local admin_pw_props
+        admin_pw_props=$(sudo grep '^admin_pw=' "$creds_file" | cut -d= -f2)
+        sudo tee "$admin_props" >/dev/null <<EOF
+security.protocol=SASL_SSL
+sasl.mechanism=SCRAM-SHA-512
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="admin" password="$admin_pw_props";
+ssl.truststore.type=PEM
+ssl.truststore.location=$certs_dir/ca.crt
+ssl.endpoint.identification.algorithm=
+EOF
+        sudo chown root:root "$admin_props"
+        sudo chmod 600 "$admin_props"
+        unset admin_pw_props
+    fi
+
+    # ---- Decisão 6: EnvironmentFile (mínimo — só CLUSTER_ID + JVM heap) ----
+    # Toda config sensível e de listener vai em server.properties (file-based).
+    # CLUSTER_ID precisa estar no env do container (entrypoint exige); JVM
+    # heap fica aqui pra rotação trivial sem regerar config.
     if $DRY_RUN; then
         echo "[DRY-RUN] Escreveria $env_file"
     else
-        local cluster_id_current
-        cluster_id_current=$(sudo grep '^cluster_id=' "$creds_file" | cut -d= -f2)
-        if [[ -z "$cluster_id_current" ]]; then
-            log_error "cluster_id vazio em $creds_file. Abortando."
-            exit 1
-        fi
-        # KAFKA_LOG_DIRS override do default `/tmp/kraft-combined-logs` da
-        # imagem apache/kafka:4.2.0 — sem isso, o broker escreveria em /tmp
-        # dentro do container (efêmero, NÃO no volume mounted), resultando em
-        # data loss silencioso no primeiro restart (cluster_id mismatch entre
-        # env e meta.properties recriado em /tmp).
-        #
-        # KAFKA_HEAP_OPTS PRECISA de aspas — systemd EnvironmentFile parser
-        # tokeniza por espaço sem quoting; sem aspas, apenas `-Xmx1g` é setado
-        # e `-Xms1g` é descartado silenciosamente.
+        local cluster_id_env
+        cluster_id_env=$(sudo grep '^cluster_id=' "$creds_file" | cut -d= -f2)
         sudo tee "$env_file" >/dev/null <<EOF
-CLUSTER_ID=$cluster_id_current
-KAFKA_PROCESS_ROLES=broker,controller
-KAFKA_NODE_ID=1
-KAFKA_LISTENERS=PLAINTEXT://10.0.2.87:9092,CONTROLLER://10.0.2.87:9093
-KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://10.0.2.87:9092
-KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
-KAFKA_CONTROLLER_QUORUM_VOTERS=1@10.0.2.87:9093
-KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT
-KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-KAFKA_LOG_DIRS=/var/lib/kafka/data
-KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
-KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
-KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
-KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
-KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR=1
-KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR=1
+CLUSTER_ID=$cluster_id_env
 KAFKA_HEAP_OPTS="-Xmx1g -Xms1g"
 EOF
         sudo chown root:root "$env_file"
         sudo chmod 600 "$env_file"
-        unset cluster_id_current
+        unset cluster_id_env
     fi
 
-    # systemd unit (sempre re-aplicado). Heredoc single-quoted: paths hardcoded.
-    # Container monta /var/lib/uniplus/kafka/data em /var/lib/kafka/data
-    # (path declarado VOLUME no Dockerfile da imagem oficial). KAFKA_LOG_DIRS
-    # explicitamente override do default `/tmp/kraft-combined-logs` para esse
-    # mesmo path — ver heredoc do EnvironmentFile acima. Network host pra
-    # listener bind direto na VCN privada.
+    # ---- Decisão 7: systemd unit ----
+    # Mount config_dir como /mnt/shared/config no container — KafkaDockerWrapper
+    # setup picks up server.properties dali e merge com defaults; certs como
+    # /etc/kafka/secrets ro; data dir como /var/lib/kafka/data.
     if $DRY_RUN; then
         echo "[DRY-RUN] Escreveria $unit_file"
     else
         sudo tee "$unit_file" >/dev/null <<'UNIT'
 [Unit]
-Description=Uni+ Apache Kafka 4.2.0 KRaft (standalone data-host)
+Description=Uni+ Apache Kafka 4.2.0 KRaft (SASL_SSL + SCRAM-SHA-512)
 Documentation=https://github.com/unifesspa-edu-br/uniplus-infra/blob/main/docs/RUNBOOKS.md
 After=docker.service network-online.target
 Requires=docker.service
@@ -1474,23 +1682,10 @@ ExecStartPre=-/usr/bin/docker rm -f uniplus-kafka
 ExecStart=/usr/bin/docker run --rm --name uniplus-kafka \
   --network host \
   -e CLUSTER_ID \
-  -e KAFKA_PROCESS_ROLES \
-  -e KAFKA_NODE_ID \
-  -e KAFKA_LISTENERS \
-  -e KAFKA_ADVERTISED_LISTENERS \
-  -e KAFKA_CONTROLLER_LISTENER_NAMES \
-  -e KAFKA_CONTROLLER_QUORUM_VOTERS \
-  -e KAFKA_INTER_BROKER_LISTENER_NAME \
-  -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP \
-  -e KAFKA_LOG_DIRS \
-  -e KAFKA_AUTO_CREATE_TOPICS_ENABLE \
-  -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR \
-  -e KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR \
-  -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR \
-  -e KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR \
-  -e KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR \
   -e KAFKA_HEAP_OPTS \
   -v /var/lib/uniplus/kafka/data:/var/lib/kafka/data \
+  -v /etc/uniplus-kafka/config:/mnt/shared/config:ro \
+  -v /etc/uniplus-kafka/certs:/etc/kafka/secrets:ro \
   apache/kafka:4.2.0
 
 ExecStop=/usr/bin/docker stop -t 30 uniplus-kafka
@@ -1504,29 +1699,32 @@ UNIT
     run "sudo systemctl enable uniplus-kafka"
 
     if $DRY_RUN; then
-        echo "[DRY-RUN] systemctl start uniplus-kafka + broker-api-versions probe"
+        echo "[DRY-RUN] systemctl start uniplus-kafka + SASL_SSL broker-api-versions probe"
     elif sudo systemctl is-active --quiet uniplus-kafka; then
         log_success "uniplus-kafka já ativo — preservando state (sem restart)."
     else
         sudo systemctl start uniplus-kafka
-        log_info "Aguardando Kafka aceitar conexões (cold start ~30-90s)..."
+        log_info "Aguardando Kafka aceitar conexões SASL_SSL (cold start ~30-90s)..."
         local attempts=0
-        # broker-api-versions é o probe canônico — retorna lista de APIs
-        # quando o broker está ready (post-format + ISR estabilizada). Timeout
-        # mais largo (180s) que Postgres/Redis pelo cold start de JVM + KRaft
-        # metadata controller bootstrap.
-        until sudo docker exec uniplus-kafka \
-                /opt/kafka/bin/kafka-broker-api-versions.sh \
-                --bootstrap-server localhost:9092 &>/dev/null; do
+        # broker-api-versions agora exige --command-config com cliente SASL_SSL.
+        # admin.properties tem JAAS + truststore PEM. Container ad-hoc com
+        # mount do file e do CA cert — não invade o uniplus-kafka.
+        until sudo docker run --rm --network host \
+                -v "$admin_props:/tmp/admin.properties:ro" \
+                -v "$certs_dir/ca.crt:$certs_dir/ca.crt:ro" \
+                --entrypoint /opt/kafka/bin/kafka-broker-api-versions.sh \
+                apache/kafka:4.2.0 \
+                --bootstrap-server 10.0.2.87:9092 \
+                --command-config /tmp/admin.properties &>/dev/null; do
             attempts=$(( attempts + 1 ))
             if (( attempts >= 36 )); then
-                log_error "Kafka não respondeu broker-api-versions em 180s."
+                log_error "Kafka SASL_SSL não respondeu broker-api-versions em 180s."
                 log_error "Ver: sudo journalctl -u uniplus-kafka -n 100"
                 exit 1
             fi
             sleep 5
         done
-        log_success "uniplus-kafka ativo + broker-api-versions OK."
+        log_success "uniplus-kafka ativo + SASL_SSL broker-api-versions OK."
     fi
 }
 
@@ -1562,10 +1760,11 @@ summary_data() {
     echo "    1. Ler:        sudo cat $DATA_BASE/minio/.bootstrap-creds"
     echo "    2. Custodiar:  Vault (secret/standalone/minio/root) + gestor institucional"
     echo "    3. Limpar:     sudo shred -u $DATA_BASE/minio/.bootstrap-creds"
-    echo "  Kafka — runbook §13.2 (cluster_id NÃO é segredo):"
+    echo "  Kafka — runbook §13.2 (admin SCRAM password é segredo, cluster_id NÃO):"
     echo "    1. Ler:        sudo cat $DATA_BASE/kafka/.bootstrap-creds"
-    echo "    2. Registrar:  Vault (secret/standalone/kafka/cluster) — auditoria"
-    echo "    3. .bootstrap-creds permanece (não há shred — sem cleartext de senha)"
+    echo "    2. Custodiar:  Vault (secret/standalone/kafka/admin) — admin_pw"
+    echo "    3. Registrar:  Vault (secret/standalone/kafka/cluster) — cluster_id (auditoria)"
+    echo "    4. CA cert pra clients: /etc/uniplus-kafka/certs/ca.crt (distribuir pra apps Fase 5 + AKHQ)"
     echo ""
     echo "Validar:"
     echo "  df -h $DATA_BASE/*"
@@ -1574,8 +1773,11 @@ summary_data() {
     echo "  sudo docker exec -i uniplus-redis sh -c 'read -r P; REDISCLI_AUTH=\$P redis-cli ping' \\"
     echo "    <<<\"\$(sudo grep ^default_pw= $DATA_BASE/redis/.bootstrap-creds | cut -d= -f2)\""
     echo "  curl -sf http://10.0.2.87:9000/minio/health/live && echo ' — MinIO health OK'"
-    echo "  sudo docker exec uniplus-kafka /opt/kafka/bin/kafka-broker-api-versions.sh \\"
-    echo "    --bootstrap-server localhost:9092 | head -3"
+    echo "  sudo docker run --rm --network host \\"
+    echo "    -v $DATA_BASE/kafka/admin.properties:/tmp/admin.properties:ro \\"
+    echo "    -v /etc/uniplus-kafka/certs/ca.crt:/etc/uniplus-kafka/certs/ca.crt:ro \\"
+    echo "    --entrypoint /opt/kafka/bin/kafka-broker-api-versions.sh \\"
+    echo "    apache/kafka:4.2.0 --bootstrap-server 10.0.2.87:9092 --command-config /tmp/admin.properties | head -3"
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Migra Kafka standalone (mergeado em PR #137 com PLAINTEXT) para **SASL_SSL + SCRAM-SHA-512 + StandardAuthorizer** conforme ADR-009. Apps Fase 5 chegam com auth+cifra desde o primeiro PR — sem refactor de migração.

## Mudanças

### ADR-009 (commit 1)

Formaliza a decisão arquitetural. Detalha alternativas rejeitadas (SASL_PLAINTEXT, mTLS puro, OAUTHBEARER), trade-offs, caminho de migração para hml/prod.

### `step_data_setup_kafka` refatorada (commit 2)

- **TLS:** cert PEM self-signed (validade 10 anos) gerado por `openssl req` com SAN multi-tipo (`DNS:kafka.standalone.portaluni.com.br`, `DNS:localhost`, `IP:10.0.2.87`, `IP:127.0.0.1`). Persistido em `/etc/uniplus-kafka/certs/`. cert-manager fica para hml/prod com secret-sync (extensão K8s não atinge nativamente container fora do cluster).
- **Authentication:** SCRAM-SHA-512 admin embarcada via `kafka-storage.sh format --add-scram` em container ad-hoc ANTES do `systemctl start` na 1ª run (catch-22 sem isso).
- **Authorization:** `StandardAuthorizer` (KRaft-native, substitui AclAuthorizer da era ZK). `super.users=User:admin`, `allow.everyone.if.no.acl.found=false` fail-closed.
- **`server.properties` em vez de env vars `KAFKA_*`:** entrypoint do `apache/kafka:4.2.0` traduz env→property mas NÃO preserva hyphens — `listener.name.sasl_ssl.scram-sha-512.sasl.jaas.config` é inviável como env. Solução oficial: `--mounted-configs-dir`.
- **`admin.properties`** em `$DATA_BASE/kafka/admin.properties` (root:root 600) pra ferramentas CLI via `--command-config`.
- **`.bootstrap-creds`** agora `cluster_id` + `admin_pw`. Migração explícita pelo operador para deployments PR #137 (fail-fast com link §13.1.1).

### RUNBOOKS §13 reescrita (commit 3)

- §13.1 Bootstrap (incluindo §13.1.1 Migração PLAINTEXT → SASL_SSL para deployments PR #137)
- §13.2 Custódia (admin_pw + cluster_id + ca_cert no Vault)
- §13.3 Validação E2E via pod K8s com client.properties + ca.crt em ConfigMap efêmero
- §13.4 Restore via meta.properties + Vault (sanidade dual)
- §13.5 Operações comuns (list/create/SCRAM user/ACLs prefixed)
- §13.6 Rotação admin password (com disclaimer sobre `/proc/cmdline` exposure ~1s)
- §13.7 Rotação cert TLS
- §13.8 Backup/restore (incluir certs + server.properties)
- §13.9 Pattern migração hml/prod
- §13.10 Troubleshooting expandido

## Test plan

- [x] `bash -n scripts/bootstrap-standalone.sh` ✅
- [x] `shellcheck scripts/bootstrap-standalone.sh` ✅
- [x] `markdownlint-cli2 docs/` ✅
- [x] **code-reviewer subagent pré-PR** — 2 P1 endereçados:
  - **P1.1:** error message do script apontava §13.4 (que pressupõe admin_pw em Vault) → ajustado para §13.1.1 com procedimento completo de migração de deployment PR #137
  - **P1.2:** §13.6 (rotação) não documentava trade-off de exposure de `$NEW_PW` em `/proc` → adicionado disclaimer explícito
- [x] Validação local: `docker run apache/kafka:4.2.0` com `--add-scram` funcionou; PEM keystore aceito; `--mounted-configs-dir` carrega server.properties customizado
- [ ] CI verde (7 jobs)
- [ ] Codex review sem findings remanescentes
- [ ] Smoke test pós-merge: SASL_SSL broker + admin SCRAM auth + ACL fail-closed

## Notas

- **Trade-off conhecido:** `admin_pw` aparece em `/proc/<pid>/cmdline` do container `kafka-storage` por ~1s durante format inicial — `--add-scram` exige inline. Container descartável + namespace isolado torna aceitável em standalone. Documentado tanto no script quanto no §13.6 do RUNBOOKS.
- **Self-signed estático 10 anos** — sem rotação programática. RUNBOOKS §13.7 cobre rotação manual; pattern hml/prod usa cert-manager + secret-sync (ADR-009 §"Caminho de migração").
- **Migração de PR #137:** standalone aceita reset do storage (sem state real); RUNBOOKS §13.1.1 documenta procedimento completo.

Closes #138
Refs ADR-009, #40 (Epic standalone), #139 (Kafka Web UI — bloqueada por este PR)