### PR TITLE
fix(standalone): Kafka bootstrap em fresh host — fmt_props + admin.properties ownership

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1934,7 +1934,7 @@ A função `step_data_setup_kafka` em `scripts/bootstrap-standalone.sh` provisio
    - SASL: `sasl.enabled.mechanisms=SCRAM-SHA-512`, JAAS inline para os 2 listeners
    - TLS: `ssl.keystore.type=PEM`, `ssl.keystore.location=/etc/kafka/secrets/server.pem` (bundle cert+key concatenados — Kafka 4.x não tem propriedade `*.key.location` separada), `ssl.truststore.type=PEM`, `ssl.truststore.location=/etc/kafka/secrets/ca.crt`, `ssl.client.auth=none`
    - AuthZ: `authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer`, `super.users=User:admin`, `allow.everyone.if.no.acl.found=false` (fail-closed)
-6. `admin.properties` em `/var/lib/uniplus/kafka/admin.properties` (root:root 600) — client config para `kafka-topics.sh`/`kafka-acls.sh`/`kafka-configs.sh`/`kafka-broker-api-versions.sh` rodando como admin via `--command-config`.
+6. `admin.properties` em `/var/lib/uniplus/kafka/admin.properties` (mode `600`, owner `1000:1000` — uid do container precisa ler quando montado via `docker run -v`) — client config para `kafka-topics.sh`/`kafka-acls.sh`/`kafka-configs.sh`/`kafka-broker-api-versions.sh` rodando como admin via `--command-config`.
 7. EnvironmentFile minimizado `/etc/uniplus-kafka.env` (root:root 600) com `CLUSTER_ID` (entrypoint exige) + `KAFKA_HEAP_OPTS="-Xmx1g -Xms1g"` (aspas obrigatórias — systemd EnvironmentFile parser tokeniza por espaço sem quoting).
 8. `systemd` unit `/etc/systemd/system/uniplus-kafka.service` (`Restart=always`, `TimeoutStartSec=180`, `--network host`). Mount `config_dir → /mnt/shared/config:ro`; `KafkaDockerWrapper setup` do entrypoint pega o `server.properties` dali. Mount `certs_dir → /etc/kafka/secrets:ro`. Data dir → `/var/lib/kafka/data`.
 

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -1519,6 +1519,9 @@ CNF
         # server.properties mínimo só pra format (validar topology). NÃO usar
         # o $server_props final — ele tem JAAS/SCRAM cleartext que ainda não
         # foi gerado neste ponto da função (geração logo abaixo).
+        # KafkaConfig.validateValues exige advertised.listeners + inter.broker.
+        # listener.name presentes mesmo em format-time (broker ainda não inicia,
+        # mas a config é parseada pra validar topologia).
         local fmt_props
         fmt_props=$(sudo mktemp)
         sudo tee "$fmt_props" >/dev/null <<EOF
@@ -1526,7 +1529,9 @@ process.roles=broker,controller
 node.id=1
 controller.quorum.voters=1@10.0.2.87:9093
 listeners=SASL_SSL://10.0.2.87:9092,CONTROLLER://10.0.2.87:9093
+advertised.listeners=SASL_SSL://10.0.2.87:9092
 controller.listener.names=CONTROLLER
+inter.broker.listener.name=SASL_SSL
 listener.security.protocol.map=CONTROLLER:SASL_SSL,SASL_SSL:SASL_SSL
 log.dirs=/var/lib/kafka/data
 EOF
@@ -1620,8 +1625,10 @@ EOF
     # ---- Decisão 5: admin.properties (CLI tools como admin) ----
     # Padrão para `kafka-topics.sh --command-config admin.properties`,
     # `kafka-acls.sh --command-config ...`, `kafka-configs.sh --command-config ...`.
