### PR TITLE
fix(apps): kafka-ui OIDC authentication idtoken → cookie (login fix)

### DIFF
--- a/apps/kafka-ui/files/application.yml.tpl
+++ b/apps/kafka-ui/files/application.yml.tpl
@@ -80,11 +80,30 @@ akhq:
 
 # Micronaut OIDC (consumido pelo AKHQ). issuer + client_id no values;
 # client_secret via env OIDC_CLIENT_SECRET (envFrom do Secret kafka-ui-oidc-client).
+#
+# authentication: cookie — Micronaut gera sua própria JWT de sessão
+# (assinada com HS256 + MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET
+# do ESO) ao invés de reusar o id_token do Keycloak como cookie. Necessário
+# porque o AKHQ OidcAuthenticationMapper sobrescreve o attributes map do
+# Authentication, perdendo o `openid-token` que `idtoken` mode espera —
+# resultando em `OauthErrorResponseException` no IdTokenLoginHandler:103
+# após login OIDC bem-sucedido. Com cookie mode, AKHQ pode mapear claims
+# (groups, username) sem que Micronaut dependa do id_token preservado.
+#
+# JWKS jwks.keycloak.url permite Micronaut validar id_token no momento do
+# login (extrair groups claim) — não necessário para sessão subsequente
+# (cookie mode usa HS256 local).
 {{- if .Values.kafkaUi.oidc.enabled }}
 micronaut:
   security:
     enabled: true
-    authentication: idtoken
+    authentication: cookie
+    token:
+      jwt:
+        signatures:
+          jwks:
+            {{ .Values.kafkaUi.oidc.providerName }}:
+              url: "{{ .Values.kafkaUi.oidc.issuerUri }}/protocol/openid-connect/certs"
     oauth2:
       enabled: true
       clients:


### PR DESCRIPTION
## Summary

Hotfix de bug runtime descoberto durante o **primeiro login OIDC end-to-end** pós-PR #146 (LE prod). Callback Keycloak → AKHQ retornava:

\`\`\`
{
  \"message\": \"Internal Server Error: null\",
  \"stacktrace\": [{
    \"message\": \"io.micronaut.security.errors.OauthErrorResponseException\\n
       \\tat io.micronaut.security.oauth2.endpoint.token.response.IdTokenLoginHandler.lambda\$getCookies\$0(IdTokenLoginHandler.java:103)\\n
       \\tat java.base/java.util.Optional.orElseThrow(...)\\n
       \\tat io.micronaut.security.oauth2.endpoint.token.response.IdTokenLoginHandler.getCookies(IdTokenLoginHandler.java:103)\"
  }]
}
\`\`\`

## Causa raiz

Micronaut Security em modo \`authentication: idtoken\` espera encontrar o id_token JWT em \`authentication.getAttributes().get(\"openid-token\")\` para gerar cookie de sessão. AKHQ tem um \`OidcAuthenticationMapper\` customizado que **sobrescreve o attributes map** durante mapeamento de claims (preferred_username, groups → roles AKHQ), removendo a chave \`openid-token\`. Resultado: login OIDC bem-sucedido (token endpoint trocou code por id_token), mas IdTokenLoginHandler:103 lança \`OauthErrorResponseException\` ao tentar acessar attributes que não existem mais.

Bug não aparece em smoke test sem login real — só ao completar callback OIDC.

## Fix

\`apps/kafka-ui/files/application.yml.tpl\`:

- \`authentication: idtoken\` → \`authentication: cookie\`
- Adicionado \`micronaut.security.token.jwt.signatures.jwks.keycloak.url\` apontando para Keycloak JWKS endpoint (defensive — permite Micronaut validar id_token no login para extrair claims sem depender de mappers customizados)

Com \`authentication: cookie\`, Micronaut gera **sua própria JWT de sessão** assinada com HS256 + \`MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET\` (já provisionado via ESO #142), independente do id_token preservado por mappers customizados.

Pattern recomendado pela documentação oficial AKHQ (https://akhq.io/docs/configuration/authentifications/oidc.html).

## Test plan

- [x] \`helm lint apps/kafka-ui/\` ✅
- [x] \`helm template\` renderiza estrutura correta (verificado manualmente)
- [ ] CI verde (7 jobs)
- [ ] Codex review
- [ ] Pós-merge: ArgoCD reconcilia → checksum/config muda → pod restart automático
- [ ] Login OIDC end-to-end funcional (callback retorna 302 para /ui em vez de 500)

## Por que escapou

PR #142 ficou em CrashLoopBackOff por #144 (PKIX), pod nunca subiu para validar OIDC. PR #146 resolveu PKIX, pod ficou Healthy, mas \`/ui\` carrega sem login (200 do redirect inicial). Bug só apareceu **agora**, no primeiro login real, porque o erro acontece no callback após autenticação Keycloak — fluxo que smoke automatizado não cobria.

Lição: smoke E2E para apps com OIDC precisa **fazer login real** (não só health check), idealmente com um user de teste no IdP. Mantém a lição existente de \`feedback_bootstrap_smoke_fresh.md\` (integration bugs requerem runtime real).

Refs PR #142, PR #146, ADR-009