### PR TITLE
feat(apps): AKHQ Web UI Kafka — kafka-ui chart + integração realm uniplus

### DIFF
--- a/apps/kafka-ui/Chart.yaml
+++ b/apps/kafka-ui/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: kafka-ui
+description: |
+  Web UI de gerenciamento do cluster Apache Kafka (AKHQ). Conecta ao
+  broker SASL_SSL no data-host (ADR-009) via SCRAM-SHA-512; autentica
+  usuários via OIDC do realm `uniplus` no Keycloak local.
+type: application
+
+# Versão do chart wrapper Uni+. Bump em qualquer mudança de template/values.
+version: 0.1.0
+
+# Versão do AKHQ upstream empacotado (sincronizar com image.tag).
+appVersion: "0.27.0"
+
+home: https://github.com/unifesspa-edu-br/uniplus-infra
+sources:
+  - https://github.com/unifesspa-edu-br/uniplus-infra
+  - https://github.com/tchiotludo/akhq
+
+maintainers:
+  - name: CTIC UNIFESSPA
+    email: jeferson.ferreira@unifesspa.edu.br
+
+keywords:
+  - uniplus
+  - kafka
+  - akhq
+  - admin
+  - unifesspa
+
+annotations:
+  category: data
+  licenses: Apache-2.0

--- a/apps/kafka-ui/README.md
+++ b/apps/kafka-ui/README.md
@@ -1,0 +1,83 @@
+# kafka-ui (AKHQ)
+
+Helm chart wrapper Uni+ para [AKHQ](https://github.com/tchiotludo/akhq) — Web UI de gerenciamento do cluster Apache Kafka. Conecta ao broker SASL_SSL no `data-host` (ADR-009) via SCRAM-SHA-512; autentica usuários via OIDC do realm `uniplus` no Keycloak local.
+
+## Status
+
+Provisionado em **standalone** (issue #139, sub-issue de #40 Epic standalone). Bloqueado por #138 (Kafka SASL_SSL hardening, mergeado em PR #140 + hotfix #141 — ADR-009).
+
+## Arquitetura
+
+```
+Browser (admin Uni+)
+  └── HTTPS via Traefik IngressRoute
+       https://kafka-ui.standalone.portaluni.com.br
+            └── AKHQ pod (apps/kafka-ui chart, namespace uniplus)
+                 ├── OIDC client `kafka-ui` no realm `uniplus` (confidential)
+                 ├── SCRAM admin via ESO (`secret/standalone/kafka/admin`)
+                 ├── CA cert PEM via projected volume (mesmo Secret ESO)
+                 └── conexão SASL_SSL → 10.0.2.87:9092
+```
+
+## Permissões via groups Keycloak → roles AKHQ
+
+Mapping no `application.yml` renderizado pelo chart:
+
+| Grupo Keycloak | Role AKHQ | Capacidades |
+|---|---|---|
+| `/admins/kafka` | `kafka-admins` | criar/deletar tópicos, gerenciar ACLs, alterar consumer groups, configurar broker |
+| `/users/uniplus` | `kafka-readonly` | listar tópicos, inspecionar mensagens, ver consumer groups (sem write) |
+| (sem grupo) | `no-roles` | sem acesso (default-group) |
+
+## Pré-requisitos antes do ArgoCD sync
+
+1. **Realm `uniplus` com client `kafka-ui` confidential criado** + mapper `groups` exportando membership em `groups` claim do JWT
+2. **`secret/standalone/kafka/admin` em Vault** com keys `username`, `password`, `ca_cert` (criado no §13.2 do RUNBOOKS pós-hotfix #141)
+3. **`secret/standalone/keycloak/clients/kafka-ui` em Vault** com `client_secret` do client OIDC (custódia manual via `vault kv put`)
+
+Sem esses 3, ESOs ficam em `SecretNotFound` e o pod entra em `CreateContainerConfigError`.
+
+## Configuração mínima para habilitar
+
+Em `environments/standalone/values.yaml`:
+
+```yaml
+kafkaUi:
+  enabled: true
+  kafka:
+    bootstrapServers: 10.0.2.87:9092
+  oidc:
+    issuerUri: https://standalone.portaluni.com.br/auth/realms/uniplus
+  ingress:
+    enabled: true
+    host: kafka-ui.standalone.portaluni.com.br
+    tls:
+      certManager:
+        enabled: true
+        clusterIssuer: letsencrypt-staging
+  networkPolicy:
+    dataHostCIDR: 10.0.2.0/24
+```
+
+## Operações comuns
+
+Ver `docs/RUNBOOKS.md` §14 para procedimentos:
+
+- §14.1 Pré-flight: secrets em Vault + client OIDC no realm
+- §14.2 Smoke test (login admin → criar tópico → produzir/consumir → ver no UI)
+- §14.3 Adicionar usuário ao grupo `/admins/kafka` no Keycloak
+- §14.4 Troubleshooting (OIDC redirect, SCRAM auth, cert PKIX, NetworkPolicy)
+
+## Trade-offs e limitações
+
+- **AKHQ é stateless** — perda de pod sem impacto em state (estado vive no Kafka).
+- **OIDC PKCE não suportado em provider customizado em 0.27.x** — usamos confidential client com `client_secret` em Vault. AKHQ é backend (não SPA), então confidential é correto arquiteturalmente.
+- **Audit log de operações no AKHQ → SIEM** ainda não integrado (futuro hardening).
+- **Multi-cluster** desligado — só `standalone-kafka` por enquanto. SP1/SP2/PA1 entram quando charts data/* aterrissarem (gap pré-existente, fora do escopo).
+
+## Referências
+
+- [AKHQ docs](https://akhq.io/docs/)
+- [Apache Kafka 4.2 docs](https://kafka.apache.org/42/documentation.html)
+- ADR-009 — Kafka SASL_SSL + SCRAM-SHA-512
+- Issue #139 — escopo deste chart

--- a/apps/kafka-ui/files/application.yml.tpl
+++ b/apps/kafka-ui/files/application.yml.tpl
@@ -1,0 +1,105 @@
+akhq:
+  # Conexões a clusters Kafka. Em standalone só temos 1; o `bootstrap-servers`
+  # vem do values; SCRAM credentials são injetadas via env (envFrom do Secret
+  # sintetizado pelo ESO `kafka-admin`). CA cert PEM montado em /etc/akhq/certs/ca.crt
+  # via projected volume — também sintetizado pelo ESO.
+  connections:
+    {{ .Values.kafkaUi.kafka.clusterName }}:
+      properties:
+        bootstrap.servers: "{{ .Values.kafkaUi.kafka.bootstrapServers }}"
+        security.protocol: {{ .Values.kafkaUi.kafka.securityProtocol }}
+        sasl.mechanism: {{ .Values.kafkaUi.kafka.saslMechanism }}
+        # JAAS config interpolado de env (KAFKA_USERNAME + KAFKA_PASSWORD
+        # vêm do envFrom do Secret kafka-admin sintetizado pelo ESO).
+        sasl.jaas.config: 'org.apache.kafka.common.security.scram.ScramLoginModule required username="${KAFKA_USERNAME}" password="${KAFKA_PASSWORD}";'
+        ssl.truststore.type: PEM
+        ssl.truststore.location: /etc/akhq/certs/ca.crt
+        # Self-signed cert do broker tem SAN cobrindo IP + DNS, mas
+        # disabilitar hostname verification mantém o pattern do
+        # admin.properties do data-host (§13).
+        ssl.endpoint.identification.algorithm: ""
+
+  # Segurança: OIDC via Keycloak realm `uniplus`.
+  security:
+    default-group: no-roles
+    groups:
+      no-roles:
+        roles: []
+        attributes: { description: "Sem permissão" }
+      kafka-admins:
+        roles:
+          - topic/read
+          - topic/insert
+          - topic/delete
+          - topic/config/update
+          - group/read
+          - group/delete
+          - group/offsets/update
+          - schema/read
+          - schema/insert
+          - schema/delete
+          - schema/version/delete
+          - acl/read
+          - acl/insert
+          - acl/delete
+          - node/read
+          - node/config/update
+        attributes: { description: "Administradores do Kafka" }
+      kafka-readonly:
+        roles:
+          - topic/read
+          - group/read
+          - schema/read
+          - acl/read
+          - node/read
+        attributes: { description: "Acesso de leitura ao Kafka" }
+{{- if .Values.kafkaUi.oidc.enabled }}
+    oidc:
+      enabled: true
+      providers:
+        {{ .Values.kafkaUi.oidc.providerName }}:
+          label: "Login Uni+"
+          # Mapping do claim `groups` (do Keycloak) para grupos AKHQ.
+          # O token JWT do Keycloak deve ter um mapper `groups` configurado
+          # para incluir o membership do usuário.
+          groups-field: {{ .Values.kafkaUi.oidc.groupsClaim }}
+          username-field: preferred_username
+          # AKHQ OIDC mapping: `name:` é a key da role AKHQ definida acima
+          # em `akhq.security.groups` (NÃO a claim do IdP); `groups:` lista
+          # os valores que o IdP devolve no claim `groups-field` que devem
+          # ser mapeados a essa role. Usar `role:` é syntax incorreta — AKHQ
+          # ignora silenciosamente e o user cai em default-group=no-roles.
+          groups:
+            - name: kafka-admins
+              groups:
+                - "{{ .Values.kafkaUi.oidc.groups.kafkaAdminsClaim }}"
+            - name: kafka-readonly
+              groups:
+                - "{{ .Values.kafkaUi.oidc.groups.kafkaReadOnlyClaim }}"
+{{- end }}
+
+# Micronaut OIDC (consumido pelo AKHQ). issuer + client_id no values;
+# client_secret via env OIDC_CLIENT_SECRET (envFrom do Secret kafka-ui-oidc-client).
+{{- if .Values.kafkaUi.oidc.enabled }}
+micronaut:
+  security:
+    enabled: true
+    authentication: idtoken
+    oauth2:
+      enabled: true
+      clients:
+        {{ .Values.kafkaUi.oidc.providerName }}:
+          client-id: {{ .Values.kafkaUi.oidc.clientId }}
+          client-secret: ${OIDC_CLIENT_SECRET}
+          openid:
+            issuer: "{{ .Values.kafkaUi.oidc.issuerUri }}"
+    endpoints:
+      logout:
+        get-allowed: true
+{{- end }}
+
+{{- if .Values.kafkaUi.metrics.enabled }}
+endpoints:
+  prometheus:
+    sensitive: false
+{{- end }}

--- a/apps/kafka-ui/templates/_helpers.tpl
+++ b/apps/kafka-ui/templates/_helpers.tpl
@@ -1,0 +1,77 @@
+{{/*
+Nome curto do release. AKHQ não tem peculiaridades de naming; segue
+pattern padrão Helm (release.Chart) com truncate p/ DNS-1123.
+*/}}
+{{- define "kafkaUi.fullname" -}}
+{{- if .Values.kafkaUi.fullnameOverride -}}
+{{- .Values.kafkaUi.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.kafkaUi.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Selector labels (subset estável dos commonLabels — match.io.k.s/name e
+match.io.k.s/instance só; version e managed-by mudam entre releases e
+quebrariam selectors se incluídos).
+*/}}
+{{- define "kafkaUi.selectorLabels" -}}
+app.kubernetes.io/name: {{ default .Chart.Name .Values.kafkaUi.nameOverride }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Labels padrão Uni+ + chart info, aplicados a TODOS os recursos do chart.
+*/}}
+{{- define "kafkaUi.labels" -}}
+{{ include "kafkaUi.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ServiceAccount name — usa Values.serviceAccount.name se setado, senão
+fullname com sufixo "-sa".
+*/}}
+{{- define "kafkaUi.serviceAccountName" -}}
+{{- if .Values.kafkaUi.serviceAccount.create -}}
+{{- default (printf "%s-sa" (include "kafkaUi.fullname" .)) .Values.kafkaUi.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.kafkaUi.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Nome do Secret K8s sintetizado pelo ESO `kafkaAdmin` — convenção
+<fullname>-kafka-admin (consumido por envFrom no deployment).
+*/}}
+{{- define "kafkaUi.kafkaAdminSecretName" -}}
+{{ include "kafkaUi.fullname" . }}-kafka-admin
+{{- end -}}
+
+{{/*
+Nome do Secret K8s sintetizado pelo ESO `oidcClient`.
+*/}}
+{{- define "kafkaUi.oidcClientSecretName" -}}
+{{ include "kafkaUi.fullname" . }}-oidc-client
+{{- end -}}
+
+{{/*
+Nome do Secret K8s sintetizado pelo ESO `jwt` — JWT signing secret do
+Micronaut security do AKHQ.
+*/}}
+{{- define "kafkaUi.jwtSecretName" -}}
+{{ include "kafkaUi.fullname" . }}-jwt
+{{- end -}}
+
+{{/*
+Nome do ConfigMap com application.yml renderizado.
+*/}}
+{{- define "kafkaUi.configMapName" -}}
+{{ include "kafkaUi.fullname" . }}-config
+{{- end -}}