-    # Mode 600 root:root; tools rodam via sudo no host data-host ou via
-    # docker run com mount.
+    # Mode 600 chown 1000:1000 — uid do container kafka tools precisa ler quando
+    # rodado via `docker run -v admin.properties:/tmp/...`. Mount preserva perms
+    # do host; sem chown 1000:1000 o probe falha com AccessDeniedException.
+    # Mesmo pattern do server.properties (que também tem SCRAM cleartext).
     if ! $DRY_RUN; then
         local admin_pw_props
         admin_pw_props=$(sudo grep '^admin_pw=' "$creds_file" | cut -d= -f2)
@@ -1633,7 +1640,7 @@ ssl.truststore.type=PEM
 ssl.truststore.location=$certs_dir/ca.crt
 ssl.endpoint.identification.algorithm=
 EOF
-        sudo chown root:root "$admin_props"
+        sudo chown 1000:1000 "$admin_props"
         sudo chmod 600 "$admin_props"
         unset admin_pw_props
     fi


### PR DESCRIPTION
## Summary

Hotfix de 2 bugs introduzidos em PR #140 (mergeado em 634c32a9) que escaparam os 4 rounds Codex + code-reviewer subagent — só apareceram durante smoke test em fresh data dir (re-run em host com state existente passa porque `already_initialized=true` skip o format e o probe usa pod ad-hoc com mount diferente).

## Bugs

### 1. Format falha com `inter.broker.listener.name must be a listener name defined in advertised.listeners`

`fmt_props` minimo (usado pelo container ad-hoc `kafka-storage.sh` com `--add-scram`) não tinha `advertised.listeners` nem `inter.broker.listener.name`. `KafkaConfig.validateValues` parseia a config mesmo em format-time e rejeita.

**Fix:** adicionar 2 linhas no heredoc:
```
advertised.listeners=SASL_SSL://10.0.2.87:9092
inter.broker.listener.name=SASL_SSL
```

### 2. Probe de readiness `AccessDeniedException: /tmp/admin.properties` (timeout 180s)

`admin.properties` era `root:root` mode 600. Bind mount no container ad-hoc preserva perms do host; container kafka tools roda como `appuser` uid 1000 e não consegue ler.

**Fix:** `chown 1000:1000` (mantém mode 600). Mesmo pattern do `server.properties` que também tem SCRAM password em cleartext.

## Validação end-to-end

Smoke test em data-host após shred + reset data dir:

- ✅ Bootstrap idempotente; certs/creds preservados ou regenerados conforme estado
- ✅ Format do storage com `--add-scram` (admin SCRAM-SHA-512 embarcada)
- ✅ Broker SASL_SSL Active + listener.name=SASL_SSL READY (logs)
- ✅ `kafka-broker-api-versions.sh --command-config admin.properties` retorna lista de APIs
- ✅ Custódia em Vault: `secret/standalone/kafka/admin` v1 + `secret/standalone/kafka/cluster` v2
- ✅ Pod K8s ad-hoc com client.properties + ca.crt em ConfigMap efêmero: produce + consume + delete topic OK via flannel→VCN

## Por que escapou ao review

Os 4 rounds Codex revisaram **mudanças no código** com lógica formal (config inválida, idempotency check, cert location). Os 2 bugs são de **integration**: validação do Kafka acontece em runtime (format command faz parse e validação completa de config); ownership de bind mount é comportamento docker. Nenhum static analysis pega.

Code-reviewer subagent perdeu o mesmo motivo — focou em segurança/lógica/coerência mas não simulou a execução real.

**Lição:** PR de bootstrap script grande precisa smoke test em fresh data dir ANTES do merge, não só re-run em host com state existente. Adicionar à memória de feedback workflow.

## Test plan

- [x] `bash -n scripts/bootstrap-standalone.sh` ✅
- [x] `shellcheck scripts/bootstrap-standalone.sh` ✅
- [x] `markdownlint-cli2 docs/RUNBOOKS.md` ✅
- [x] **Smoke test em fresh data dir** (data-host real): bootstrap completo + Kafka SASL_SSL + smoke test pod K8s round-trip — TODOS OK
- [ ] CI verde (7 jobs)
- [ ] Codex review

Refs PR #140, ADR-009