### PR TITLE
fix(apps): kafka-ui OIDC groups mapping invertido (name=claim, groups=role)

### DIFF
--- a/apps/kafka-ui/files/application.yml.tpl
+++ b/apps/kafka-ui/files/application.yml.tpl
@@ -64,18 +64,24 @@ akhq:
           # para incluir o membership do usuário.
           groups-field: {{ .Values.kafkaUi.oidc.groupsClaim }}
           username-field: preferred_username
-          # AKHQ OIDC mapping: `name:` é a key da role AKHQ definida acima
-          # em `akhq.security.groups` (NÃO a claim do IdP); `groups:` lista
-          # os valores que o IdP devolve no claim `groups-field` que devem
-          # ser mapeados a essa role. Usar `role:` é syntax incorreta — AKHQ
-          # ignora silenciosamente e o user cai em default-group=no-roles.
+          # AKHQ OIDC mapping (sintaxe correta — verificada via doc oficial
+          # https://akhq.io/docs/configuration/authentifications/oidc.html
+          # após bug runtime descoberto em login real):
+          #   - `name:` é o VALOR do claim do IdP (ex: "/admins/kafka")
+          #   - `groups:` lista os AKHQ role groups (definidos em
+          #     akhq.security.groups acima) que o user assume
+          # Inverso: usar `name: kafka-admins` + `groups: [/admins/kafka]`
+          # passa silenciosamente em start (sem erro de schema) mas mapa
+          # nunca match — user fica com roles=[isAuthenticated()] only,
+          # cookie JWT tem groups vazio "{}", "página inicial" não carrega
+          # tópicos. Esse foi o bug que ficou pendente em #142 → #149.
           groups:
-            - name: kafka-admins
+            - name: "{{ .Values.kafkaUi.oidc.groups.kafkaAdminsClaim }}"
               groups:
-                - "{{ .Values.kafkaUi.oidc.groups.kafkaAdminsClaim }}"
-            - name: kafka-readonly
+                - kafka-admins
+            - name: "{{ .Values.kafkaUi.oidc.groups.kafkaReadOnlyClaim }}"
               groups:
-                - "{{ .Values.kafkaUi.oidc.groups.kafkaReadOnlyClaim }}"
+                - kafka-readonly
 {{- end }}
 
 # Micronaut OIDC (consumido pelo AKHQ). issuer + client_id no values;


### PR DESCRIPTION
## Bug

Após PR #149 (JWT secret generator), sessão OIDC persiste, /api/me retorna logged:true. Mas user com membership /admins/kafka no Keycloak fica com roles=[isAuthenticated()] only — sem kafka-admins. UI carrega mas "página inicial" sem tópicos.

JWT cookie decodificado:
```json
{
  "sub": "jeferson.ferreira",
  "roles": ["isAuthenticated()"],
  "groups": "H4sIAAAAAAAA/6uuBQBDv6ajAgAAAA=="   ← gunzip → "{}"
}
```

ID token raw do Keycloak (via password grant temporário) traz `groups: ["/admins/kafka"]` ✅ corretamente — então o claim chega populated. Bug é AKHQ não mapear.

## Causa raiz

Mapping invertido em `application.yml.tpl`. Doc oficial:
https://akhq.io/docs/configuration/authentifications/oidc.html

```yaml
groups:
  - name: <VALOR-DO-CLAIM-NO-IDP>      # ex: "/admins/kafka"
    groups:
      - <NOME-DO-AKHQ-ROLE-GROUP>      # ex: kafka-admins
```

Eu tinha invertido:
```yaml
- name: kafka-admins                    # ❌ AKHQ role no name
  groups: ["/admins/kafka"]            # ❌ claim em groups
```

Schema YAML valida (campos existem nos dois sentidos), mas matcher nunca dispara → silent failure → role mapping vazio.

## Fix

Trocar  ↔  no mapping. Comentário expandido para referenciar doc oficial e o sintoma exato.

## Histórico do erro

PR #142 round 1, Codex apontou:
> AKHQ OIDC provider mappings expect the identity-provider group/role identifier under `name:`

Codex estava CORRETO, mas eu apliquei errado: pus o **nome AKHQ** no `name:` em vez de **valor IdP**. Inversão silenciosa.

## Test plan

- [x] helm lint + template renderizam corretamente
- [x] doc AKHQ oficial confirmou semântica via WebFetch
- [ ] CI verde
- [ ] Codex review
- [ ] Pós-merge: ArgoCD reconcilia, AKHQ rollout, login com user em `/admins/kafka` deve mapear para role `kafka-admins` → JWT cookie tem groups populated → UI carrega tópicos do cluster standalone

Refs PR #142, PR #147, #148, #149