--- a/apps/kafka-ui/templates/certificate.yaml
+++ b/apps/kafka-ui/templates/certificate.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.kafkaUi.enabled .Values.kafkaUi.ingress.enabled .Values.kafkaUi.ingress.tls.enabled .Values.kafkaUi.ingress.tls.certManager.enabled -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kafkaUi.fullname" . }}
+  labels:
+    {{- include "kafkaUi.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.kafkaUi.ingress.tls.secretName | default (printf "%s-tls" (include "kafkaUi.fullname" .)) }}
+  commonName: {{ .Values.kafkaUi.ingress.host }}
+  dnsNames:
+    - {{ .Values.kafkaUi.ingress.host }}
+  issuerRef:
+    name: {{ .Values.kafkaUi.ingress.tls.certManager.clusterIssuer }}
+    kind: ClusterIssuer
+{{- end }}

--- a/apps/kafka-ui/templates/configmap-akhq.yaml
+++ b/apps/kafka-ui/templates/configmap-akhq.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.kafkaUi.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kafkaUi.configMapName" . }}
+  labels:
+    {{- include "kafkaUi.labels" . | nindent 4 }}
+data:
+  # application.yml renderizado via tpl para interpolar values em todo o
+  # template. Pattern análogo ao realm-import do keycloak-replica.
+  # `${VAR}` no YAML é deixado literal — Micronaut/AKHQ resolve em runtime
+  # via env do container.
+  application.yml: |
+{{ tpl (.Files.Get "files/application.yml.tpl") . | indent 4 }}
+{{- end }}

--- a/apps/kafka-ui/templates/deployment.yaml
+++ b/apps/kafka-ui/templates/deployment.yaml
@@ -1,0 +1,132 @@
+{{- if .Values.kafkaUi.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kafkaUi.fullname" . }}
+  labels:
+    {{- include "kafkaUi.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.kafkaUi.replicas }}
+  # Stateless app — RollingUpdate sem maxSurge para forçar 1-at-a-time
+  # (cluster Kafka aceita múltiplos clients admin sem corrida; mas mantemos
+  # zero downtime trivial assim).
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      {{- include "kafkaUi.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kafkaUi.labels" . | nindent 8 }}
+      annotations:
+        # Restart automático quando application.yml muda — sha do
+        # rendered template via tpl. Mesmo pattern da `checksum/realm`
+        # do keycloak-replica.
+        checksum/config: {{ tpl (.Files.Get "files/application.yml.tpl") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "kafkaUi.serviceAccountName" . }}
+      {{- with .Values.kafkaUi.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.kafkaUi.podSecurityContext | nindent 8 }}
+      containers:
+        - name: akhq
+          image: "{{ .Values.kafkaUi.image.registry }}/{{ .Values.kafkaUi.image.repository }}:{{ .Values.kafkaUi.image.tag }}"
+          imagePullPolicy: {{ .Values.kafkaUi.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.kafkaUi.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            # AKHQ_CONFIGURATION ou MICRONAUT_CONFIG_FILES — em 0.27.0
+            # o entrypoint procura /app/application.yml por default;
+            # mountamos via ConfigMap nessa path.
+            - name: MICRONAUT_CONFIG_FILES
+              value: /app/application.yml
+            # Kafka SCRAM creds explícitas via secretKeyRef — NÃO `envFrom`
+            # do Secret kafka-admin: ele tem 3 keys (KAFKA_USERNAME,
+            # KAFKA_PASSWORD, ca.crt) e `ca.crt` contém ponto, que é caractere
+            # inválido em env var name. Kubernetes emite Warning event
+            # `InvalidEnvironmentVariableNames` em cada (re)start poluindo o
+            # event stream. ca.crt é consumido apenas via projected volume
+            # (volumeMounts abaixo). Code-reviewer P1 round 1.
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kafkaUi.kafkaAdminSecretName" . }}
+                  key: KAFKA_USERNAME
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kafkaUi.kafkaAdminSecretName" . }}
+                  key: KAFKA_PASSWORD
+            {{- if .Values.kafkaUi.oidc.enabled }}
+            # JWT signing secret — Micronaut convention: env var name é a
+            # property dotted convertida em snake-case maiúsculo. Sem essa
+            # env, group restrictions do AKHQ ficam UI-only (Codex P1 round 2).
+            - name: MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kafkaUi.jwtSecretName" . }}
+                  key: MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET
+            {{- end }}
+            {{- with .Values.kafkaUi.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.kafkaUi.oidc.enabled }}
+          envFrom:
+            # OIDC_CLIENT_SECRET — interpolado em micronaut.security.oauth2.
+            # Único campo do Secret oidc-client (sem keys com ponto), envFrom
+            # é seguro aqui.
+            - secretRef:
+                name: {{ include "kafkaUi.oidcClientSecretName" . }}
+          {{- end }}
+          volumeMounts:
+            # application.yml renderizado no ConfigMap.
+            - name: config
+              mountPath: /app/application.yml
+              subPath: application.yml
+              readOnly: true
+            # CA cert PEM do broker Kafka (self-signed). Vem do Secret
+            # sintetizado pelo ESO `kafkaAdmin` na key `ca.crt`.
+            - name: kafka-ca
+              mountPath: /etc/akhq/certs/ca.crt
+              subPath: ca.crt
+              readOnly: true
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: {{ .Values.kafkaUi.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.kafkaUi.startupProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: {{ .Values.kafkaUi.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: {{ .Values.kafkaUi.readinessProbe.periodSeconds }}
+          resources:
+            {{- toYaml .Values.kafkaUi.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "kafkaUi.configMapName" . }}
+        - name: kafka-ca
+          secret:
+            secretName: {{ include "kafkaUi.kafkaAdminSecretName" . }}
+            items:
+              - key: ca.crt
+                path: ca.crt
+{{- end }}

--- a/apps/kafka-ui/templates/externalsecret.yaml
+++ b/apps/kafka-ui/templates/externalsecret.yaml
@@ -1,0 +1,84 @@
+{{- if and .Values.kafkaUi.enabled .Values.kafkaUi.externalSecrets.enabled -}}
+# ESO 1: SCRAM admin do Kafka + CA cert PEM. Sintetiza Secret K8s
+# `<fullname>-kafka-admin` com 3 keys: KAFKA_USERNAME, KAFKA_PASSWORD,
+# ca.crt. As 2 primeiras vão via envFrom; ca.crt vai via projected
+# volume (mount em /etc/akhq/certs/ca.crt).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "kafkaUi.kafkaAdminSecretName" . }}
+  labels:
+    {{- include "kafkaUi.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.kafkaUi.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ .Values.kafkaUi.externalSecrets.secretStoreRef.kind }}
+    name: {{ .Values.kafkaUi.externalSecrets.secretStoreRef.name }}
+  target:
+    name: {{ include "kafkaUi.kafkaAdminSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: KAFKA_USERNAME
+      remoteRef:
+        key: {{ .Values.kafkaUi.externalSecrets.kafkaAdmin.vaultPath }}
+        property: {{ .Values.kafkaUi.externalSecrets.kafkaAdmin.usernameKey }}
+    - secretKey: KAFKA_PASSWORD
+      remoteRef:
+        key: {{ .Values.kafkaUi.externalSecrets.kafkaAdmin.vaultPath }}
+        property: {{ .Values.kafkaUi.externalSecrets.kafkaAdmin.passwordKey }}
+    - secretKey: ca.crt
+      remoteRef:
+        key: {{ .Values.kafkaUi.externalSecrets.kafkaAdmin.vaultPath }}
+        property: {{ .Values.kafkaUi.externalSecrets.kafkaAdmin.caCertKey }}
+{{- if .Values.kafkaUi.oidc.enabled }}
+---
+# ESO 2: OIDC client_secret do client `kafka-ui` no realm uniplus.
+# Custodiado em Vault (operador one-shot ou via Keycloak Admin API
+# durante setup do realm). Disponibilizado via env OIDC_CLIENT_SECRET.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "kafkaUi.oidcClientSecretName" . }}
+  labels:
+    {{- include "kafkaUi.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.kafkaUi.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ .Values.kafkaUi.externalSecrets.secretStoreRef.kind }}
+    name: {{ .Values.kafkaUi.externalSecrets.secretStoreRef.name }}
+  target:
+    name: {{ include "kafkaUi.oidcClientSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: {{ .Values.kafkaUi.externalSecrets.oidcClient.vaultPath }}
+        property: {{ .Values.kafkaUi.externalSecrets.oidcClient.clientSecretKey }}
+---
+# ESO 3: JWT signing secret do Micronaut security do AKHQ. Sem isso AKHQ
+# 0.25+ NÃO enforce group restrictions no API layer — apenas UI — e users
+# podem bypass via direct backend requests (Codex P1 round 2). Sintetizado
+# como Secret com key MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET
+# (env var Micronaut convention: dots → underscores, uppercased) consumida
+# via env.valueFrom.secretKeyRef no deployment.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "kafkaUi.jwtSecretName" . }}
+  labels:
+    {{- include "kafkaUi.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.kafkaUi.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ .Values.kafkaUi.externalSecrets.secretStoreRef.kind }}
+    name: {{ .Values.kafkaUi.externalSecrets.secretStoreRef.name }}
+  target:
+    name: {{ include "kafkaUi.jwtSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET
+      remoteRef:
+        key: {{ .Values.kafkaUi.externalSecrets.jwt.vaultPath }}
+        property: {{ .Values.kafkaUi.externalSecrets.jwt.signingSecretKey }}
+{{- end }}
+{{- end }}

--- a/apps/kafka-ui/templates/ingressroute.yaml
+++ b/apps/kafka-ui/templates/ingressroute.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.kafkaUi.enabled .Values.kafkaUi.ingress.enabled -}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "kafkaUi.fullname" . }}
+  labels:
+    {{- include "kafkaUi.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.kafkaUi.ingress.entryPoint }}
+  routes:
+    - match: Host(`{{ .Values.kafkaUi.ingress.host }}`)
+      kind: Rule
+      services:
+        - name: {{ include "kafkaUi.fullname" . }}
+          port: 8080
+          # AKHQ não roda atrás de path prefix — proxy precisa preservar
+          # X-Forwarded-{Host,Proto} para Micronaut OIDC redirect URI bater
+          # com o registrado no Keycloak. Traefik faz isso por default.
+  {{- if .Values.kafkaUi.ingress.tls.enabled }}
+  tls:
+    secretName: {{ .Values.kafkaUi.ingress.tls.secretName | default (printf "%s-tls" (include "kafkaUi.fullname" .)) }}
+  {{- end }}
+{{- end }}

--- a/apps/kafka-ui/templates/networkpolicy.yaml
+++ b/apps/kafka-ui/templates/networkpolicy.yaml
@@ -1,0 +1,85 @@
+{{- if and .Values.kafkaUi.enabled .Values.kafkaUi.networkPolicy.enabled -}}
+{{- if not .Values.kafkaUi.networkPolicy.dataHostCIDR -}}
+{{- fail "kafkaUi.networkPolicy.dataHostCIDR é obrigatório quando networkPolicy.enabled=true (sem isso o egress para Kafka data-host fica em default-deny silencioso). Configurar em environments/<env>/values.yaml." -}}
+{{- end -}}
+{{- if and .Values.kafkaUi.oidc.enabled (not .Values.kafkaUi.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "kafkaUi.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (AKHQ chama OIDC discovery/token endpoints em HTTPS contra o issuer público; sem essa entrada o egress fica em default-deny e auth flows falham silenciosamente). Configurar para o IP público do k8s-host /32 em environments/<env>/values.yaml." -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kafkaUi.fullname" . }}
+  labels:
+    {{- include "kafkaUi.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kafkaUi.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # HTTP do Traefik (apenas pods do namespace traefik)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.kafkaUi.networkPolicy.traefikNamespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- if and .Values.kafkaUi.metrics.enabled .Values.kafkaUi.serviceMonitor.enabled }}
+    # Prometheus scrape em /prometheus (via mesma porta 8080).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.kafkaUi.networkPolicy.monitoringNamespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- end }}
+  egress:
+    # DNS (CoreDNS)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Kafka data-host (subnet privada VCN)
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.kafkaUi.networkPolicy.dataHostCIDR }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.kafkaUi.networkPolicy.dataHostPort }}
+    # Keycloak in-cluster (path interno se issuerUri usa Service DNS;
+    # mantido como fallback útil — apps na cluster mesh podem chamar
+    # diretamente em vez de via IngressRoute).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.kafkaUi.networkPolicy.keycloakNamespace }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: keycloak-replica
+      ports:
+        - protocol: TCP
+          port: {{ .Values.kafkaUi.networkPolicy.keycloakPort }}
+    {{- if .Values.kafkaUi.oidc.enabled }}
+    # OIDC issuer público (HTTPS). Em standalone, AKHQ usa
+    # `https://standalone.portaluni.com.br/auth/realms/uniplus` que
+    # resolve via DNS para o public IP do k8s-host (164.152.53.29) e
+    # entra via Traefik IngressRoute do Keycloak. Sem este egress, o
+    # OIDC discovery e token exchange falham silenciosamente em
+    # default-deny (TLS handshake never completes).
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.kafkaUi.networkPolicy.oidcIssuerCIDR }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.kafkaUi.networkPolicy.oidcIssuerPort }}
+    {{- end }}
+{{- end }}

--- a/apps/kafka-ui/templates/service.yaml
+++ b/apps/kafka-ui/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.kafkaUi.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kafkaUi.fullname" . }}
+  labels:
+    {{- include "kafkaUi.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "kafkaUi.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/apps/kafka-ui/templates/serviceaccount.yaml
+++ b/apps/kafka-ui/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.kafkaUi.enabled .Values.kafkaUi.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kafkaUi.serviceAccountName" . }}
+  labels:
+    {{- include "kafkaUi.labels" . | nindent 4 }}
+{{- end }}

--- a/apps/kafka-ui/templates/servicemonitor.yaml
+++ b/apps/kafka-ui/templates/servicemonitor.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.kafkaUi.enabled .Values.kafkaUi.metrics.enabled .Values.kafkaUi.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kafkaUi.fullname" . }}
+  labels:
+    {{- include "kafkaUi.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kafkaUi.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /prometheus
+      interval: {{ .Values.kafkaUi.serviceMonitor.interval }}
+{{- end }}

--- a/apps/kafka-ui/values.schema.json
+++ b/apps/kafka-ui/values.schema.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "commonLabels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "kafkaUi": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "registry": { "type": "string" },
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "enum": ["Always", "IfNotPresent", "Never"] }
+          },
+          "required": ["registry", "repository", "tag", "pullPolicy"]
+        },
+        "imagePullSecrets": { "type": "array" },
+        "fullnameOverride": { "type": "string" },
+        "nameOverride": { "type": "string" },
+        "replicas": { "type": "integer", "minimum": 1 },
+        "resources": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "serviceAccount": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "create": { "type": "boolean" },
+            "name": { "type": "string" }
+          }
+        },
+        "kafka": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "clusterName": { "type": "string", "minLength": 1 },
+            "bootstrapServers": { "type": "string" },
+            "securityProtocol": { "enum": ["PLAINTEXT", "SASL_PLAINTEXT", "SSL", "SASL_SSL"] },
+            "saslMechanism": { "enum": ["PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512", "GSSAPI", "OAUTHBEARER"] }
+          },
+          "required": ["clusterName", "securityProtocol", "saslMechanism"]
+        },
+        "oidc": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "providerName": { "type": "string", "minLength": 1 },
+            "issuerUri": { "type": "string" },
+            "clientId": { "type": "string", "minLength": 1 },
+            "groupsClaim": { "type": "string" },
+            "groups": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "kafkaAdminsClaim": { "type": "string" },
+                "kafkaReadOnlyClaim": { "type": "string" }
+              }
+            }
+          },
+          "required": ["enabled", "providerName", "clientId", "groupsClaim", "groups"]
+        },
+        "externalSecrets": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "refreshInterval": { "type": "string" },
+            "secretStoreRef": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "kind": { "enum": ["ClusterSecretStore", "SecretStore"] },
+                "name": { "type": "string" }
+              },
+              "required": ["kind", "name"]
+            },
+            "kafkaAdmin": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "vaultPath": { "type": "string" },
+                "usernameKey": { "type": "string" },
+                "passwordKey": { "type": "string" },
+                "caCertKey": { "type": "string" }
+              },
+              "required": ["vaultPath", "usernameKey", "passwordKey", "caCertKey"]
+            },
+            "oidcClient": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "vaultPath": { "type": "string" },
+                "clientSecretKey": { "type": "string" }
+              },
+              "required": ["vaultPath", "clientSecretKey"]
+            },
+            "jwt": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "vaultPath": { "type": "string" },
+                "signingSecretKey": { "type": "string" }
+              },
+              "required": ["vaultPath", "signingSecretKey"]
+            }
+          }
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "entryPoint": { "type": "string" },
+            "host": { "type": "string" },
+            "tls": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "secretName": { "type": "string" },
+                "certManager": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "clusterIssuer": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "networkPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "traefikNamespace": { "type": "string" },
+            "monitoringNamespace": { "type": "string" },
+            "dataHostCIDR": { "type": "string" },
+            "dataHostPort": { "type": "integer" },
+            "keycloakService": { "type": "string" },
+            "keycloakNamespace": { "type": "string" },
+            "keycloakPort": { "type": "integer" },
+            "oidcIssuerCIDR": { "type": "string" },
+            "oidcIssuerPort": { "type": "integer" }
+          }
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "interval": { "type": "string" }
+          }
+        },
+        "startupProbe": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "livenessProbe": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "readinessProbe": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "podSecurityContext": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "containerSecurityContext": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "extraEnv": {
+          "type": "array"
+        }
+      },
+      "required": ["enabled", "image", "kafka", "oidc"]
+    }
+  }
+}

