### PR TITLE
feat(standalone): promove TLS Keycloak + kafka-ui para LE prod (#144)

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -394,10 +394,14 @@ keycloak:
       secretName: keycloak-replica-tls
       certManager:
         enabled: true
-        # Em standalone usamos LE staging durante validação (Fase 4-6).
-        # Promover para `letsencrypt-prod` após smoke test completo
-        # (procedimento em docs/RUNBOOKS.md §10.6).
-        clusterIssuer: letsencrypt-staging
+        # Promovido para LE prod em 2026-05-07 após smoke test E2E completo
+        # (RUNBOOKS §10.6). Resolve issue #144: AKHQ JDK não confiava em LE
+        # staging CA (não está nos cacerts default do Java) — pod ficava em
+        # CrashLoopBackOff com `PKIX path building failed` durante OIDC
+        # discovery. LE prod CA (ISRG Root X1) é trustada por todos os
+        # clientes nativamente. Rate limit 50 certs/week por domain registrado
+        # — folga grande em standalone (1 cert Keycloak + 1 cert kafka-ui).
+        clusterIssuer: letsencrypt-prod
 
   networkPolicy:
     enabled: true
@@ -437,9 +441,10 @@ kafkaUi:
       secretName: kafka-ui-tls
       certManager:
         enabled: true
-        # Em standalone usamos LE staging durante validação. Promover pra
-        # letsencrypt-prod após smoke test (mesmo pattern do Keycloak §10.6).
-        clusterIssuer: letsencrypt-staging
+        # Promovido para LE prod em 2026-05-07 (mesmo PR que promoveu o
+        # Keycloak — coerência). Cert real é trustado por browsers ao acessar
+        # https://kafka-ui.standalone.portaluni.com.br sem warning.
+        clusterIssuer: letsencrypt-prod
 
   networkPolicy:
     enabled: true


### PR DESCRIPTION
## Summary

Resolve issue #144 — AKHQ pod CrashLoopBackOff com `PKIX path building failed` ao fazer OIDC discovery contra Keycloak.

**Causa raiz:** cert do Keycloak está assinado por **LE staging CA** ('(STAGING) Pretend Pear X1'), que **NÃO está no cacerts default do JDK** do AKHQ. LE prod CA (ISRG Root X1) está em todo cacerts mainstream desde ~2018.

**Fix:** trocar `clusterIssuer: letsencrypt-staging` → `letsencrypt-prod` em:
- `environments/standalone/values.yaml` bloco `keycloak.ingress.tls.certManager`
- `environments/standalone/values.yaml` bloco `kafkaUi.ingress.tls.certManager` (mesmo pattern, coerência)

## Por que ambos no mesmo PR

Promover só Keycloak resolveria #144 (PKIX no AKHQ), mas deixaria o próprio AKHQ servindo cert staging para usuários acessando via browser. Promover ambos é coerente e elimina warnings em todos os endpoints externos do standalone.

## Caminho técnico

```
1. Merge → ArgoCD detecta mudança em main
2. ArgoCD reconcilia keycloak-replica + kafka-ui charts
3. Helm renderiza Certificate resources com issuerRef.name=letsencrypt-prod
4. cert-manager controller cria novo Order/Challenge contra LE prod ACME
5. LE faz HTTP-01 challenge: GET http://standalone.portaluni.com.br/.well-known/acme-challenge/<token>
6. Traefik responde com proof → LE valida ownership
7. LE emite cert real assinado por ISRG Root X1
8. cert-manager grava no Secret keycloak-replica-tls + kafka-ui-tls
9. Traefik recarrega TLS automaticamente (sem downtime)
10. AKHQ pod no próximo retry do CrashLoop faz handshake OK → fica Healthy
```

Tempo estimado total: ~30-120s.

## Trade-offs

- **Rate limit LE prod:** 50 certs/week por domain registrado (`portaluni.com.br`). Em standalone com 2 certs (Keycloak + kafka-ui), margem >25× — sem risco.
- **HTTP-01 challenge requer porta 80:** já aberta para o Traefik (HTTPS redirect existente).
- **Domain ownership:** `portaluni.com.br` controlado via Cloudflare DNS — k8s-host tem Reserved Public IP (164.152.53.29) estável.

## Pré-requisitos (todos satisfeitos)

- [x] DNS `standalone.portaluni.com.br` → 164.152.53.29 (Cloudflare)
- [x] DNS `kafka-ui.standalone.portaluni.com.br` → 164.152.53.29 (Cloudflare)
- [x] Porta 80 acessível externamente (Traefik HTTPS redirect)
- [x] ClusterIssuer `letsencrypt-prod` provisionado (PR #112)
- [x] cert-manager Healthy

## Test plan

- [x] `yamllint environments/standalone/values.yaml` ✅
- [x] `helm lint apps/keycloak-replica apps/kafka-ui` ✅
- [ ] CI verde (7 jobs)
- [ ] Codex review
- [ ] Pós-merge — verificações:
  - [ ] `kubectl get certificate -n uniplus | grep keycloak` issuerRef = letsencrypt-prod, status Ready=True
  - [ ] `curl -sI https://standalone.portaluni.com.br/auth/` retorna HTTP 200 sem `-k` (cert válido)
  - [ ] `kubectl get pod -n uniplus -l app.kubernetes.io/name=kafka-ui` 1/1 Running 0 restarts
  - [ ] AKHQ logs sem `PKIX` errors
  - [ ] Browser em `https://kafka-ui.standalone.portaluni.com.br` sem warning, redirect Keycloak OK

## Reverter (se algo der errado)

`git revert <commit>` + push. Cert-manager re-emite com staging — AKHQ volta a quebrar (estado atual). Sem perda de dados.

Closes #144
Refs ADR-008 (standalone topology), §10.6 (RUNBOOKS Keycloak cert promotion procedure)