### PR TITLE
fix(apps): kafka-ui ESO apiVersion v1beta1 → v1 + RUNBOOKS §14.1 awk→grep+cut

### DIFF
--- a/apps/kafka-ui/templates/externalsecret.yaml
+++ b/apps/kafka-ui/templates/externalsecret.yaml
@@ -3,7 +3,7 @@
 # `<fullname>-kafka-admin` com 3 keys: KAFKA_USERNAME, KAFKA_PASSWORD,
 # ca.crt. As 2 primeiras vão via envFrom; ca.crt vai via projected
 # volume (mount em /etc/akhq/certs/ca.crt).
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "kafkaUi.kafkaAdminSecretName" . }}
@@ -35,7 +35,7 @@ spec:
 # ESO 2: OIDC client_secret do client `kafka-ui` no realm uniplus.
 # Custodiado em Vault (operador one-shot ou via Keycloak Admin API
 # durante setup do realm). Disponibilizado via env OIDC_CLIENT_SECRET.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "kafkaUi.oidcClientSecretName" . }}
@@ -61,7 +61,7 @@ spec:
 # como Secret com key MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET
 # (env var Micronaut convention: dots → underscores, uppercased) consumida
 # via env.valueFrom.secretKeyRef no deployment.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "kafkaUi.jwtSecretName" . }}

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2370,11 +2370,13 @@ kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c '
     --user "$KC_BOOTSTRAP_ADMIN_USERNAME" \
     --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" >/dev/null
 
-  # 1.1 Criar grupos /admins/kafka e /users/uniplus (idempotente — ignora se existem)
+  # 1.1 Criar grupos /admins/kafka e /users/uniplus (idempotente — ignora se existem).
+  # NOTA: container quay.io/keycloak/keycloak:26.6.1 é RHEL 9 minimal e NÃO tem
+  # awk/jq/python — usar grep+cut. Pattern para extrair ID por name no CSV.
   for GP in "admins/kafka" "users/uniplus"; do
     PARENT=${GP%/*}; CHILD=${GP##*/}
     /opt/keycloak/bin/kcadm.sh create groups -r uniplus -s name="$PARENT" 2>/dev/null || true
-    PID=$(/opt/keycloak/bin/kcadm.sh get groups -r uniplus -q briefRepresentation=true --fields id,name --format csv --noquotes | awk -F, -v n="$PARENT" "\$2==n {print \$1}")
+    PID=$(/opt/keycloak/bin/kcadm.sh get groups -r uniplus --fields id,name --format csv --noquotes | grep -E ",${PARENT}\$" | cut -d, -f1 | head -1)
     /opt/keycloak/bin/kcadm.sh create groups/$PID/children -r uniplus -s name="$CHILD" 2>/dev/null || true
   done
 


### PR DESCRIPTION
## Summary

Hotfix de 2 bugs do PR #142 (mergeado em e6bf739) que escaparam Codex (3 rounds + 4 P1 endereçados) e code-reviewer subagent — só apareceram durante smoke test:

### Bug 1: ESO apiVersion v1beta1 → v1

ApplicationSet sync falha com:
```
The Kubernetes API could not find version "v1beta1" of external-secrets.io/ExternalSecret for requested resource ...
Version "v1" of external-secrets.io/ExternalSecret is installed on the destination cluster.
```

Controller ESO em standalone só serve `v1`. `apps/keycloak-replica/templates/externalsecret.yaml` já usa `v1` (consistente). PR #142 introduziu `kafka-ui` com `v1beta1` — versão errada copiada de pattern desatualizado.

**Fix:** trocar 3x `v1beta1` → `v1` em `apps/kafka-ui/templates/externalsecret.yaml`.

### Bug 2: RUNBOOKS §14.1 usa `awk` que não existe no pod Keycloak

Container `quay.io/keycloak/keycloak:26.6.1` é RHEL 9 minimal — sem `awk`, `jq` ou `python3` (apenas `grep`, `cut`, `sed`). O comando do passo 1 (criar grupos via kcadm) falha com `bash: line 9: awk: command not found`.

**Fix:** trocar `awk -F, -v n="$PARENT" "\$2==n {print \$1}"` por `grep -E ",\${PARENT}\$" | cut -d, -f1 | head -1`.

## Por que escapou

Mesmo padrão da lição `feedback_bootstrap_smoke_fresh.md` (PR #141 hotfix):

- **Codex + code-reviewer subagent:** revisam código mas não validam:
  - apiVersion da CRD contra controller real instalado no cluster
  - Comandos shell embutidos em scripts contra ferramentas disponíveis no container alvo
- **helm lint + manifest-validate CI:** aceitam ambas as versões pelo schema (v1beta1 ainda existe na CRD do operator — só não é serializada)
- **Smoke test em ambiente real é o único caminho** para pegar esses dois tipos de bug

## Validação

- [x] `helm lint apps/kafka-ui/` ✅
- [x] `helm template ... | grep external-secrets.io/v` retorna 3x `v1` (todos)
- [x] `markdownlint docs/RUNBOOKS.md` ✅
- [x] `kcadm.sh` script com grep+cut **executou com sucesso** no pod Keycloak real durante smoke test
- [ ] CI verde
- [ ] Codex review
- [ ] Pós-merge: ApplicationSet sincroniza kafka-ui com Synced/Healthy

Refs PR #142, ADR-009, #139