--- a/apps/kafka-ui/values.yaml
+++ b/apps/kafka-ui/values.yaml
@@ -1,0 +1,182 @@
+# Defaults do chart apps/kafka-ui/.
+# Cada environment (environments/<env>/values.yaml) sobrescreve apenas o
+# necessário. Por padrão o chart fica DESABILITADO — só os ambientes que
+# precisam de UI Kafka (ex.: standalone) ligam via `kafkaUi.enabled: true`.
+
+commonLabels:
+  app.kubernetes.io/part-of: uniplus
+  app.kubernetes.io/component: data-admin
+
+kafkaUi:
+  # Liga/desliga o chart inteiro. Default false.
+  enabled: false
+
+  image:
+    registry: docker.io
+    repository: tchiotludo/akhq
+    # Versão estável validada (Mar/2026). Bumps de patch são seguros;
+    # major requer revisão da application.yml schema.
+    tag: "0.27.0"
+    pullPolicy: IfNotPresent
+
+  imagePullSecrets: []
+
+  # AKHQ é stateless (não persiste nada local); 1 réplica é suficiente.
+  # Multi-réplica não dá ganho — todas leem do mesmo Kafka.
+  replicas: 1
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+  serviceAccount:
+    create: true
+    name: ""
+
+  # === Conexão ao Kafka cluster ===
+  # AKHQ pode gerenciar múltiplos clusters; em standalone só temos 1.
+  kafka:
+    # Nome do cluster como aparecerá na UI. Mantido genérico para reuso
+    # quando platform/data/* (3-DC) aterrissar.
+    clusterName: standalone
+    bootstrapServers: ""  # ex.: 10.0.2.87:9092
+    # SASL_SSL + SCRAM-SHA-512 via creds sintetizadas pelo ESO.
+    # `ssl.endpoint.identification.algorithm=` vazio aceita SAN do
+    # self-signed que cobre IP da subnet privada.
+    securityProtocol: SASL_SSL
+    saslMechanism: SCRAM-SHA-512
+
+  # === OIDC (Keycloak realm uniplus) ===
+  # AKHQ usa Micronaut OIDC. Confidential client `kafka-ui` no realm —
+  # client_secret custodiado em Vault e injetado via ExternalSecret.
+  oidc:
+    enabled: true
+    providerName: keycloak
+    issuerUri: ""                  # ex.: https://standalone.portaluni.com.br/auth/realms/uniplus
+    clientId: kafka-ui
+    # Mapping de claim `groups` → roles AKHQ. Requer mapper
+    # `groups` no client `kafka-ui` do realm.
+    groupsClaim: groups
+    groups:
+      kafkaAdminsClaim: "/admins/kafka"
+      kafkaReadOnlyClaim: "/users/uniplus"
+
+  # === ExternalSecrets (Vault → K8s Secret) ===
+  externalSecrets:
+    enabled: true
+    refreshInterval: "1h"
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: vault-default
+
+    # SCRAM admin do Kafka + CA cert do broker self-signed.
+    # Gerados em `secret/standalone/kafka/admin` via §13.2 do RUNBOOKS
+    # após bootstrap. ca_cert é PEM completo do CA do broker (necessário
+    # para AKHQ validar o handshake TLS — broker usa self-signed sem
+    # cadeia institucional).
+    kafkaAdmin:
+      vaultPath: secret/standalone/kafka/admin
+      usernameKey: username
+      passwordKey: password
+      caCertKey: ca_cert
+
+    # client_secret OIDC do confidential client `kafka-ui` no realm
+    # uniplus. Gerado pelo operador (one-shot ou via Keycloak Admin API)
+    # e custodiado no Vault. AKHQ NÃO suporta public client/PKCE para
+    # provider customizado em 0.27.x.
+    oidcClient:
+      vaultPath: secret/standalone/keycloak/clients/kafka-ui
+      clientSecretKey: client_secret
+
+    # JWT signing secret — assina cookies/tokens internos do Micronaut
+    # security AKHQ. Sem isso, AKHQ 0.25+ NÃO enforce group restrictions
+    # no API layer (apenas UI), permitindo bypass via direct backend
+    # requests (Codex P1 round 2). Operador gera 32 bytes hex e custodia
+    # em Vault durante pré-flight (RUNBOOKS §14.1).
+    jwt:
+      vaultPath: secret/standalone/kafka-ui/jwt
+      signingSecretKey: signing_secret
+
+  # === Exposição externa via Traefik IngressRoute ===
+  ingress:
+    enabled: false
+    entryPoint: websecure
+    host: ""                     # ex.: kafka-ui.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: ""             # criado pelo cert-manager se certManager.enabled
+      certManager:
+        enabled: false
+        clusterIssuer: ""        # ex.: letsencrypt-staging | letsencrypt-prod
+
+  # === NetworkPolicy ===
+  # Egress: Kafka data-host (10.0.2.87:9092) + DNS + Keycloak
+  # (cluster-internal) + OIDC issuer endpoint externo (HTTPS port 443).
+  # Ingress: somente Traefik.
+  networkPolicy:
+    enabled: true
+    traefikNamespace: traefik
+    monitoringNamespace: observability-prometheus
+    # CIDR da subnet privada VCN onde o Kafka data-host vive. Deve casar
+    # com `dataHostCIDR` do keycloak-replica para reuso de pattern.
+    dataHostCIDR: ""
+    dataHostPort: 9092
+    # Service do Keycloak local (in-cluster). Default casa com release name
+    # padrão do chart keycloak-replica em standalone.
+    keycloakService: keycloak-replica-uniplus-standalone
+    keycloakNamespace: uniplus
+    keycloakPort: 8080
+    # CIDR do endpoint público do OIDC issuer. AKHQ chama `.well-known/
+    # openid-configuration`, `/token`, `/userinfo` em HTTPS port 443 contra
+    # o issuer URL (ex.: standalone.portaluni.com.br resolve pra k8s-host
+    # public IP que entra via Traefik IngressRoute do Keycloak). Sem essa
+    # entrada, o pod resolve o DNS mas o handshake TLS é bloqueado pelo
+    # default-deny do egress. Codex P1 round 1.
+    #
+    # Em standalone OCI (k8s-host 164.152.53.29) → /32 é precise; em
+    # outros providers ajustar para o IP público real ou CIDR mais largo
+    # (NUNCA 0.0.0.0/0 — defesa em profundidade).
+    oidcIssuerCIDR: ""
+    oidcIssuerPort: 443
+
+  # === ServiceMonitor (Prometheus) ===
+  # AKHQ expõe /metrics em /prometheus (Micronaut). Gateado em
+  # `serviceMonitor.enabled AND metrics.enabled` (mesma estratégia
+  # do keycloak-replica para evitar scrape de endpoint inexistente).
+  metrics:
+    enabled: true
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+
+  # === Probes ===
+  # AKHQ tem startup ~10-30s; failureThreshold absorve cold start.
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 5
+  livenessProbe:
+    periodSeconds: 10
+  readinessProbe:
+    periodSeconds: 5
+
+  # === SecurityContext ===
+  # tchiotludo/akhq:0.27.0 roda como uid 1001 (akhq).
+  podSecurityContext:
+    fsGroup: 1001
+  containerSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    # AKHQ escreve em /tmp; rootfs pode ser readOnly se montar /tmp
+    # como emptyDir. Out of scope deste PR (deploy em prod hardening).
+    readOnlyRootFilesystem: false
+
+  # Env vars adicionais (lista de `{name, value}` ou `{name, valueFrom}`).
+  extraEnv: []

