### PR TITLE
fix(apps): kafka-ui — declarar JWT secret generator explícito (login loop)

### DIFF
--- a/apps/kafka-ui/files/application.yml.tpl
+++ b/apps/kafka-ui/files/application.yml.tpl
@@ -90,16 +90,29 @@ akhq:
 # após login OIDC bem-sucedido. Com cookie mode, AKHQ pode mapear claims
 # (groups, username) sem que Micronaut dependa do id_token preservado.
 #
+# Bloco token.jwt.signatures.secret.generator: declaração explícita do secret
+# generator necessária para Micronaut Security USAR a env var MICRONAUT_SECURITY_*
+# como secret estável (HS256). Sem esse bloco, Micronaut gera random secret
+# em-memória por request — cookie da sessão não valida em requests seguintes,
+# causando loop redirect /oauth/login → callback → login. Documentação oficial
+# Micronaut Security exige esse bloco mesmo quando env var "auto-binda".
+#
 # Micronaut faz auto-discovery do JWKS endpoint via .well-known/openid-configuration
-# do issuer — config explícita de jwks.* causa NonUniqueBeanException
-# (JwksSignatureConfigurationProperties vs JwksSignatureConfiguration) na
-# imagem AKHQ 0.27.0. Pattern recomendado: deixar Micronaut descobrir
-# automaticamente via OIDC issuer.
+# do issuer — config explícita de jwks.* causa NonUniqueBeanException na imagem
+# AKHQ 0.27.0. Pattern: deixar Micronaut descobrir automaticamente.
 {{- if .Values.kafkaUi.oidc.enabled }}
 micronaut:
   security:
     enabled: true
     authentication: cookie
+    token:
+      jwt:
+        signatures:
+          secret:
+            generator:
+              secret: ${MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET}
+              base64: false
+              jws-algorithm: HS256
     oauth2:
       enabled: true
       clients:


### PR DESCRIPTION
## Bug

Após PR #147 (cookie auth) + #148 (remove JWKS), login OIDC autentica corretamente no Keycloak (`User: jeferson.ferreira` nos access logs do AKHQ, callback retorna `303`), MAS user fica em **loop infinito** `/oauth/login/keycloak` → callback → `/oauth/login/keycloak` → ...

Access log do pod (10 ciclos em 6s):
```
GET /oauth/login/keycloak  Status: 302  User: jeferson.ferreira
GET /oauth/callback/keycloak  Status: 303  User: jeferson.ferreira
GET /oauth/login/keycloak  Status: 302  User: jeferson.ferreira  ← loop
GET /oauth/callback/keycloak  Status: 303  User: jeferson.ferreira
...
```

## Causa

Micronaut Security em `authentication: cookie` precisa do bloco **explícito** `micronaut.security.token.jwt.signatures.secret.generator` no application.yml para usar o secret HS256 estável injetado via env var. **Sem o bloco**, Micronaut gera random secret in-memory por request — cookie de sessão tem assinatura válida no momento da emissão mas **não valida** em request subsequente (secret diferente entre invocations).

Confusão comum: ter `MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET` como env var **NÃO basta** — precisa ter o YAML config declarando que o generator existe. Env var só é interpolada se o config a referencia.

## Fix

`apps/kafka-ui/files/application.yml.tpl` ganha bloco:

```yaml
micronaut:
  security:
    token:
      jwt:
        signatures:
          secret:
            generator:
              secret: ${MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET}
              base64: false
              jws-algorithm: HS256
```

Pattern oficial documentado pela AKHQ: https://akhq.io/docs/configuration/authentifications/oidc.html

## Test plan

- [x] `helm lint` ✅
- [x] `helm template` renderiza estrutura correta
- [ ] CI verde
- [ ] Codex review
- [ ] Pós-merge: ArgoCD reconcilia → checksum/config muda → pod rollout → próximo login persiste sessão entre requests

## Por que escapou

PR #147 fez cookie mode mas não declarou o generator (assumi env var auto-bind). PR #148 removeu JWKS mas não revisitou esse pattern. Bug só aparece com **login real completo**: smoke E2E com pod up + redirect 302 era OK; só ao **completar** auth no Keycloak e voltar pro AKHQ que o sintoma se manifesta.

Mais um caso da lição feedback_bootstrap_smoke_fresh.md: integration bugs em apps OIDC requerem login real para validar — health checks + handshake handshake redirect não cobre.

Refs PR #147, PR #148, ADR-009