### PR TITLE
fix(apps): kafka-ui — remover JWKS config explícita (bean conflict)

### DIFF
--- a/apps/kafka-ui/files/application.yml.tpl
+++ b/apps/kafka-ui/files/application.yml.tpl
@@ -90,20 +90,16 @@ akhq:
 # após login OIDC bem-sucedido. Com cookie mode, AKHQ pode mapear claims
 # (groups, username) sem que Micronaut dependa do id_token preservado.
 #
-# JWKS jwks.keycloak.url permite Micronaut validar id_token no momento do
-# login (extrair groups claim) — não necessário para sessão subsequente
-# (cookie mode usa HS256 local).
+# Micronaut faz auto-discovery do JWKS endpoint via .well-known/openid-configuration
+# do issuer — config explícita de jwks.* causa NonUniqueBeanException
+# (JwksSignatureConfigurationProperties vs JwksSignatureConfiguration) na
+# imagem AKHQ 0.27.0. Pattern recomendado: deixar Micronaut descobrir
+# automaticamente via OIDC issuer.
 {{- if .Values.kafkaUi.oidc.enabled }}
 micronaut:
   security:
     enabled: true
     authentication: cookie
-    token:
-      jwt:
-        signatures:
-          jwks:
-            {{ .Values.kafkaUi.oidc.providerName }}:
-              url: "{{ .Values.kafkaUi.oidc.issuerUri }}/protocol/openid-connect/certs"
     oauth2:
       enabled: true
       clients:


### PR DESCRIPTION
Pequeno fix imediato: PR #147 adicionou `micronaut.security.token.jwt.signatures.jwks.keycloak.url` como config defensiva, mas isso causa `NonUniqueBeanException` no DI Micronaut da imagem AKHQ 0.27.0:

```
Caused by: io.micronaut.context.exceptions.NonUniqueBeanException:
  Multiple possible bean candidates found:
  [JwksSignatureConfigurationProperties, JwksSignatureConfiguration]
```

Pod novo entra em CrashLoopBackOff com restart=1 ~13s após startup.

**Fix:** remover o bloco `jwks:` — Micronaut faz auto-discovery do JWKS endpoint via `.well-known/openid-configuration` do issuer URI já configurado em `oauth2.clients.keycloak.openid.issuer`. Pattern padrão OIDC, sem necessidade de config explícita.

`authentication: cookie` (fix principal de PR #147) permanece — resolve o `OauthErrorResponseException` original.

helm lint + render verificados.

Refs PR #147