--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -57,6 +57,60 @@
         "phone",
         "offline_access"
       ]
+    },
+    {
+      "clientId": "kafka-ui",
+      "name": "AKHQ — Kafka Web UI (admin)",
+      "description": "Cliente OIDC do AKHQ (apps/kafka-ui). Confidential client — AKHQ é backend, mantém client_secret no Vault. Após import inicial, operador deve recuperar o secret gerado pelo Keycloak via kcadm.sh e custodiar em secret/standalone/keycloak/clients/kafka-ui (RUNBOOKS §14.1).",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "frontchannelLogout": true,
+      "redirectUris": ["https://kafka-ui.standalone.portaluni.com.br/oauth/callback/keycloak"],
+      "webOrigins": ["https://kafka-ui.standalone.portaluni.com.br"],
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "groups"
+          }
+        }
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "name": "admins",
+      "subGroups": [
+        { "name": "kafka", "path": "/admins/kafka" }
+      ]
+    },
+    {
+      "name": "users",
+      "subGroups": [
+        { "name": "uniplus", "path": "/users/uniplus" }
+      ]
     }
   ],
   "roles": {

--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -38,6 +38,7 @@ spec:
                 - app: uniplus-api-ingresso
                 - app: clamav-scanner
                 - app: keycloak-replica
+                - app: kafka-ui
 
   template:
     metadata:

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2339,6 +2339,230 @@ ADR-009 documenta os deltas previstos:
 | `KRaft metadata controller is not yet ready` | Cold start ou storage corrupto | Aguardar até 180s; se persiste, conferir `__cluster_metadata-0/` |
 | Disk full em `vg-kafka` | Logs cresceram além do volume | `df -h /var/lib/uniplus/kafka`; aplicar `retention.ms`/`retention.bytes` por topic; expandir LVM |
 
+## 14. AKHQ — Web UI do Kafka (standalone)
+
+Web UI de gerenciamento do cluster Kafka SASL_SSL — chart `apps/kafka-ui/` (issue #139). AKHQ 0.27.x, Micronaut OIDC integrado ao realm `uniplus` do Keycloak. Pré-requisitos: §13 Kafka SASL_SSL ativo (admin SCRAM em `secret/standalone/kafka/admin`) + §10 Keycloak ativo (realm `uniplus` importado).
+
+### 14.1 Pré-flight: client OIDC + JWT signing + custódia
+
+3 segredos precisam ser custodiados em Vault antes do ArgoCD reconciliar o chart kafka-ui:
+
+1. `secret/standalone/keycloak/clients/kafka-ui` — `client_secret` (gerado pelo realm import)
+2. `secret/standalone/kafka-ui/jwt` — `signing_secret` (gerado pelo operador, 32 bytes hex)
+3. `secret/standalone/kafka/admin` — admin SCRAM Kafka (já custodiado em §13.2)
+
+Sem (1) ou (2), os ESOs ficam em `SecretNotFound` e AKHQ trava em `CreateContainerConfigError`.
+
+```bash
+kc() { sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "$@"; }
+```
+
+**Passo 1 — Garantir que o realm `uniplus` tem o client `kafka-ui` + grupos.**
+
+Realm já existente (deploy pré-PR #142) — Keycloak `start --import-realm` skip se realm existe. Adicionar via `kcadm.sh` (operação cirúrgica, sem perder customizações via Admin UI):
+
+```bash
+kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c '
+  set -e
+  /opt/keycloak/bin/kcadm.sh config credentials \
+    --server http://localhost:8080/auth \
+    --realm master \
+    --user "$KC_BOOTSTRAP_ADMIN_USERNAME" \
+    --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" >/dev/null
+
+  # 1.1 Criar grupos /admins/kafka e /users/uniplus (idempotente — ignora se existem)
+  for GP in "admins/kafka" "users/uniplus"; do
+    PARENT=${GP%/*}; CHILD=${GP##*/}
+    /opt/keycloak/bin/kcadm.sh create groups -r uniplus -s name="$PARENT" 2>/dev/null || true
+    PID=$(/opt/keycloak/bin/kcadm.sh get groups -r uniplus -q briefRepresentation=true --fields id,name --format csv --noquotes | awk -F, -v n="$PARENT" "\$2==n {print \$1}")
+    /opt/keycloak/bin/kcadm.sh create groups/$PID/children -r uniplus -s name="$CHILD" 2>/dev/null || true
+  done
+
+  # 1.2 Criar client kafka-ui confidential (idempotente)
+  EXISTING=$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus -q clientId=kafka-ui --fields id --format csv --noquotes | tail -1)
+  if [ -z "$EXISTING" ]; then
+    /opt/keycloak/bin/kcadm.sh create clients -r uniplus -f - <<JSON
+{
+  "clientId": "kafka-ui",
+  "name": "AKHQ — Kafka Web UI (admin)",
+  "enabled": true, "protocol": "openid-connect",
+  "publicClient": false, "standardFlowEnabled": true,
+  "implicitFlowEnabled": false, "directAccessGrantsEnabled": false,
+  "serviceAccountsEnabled": false, "frontchannelLogout": true,
+  "redirectUris": ["https://kafka-ui.standalone.portaluni.com.br/oauth/callback/keycloak"],
+  "webOrigins": ["https://kafka-ui.standalone.portaluni.com.br"],
+  "attributes": { "post.logout.redirect.uris": "+" },
+  "defaultClientScopes": ["web-origins","acr","profile","roles","email"]
+}
+JSON
+    CID=$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus -q clientId=kafka-ui --fields id --format csv --noquotes | tail -1)
+    # 1.3 Mapper groups (full path)
+    /opt/keycloak/bin/kcadm.sh create clients/$CID/protocol-mappers/models -r uniplus -f - <<JSON
+{
+  "name": "groups", "protocol": "openid-connect",
+  "protocolMapper": "oidc-group-membership-mapper",
+  "consentRequired": false,
+  "config": { "full.path": "true", "id.token.claim": "true",
+              "access.token.claim": "true", "userinfo.token.claim": "true",
+              "claim.name": "groups" }
+}
+JSON
+  fi
+'
+```
+
+> Em deploys novos (sem realm prévio), o realm import cobre tudo automaticamente via `apps/keycloak-replica/files/uniplus-realm.json` — esse passo 1 é noop. Para forçar re-import completo (perdendo mudanças via Admin UI), seguir §10.5.
+
+**Passo 2 — Recuperar o client_secret + custodiar:**
+
+```bash
+KAFKA_UI_SECRET=$(kc exec -n uniplus deploy/keycloak-replica-uniplus-standalone -- bash -c '
+  /opt/keycloak/bin/kcadm.sh config credentials \
+    --server http://localhost:8080/auth --realm master \
+    --user "$KC_BOOTSTRAP_ADMIN_USERNAME" --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" >/dev/null
+  CID=$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus -q clientId=kafka-ui --fields id --format csv --noquotes | tail -1)
+  /opt/keycloak/bin/kcadm.sh get clients/$CID/client-secret -r uniplus --fields value --format csv --noquotes | tail -1
+')
+echo "kafka-ui client_secret: ${KAFKA_UI_SECRET:0:8}...(redacted)"
+```
+
+**Passo 3 — Gerar JWT signing secret (32 bytes hex aleatório):**
+
+```bash
+JWT_SECRET=$(openssl rand -hex 32)
+```
+
+**Passo 4 — Custodiar ambos em Vault (k8s-host):**
+
+```bash
+read -rsp "Root token: " VAULT_TOKEN; echo
+
+# OIDC client_secret
+kc -n vault exec -i platform-vault-uniplus-standalone-0 -- \
+  sh -c 'read -r T; read -r S; export VAULT_TOKEN="$T"; vault kv put secret/standalone/keycloak/clients/kafka-ui client_secret="$S"' \
+  <<EOF
+$VAULT_TOKEN
+$KAFKA_UI_SECRET
+EOF
+
+# JWT signing secret
+kc -n vault exec -i platform-vault-uniplus-standalone-0 -- \
+  sh -c 'read -r T; read -r S; export VAULT_TOKEN="$T"; vault kv put secret/standalone/kafka-ui/jwt signing_secret="$S"' \
+  <<EOF
+$VAULT_TOKEN
+$JWT_SECRET
+EOF
+
+unset KAFKA_UI_SECRET JWT_SECRET VAULT_TOKEN
+```
+
+**Passo 5 — ArgoCD reconcilia o chart kafka-ui automaticamente** após os 3 ESOs sintetizarem os Secrets K8s (`<release>-kafka-admin`, `<release>-oidc-client`, `<release>-jwt`).
+
+### 14.2 Adicionar usuários aos grupos /admins/kafka e /users/uniplus
+
+Realm import já cria os grupos vazios. Adicionar membros:
+
+```bash
+# Via kcadm (CLI no pod Keycloak):
+kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c '
+  /opt/keycloak/bin/kcadm.sh config credentials \
+    --server http://localhost:8080/auth --realm master \
+    --user "$KC_BOOTSTRAP_ADMIN_USERNAME" --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" >/dev/null
+
+  # Criar usuário (ou pular se já existe via Gov.br federado)
+  /opt/keycloak/bin/kcadm.sh create users -r uniplus \
+    -s username=jeferson.ferreira -s email=jeferson.ferreira@unifesspa.edu.br \
+    -s firstName=Jeferson -s lastName="Ferreira da Silva" -s enabled=true || true
+
+  # Buscar IDs do user e do grupo /admins/kafka
+  USER_ID=$(/opt/keycloak/bin/kcadm.sh get users -r uniplus -q username=jeferson.ferreira \
+    --fields id --format csv --noquotes | tail -1)
+  GROUP_ID=$(/opt/keycloak/bin/kcadm.sh get groups -r uniplus \
+    --fields id,path --format csv --noquotes | grep "/admins/kafka" | cut -d, -f1)
+
+  # Adicionar
+  /opt/keycloak/bin/kcadm.sh update users/$USER_ID/groups/$GROUP_ID -r uniplus -s userId=$USER_ID -s groupId=$GROUP_ID
+'
+```
+
+Ou via Admin UI: `Users → <user> → Groups → Join /admins/kafka`.
+
+### 14.3 Smoke test end-to-end
+
+```bash
+# 1) ESOs sincronizaram
+kc get externalsecret -n uniplus | grep kafka-ui
+# Esperado: <release>-kafka-admin SecretSynced=True
+#           <release>-oidc-client  SecretSynced=True
+
+# 2) Pod Running 1/1
+kc get pod -n uniplus -l app.kubernetes.io/name=kafka-ui
+# Esperado: 1/1 Running
+
+# 3) Logs limpos (sem erros de kafka conn ou OIDC discovery)
+kc logs -n uniplus -l app.kubernetes.io/name=kafka-ui --tail=100 | \
+  grep -E "ERROR|Bound to|Started|OIDC"
+# Esperado: "Server Started" (Micronaut), bound em 0.0.0.0:8080
+
+# 4) Health endpoint
+kc exec -n uniplus -l app.kubernetes.io/name=kafka-ui -- \
+  curl -sf http://localhost:8080/health
+# Esperado: {"status":"UP"}
+
+# 5) Login real (do laptop):
+xdg-open https://kafka-ui.standalone.portaluni.com.br
+# - Aceitar warning de cert (LE staging)
+# - Click "Login Uni+" → redireciona para Keycloak
+# - Autenticar com user que tem membership /admins/kafka
+# - Após callback, ver dropdown "standalone" no canto superior + lista de tópicos
+```
+
+### 14.4 Rotacionar client_secret
+
+```bash
+# 1) Regenerar no Keycloak via Admin API
+NEW_SECRET=$(kc exec -n uniplus deploy/keycloak-replica-uniplus-standalone -- bash -c '
+  /opt/keycloak/bin/kcadm.sh config credentials \
+    --server http://localhost:8080/auth --realm master \
+    --user "$KC_BOOTSTRAP_ADMIN_USERNAME" --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" >/dev/null
+  CID=$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus -q clientId=kafka-ui --fields id --format csv --noquotes | tail -1)
+  /opt/keycloak/bin/kcadm.sh create clients/$CID/client-secret -r uniplus \
+    --fields value --format csv --noquotes | tail -1
+')
+
+# 2) Atualizar Vault
+read -rsp "Root token: " TKN; echo
+kc -n vault exec -i platform-vault-uniplus-standalone-0 -- \
+  sh -c 'read -r T; read -r S; export VAULT_TOKEN="$T"; vault kv put secret/standalone/keycloak/clients/kafka-ui client_secret="$S"' \
+  <<EOF
+$TKN
+$NEW_SECRET
+EOF
+
+# 3) Forçar refresh do ESO (default refreshInterval=1h)
+kc annotate externalsecret -n uniplus \
+  $(kc get externalsecret -n uniplus -o name | grep oidc-client) \
+  force-sync="$(date +%s)" --overwrite
+
+# 4) Restart do AKHQ pra reler env
+kc rollout restart deployment -n uniplus -l app.kubernetes.io/name=kafka-ui
+
+unset NEW_SECRET TKN
+```
+
+### 14.5 Troubleshooting
+
+| Sintoma | Diagnóstico | Fix |
+|---|---|---|
+| Pod `CreateContainerConfigError: secret <release>-oidc-client not found` | ESO `<release>-oidc-client` ainda não sincronizou — secret/standalone/keycloak/clients/kafka-ui ausente em Vault | Rodar §14.1 (custódia do client_secret) |
+| Pod `CreateContainerConfigError: secret <release>-jwt not found` | ESO JWT ainda não sintetizou — secret/standalone/kafka-ui/jwt ausente em Vault | Rodar §14.1 passo 3+4 (gerar + custodiar JWT signing secret) |
+| Pod `CreateContainerConfigError: secret <release>-kafka-admin not found` | ESO ainda não sintetizou — secret/standalone/kafka/admin ausente em Vault | Rodar §13.2 (custódia admin SCRAM Kafka) |
+| AKHQ logs: `org.apache.kafka.common.errors.SslAuthenticationException: SSL handshake failed` | CA cert PEM ausente no Secret kafka-admin (key `ca.crt` faltando) | `vault kv get secret/standalone/kafka/admin` confere se `ca_cert` está populado; rodar §13.2 step 2 incluindo `ca_cert=$(ssh ...sudo cat /etc/uniplus-kafka/certs/ca.crt)` |
+| Login redireciona pro Keycloak mas após callback retorna 401/Forbidden no AKHQ | Membership do user no grupo `/admins/kafka` ausente OU mapper `groups` no client kafka-ui ausente/quebrado | Confirmar grupo via Admin UI; verificar `kc get configmap -n uniplus <release>-config -o yaml` se `claim.name=groups` no protocolMapper |
+| AKHQ logs: `Connection to node -1 failed: Authentication failed: Invalid username or password` | Senha SCRAM em Vault desatualizada vs Kafka runtime | Rodar §13.6 (rotação admin Kafka) — sincroniza Vault + restart broker; depois forçar refresh ESO `kafka-admin` |
+| `redirect_uri did not match` no Keycloak | URI no realm ≠ `https://kafka-ui.standalone.portaluni.com.br/oauth/callback/keycloak` | Conferir `redirectUris` no client `kafka-ui` (Admin UI ou kcadm); ajustar se domínio do `ingress.host` mudou |
+| Browser warning permanente "Not secure" | Cert LE staging — esperado em validação | Promover para `letsencrypt-prod` (alterar `clusterIssuer` em `environments/standalone/values.yaml`) — mesmo procedimento §10.6 do Keycloak |
+
 ---
 
 *Documento mantido pelo CTIC/UNIFESSPA. Atualizações via Pull Request.*

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -414,6 +414,56 @@ keycloak:
     enabled: false
 
 # ----------------------------------------------------------------------------
+# kafka-ui (AKHQ) — Web UI de gerenciamento do cluster Kafka SASL_SSL.
+# Conecta ao broker no data-host (10.0.2.87:9092 SASL_SSL) e autentica
+# usuários via OIDC do realm `uniplus` no Keycloak local. Issue #139.
+# ----------------------------------------------------------------------------
+kafkaUi:
+  enabled: true
+
+  kafka:
+    bootstrapServers: 10.0.2.87:9092
+
+  oidc:
+    enabled: true
+    issuerUri: https://standalone.portaluni.com.br/auth/realms/uniplus
+
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    host: kafka-ui.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: kafka-ui-tls
+      certManager:
+        enabled: true
+        # Em standalone usamos LE staging durante validação. Promover pra
+        # letsencrypt-prod após smoke test (mesmo pattern do Keycloak §10.6).
+        clusterIssuer: letsencrypt-staging
+
+  networkPolicy:
+    enabled: true
+    traefikNamespace: traefik
+    monitoringNamespace: observability-prometheus
+    # /24 da subnet privada VCN onde o Kafka data-host vive (mais permissivo
+    # que o /32 do Keycloak porque AKHQ pode futuramente alcançar múltiplos
+    # brokers num cluster HA).
+    dataHostCIDR: 10.0.2.0/24
+    dataHostPort: 9092
+    keycloakService: keycloak-replica-uniplus-standalone
+    keycloakNamespace: uniplus
+    keycloakPort: 8080
+    # IP público do k8s-host OCI standalone (164.152.53.29) /32. AKHQ chama
+    # OIDC discovery + token endpoints contra `standalone.portaluni.com.br`
+    # que resolve para esse IP e entra via Traefik IngressRoute do Keycloak.
+    # Sem essa entrada o egress fica em default-deny (Codex P1 round 1).
+    oidcIssuerCIDR: 164.152.53.29/32
+    oidcIssuerPort: 443
+
+  serviceMonitor:
+    enabled: false
+
+# ----------------------------------------------------------------------------
 # Componentes stateful no data-host (Postgres, Kafka, MinIO, Redis) rodam
 # FORA do K8s, gerenciados por systemd em /var/lib/uniplus/* (ADR-002 +
 # ADR-005). Endpoints chegam às apps via External Secrets sintetizados a


### PR DESCRIPTION
## Summary

Provisiona AKHQ 0.27.0 (Web UI Kafka) como chart Helm `apps/kafka-ui/` para standalone Uni+. Conecta ao broker SASL_SSL no data-host (PR #140 + hotfix #141, ADR-009) via SCRAM-SHA-512; autentica usuários via OIDC do realm `uniplus` no Keycloak (PR #131).

## Mudanças

### Commit 1: `feat(apps): kafka-ui chart skeleton (AKHQ 0.27.0)`

Chart wrapper Uni+ completo (15 arquivos, 966 lines):

- `Chart.yaml` + `values.yaml` + `values.schema.json` (strict)
- `files/application.yml.tpl` — config AKHQ renderizado por `tpl`: conexão SASL_SSL via env interpolado pelo Micronaut, OIDC com `${OIDC_CLIENT_SECRET}`, mapping groups Keycloak (`/admins/kafka` → `kafka-admins`, `/users/uniplus` → `kafka-readonly`)
- `templates/`: ConfigMap, Deployment, Service, ServiceAccount, ExternalSecret (2x: kafka-admin + oidc-client), IngressRoute, Certificate, NetworkPolicy, ServiceMonitor

### Commit 2: `feat(standalone): wire kafka-ui no realm uniplus + values + AppSet`

- `apps/keycloak-replica/files/uniplus-realm.json`: novo client confidential `kafka-ui` (sem secret embutido — Keycloak gera no import; operador custodia via §14.1) com mapper `groups` (oidc-group-membership-mapper, `full.path=true`); novos grupos `/admins/kafka` e `/users/uniplus` pré-criados vazios
- `environments/standalone/values.yaml`: `kafkaUi.enabled=true` com configuração end-to-end (bootstrap servers, OIDC issuer, ingress LE staging, networkPolicy)
- `argocd/applicationset.yaml`: `kafka-ui` adicionado à lista do `uniplus-apps` AppSet

### Commit 3: `docs(runbooks): §14 — AKHQ Web UI standalone (pré-flight, smoke, rotação)`

5 sub-seções:
- §14.1 Pré-flight: recuperar `client_secret` aleatório do realm import via kcadm.sh + custodiar em `secret/standalone/keycloak/clients/kafka-ui` (sem isso ESO trava AKHQ)
- §14.2 Adicionar membros aos grupos `/admins/kafka` e `/users/uniplus` (kcadm CLI ou Admin UI)
- §14.3 Smoke test E2E (ESO sync → pod Running → /health → login real)
- §14.4 Rotacionar `client_secret`
- §14.5 Troubleshooting (SecretNotFound, SSL handshake, groups claim, SCRAM mismatch, redirect_uri, cert staging)

## Test plan

- [x] `helm lint apps/kafka-ui/ apps/keycloak-replica/` ✅
- [x] `helm template test apps/kafka-ui/` renderiza 9 resources sem warnings
- [x] `yamllint apps/kafka-ui/ environments/standalone/ argocd/` ✅
- [x] `markdownlint docs/RUNBOOKS.md` ✅
- [x] **code-reviewer subagent pré-PR** — 2 P1 endereçados:
  - **P1-A:** `extraEnv` estava posicionado após `envFrom`, indent 12 colaria items dentro do `envFrom` list (inválido). Movido para dentro do bloco `env:` na ordem correta. Default `extraEnv: []` mascarava o bug.
  - **P1-B:** `envFrom` no Secret `kafka-admin` exporia key `ca.crt` como env var inválida (`InvalidEnvironmentVariableNames` warning event no startup). Trocado para explicit `env.valueFrom.secretKeyRef` para `KAFKA_USERNAME`/`KAFKA_PASSWORD` apenas; `ca.crt` consumido só via projected volume.
- [ ] CI verde (7 jobs)
- [ ] Codex review sem findings remanescentes
- [ ] Smoke test pós-merge (pré-flight §14.1 → ESO sync → login OIDC → criar tópico via UI)

## Notas técnicas

- **Confidential client OIDC** (não public+PKCE) — AKHQ 0.27.x não suporta PKCE em provider customizado. Backend Java tem Vault, então custódia de `client_secret` mantém pattern dos demais charts. Pattern divergente do `uniplus-portal` (public+PKCE) que é apropriado pra SPA.
- **Self-signed CA cert do broker** distribuído via projected volume do mesmo Secret ESO (`kafka-admin` key `ca.crt`) — operador NÃO precisa distribuir manualmente.
- **`MICRONAUT_CONFIG_FILES=/app/application.yml`** — env supported pela imagem AKHQ 0.27.0.
- **Bootstrap manual obrigatório:** §14.1 exige operador custodiar `client_secret` (gerado pelo realm import) em Vault antes do ArgoCD sincronizar. Pattern análogo ao admin password do Keycloak.

Closes #139
Refs ADR-009, #138 (precondicionou via SASL_SSL + ca_cert no Vault), #40 (Epic standalone)