### PR TITLE
feat(standalone): Apicurio Registry — schema registry OIDC + Postgres data-host

### DIFF
--- a/apps/apicurio-registry/Chart.yaml
+++ b/apps/apicurio-registry/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: apicurio-registry
+description: |
+  Apicurio Registry — schema/API artifact registry compatível com a Confluent
+  Schema Registry API. Storage SQL no Postgres standalone (DB `apicurio`,
+  custodiado em Vault); autenticação via OIDC do realm `uniplus` no Keycloak
+  local com role-based authorization (sr-admin/sr-developer/sr-readonly
+  mapeados a partir de groups do JWT).
+
+  Reuso completo da stack standalone — sem Keycloak/DB/issuer próprios.
+type: application
+
+version: 0.1.0
+
+# Apicurio Registry upstream (sincronizar com image.tag).
+appVersion: "3.2.4"
+
+home: https://github.com/unifesspa-edu-br/uniplus-infra
+sources:
+  - https://github.com/unifesspa-edu-br/uniplus-infra
+  - https://github.com/Apicurio/apicurio-registry
+
+maintainers:
+  - name: CTIC UNIFESSPA
+    email: jeferson.ferreira@unifesspa.edu.br
+
+keywords:
+  - uniplus
+  - kafka
+  - schema-registry
+  - apicurio
+  - unifesspa
+
+annotations:
+  category: data
+  licenses: Apache-2.0

--- a/apps/apicurio-registry/README.md
+++ b/apps/apicurio-registry/README.md
@@ -1,0 +1,46 @@
+# apicurio-registry
+
+Apicurio Registry — schema registry compatível com a Confluent Schema Registry API. Storage SQL no Postgres standalone, autenticação OIDC via Keycloak realm `uniplus` com role-based authorization.
+
+## Quando usar
+
+Ative apenas em ambientes que precisam de schema/API artifact registry para validação de eventos Kafka (Avro, JSON Schema, Protobuf, OpenAPI, AsyncAPI). Em standalone roda com 1 réplica e DB compartilhado com os demais services do data-host.
+
+## Pré-requisitos
+
+| Recurso | De onde vem |
+|---|---|
+| Database `apicurio` + role `apicurio` no Postgres | `step_data_setup_apicurio_db` do `scripts/bootstrap-standalone.sh` |
+| Senha do role no Vault | Custódia manual em `secret/standalone/postgres/apicurio` (RUNBOOKS §15.2) |
+| Client OIDC `apicurio-registry` no realm uniplus | Import do realm pelo chart `keycloak-replica` |
+| `client_secret` no Vault | Recuperado via `kcadm.sh` pós-import (RUNBOOKS §15.1) |
+| Cert Let's Encrypt prod | cert-manager via `ingress.tls.certManager.clusterIssuer: letsencrypt-prod` |
+| DNS público | `schema-registry.standalone.portaluni.com.br` → IP do k8s-host |
+
+## Roles e mapeamento
+
+Apicurio define 3 roles internas. Mapeamento via env `APICURIO_AUTH_ROLES_*` lê o valor exato do claim JWT (path = `groups`, full path Keycloak).
+
+| Apicurio role | Permissão | Mapeado de | User exemplo |
+|---|---|---|---|
+| `sr-admin` | RW + admin (delete, configurar, exportar) | `/admins/kafka` | `jeferson.ferreira` |
+| `sr-developer` | RW em artifacts | `/users/uniplus` | usuários gerais Uni+ |
+| `sr-readonly` | leitura | (vazio — sem mapping default) | — |
+
+Sem grupo no JWT = nenhuma role atribuída → todas as operações retornam 403 (anonymous read access OFF).
+
+## Por que `auth.apicur.io` não é usado
+
+Apicurio Registry vem com default `QUARKUS_OIDC_AUTH_SERVER_URL=https://auth.apicur.io/auth/realms/apicurio-local` apontando para um **Keycloak demo público mantido pela Red Hat**. Este chart **sempre** sobrescreve com `oidc.issuerUri` do nosso Keycloak local — sem SLA externo, sem users públicos, sem dependência de domínio fora da nossa zona.
+
+## Endpoints úteis
+
+- UI: `https://schema-registry.standalone.portaluni.com.br/ui` (login OIDC obrigatório)
+- API V3 (Apicurio nativa): `/apis/registry/v3`
+- API V2 (Confluent SR compat): `/apis/ccompat/v7`
+- Health: `/q/health/{started,live,ready}`
+- Metrics: `/q/metrics` (Prometheus, scrape via `serviceMonitor.enabled: true`)
+
+## Operação
+
+Procedimentos detalhados em `docs/RUNBOOKS.md` §15 (deploy, custódia, smoke, troubleshooting, bootstrap inicial de schemas).

--- a/apps/apicurio-registry/templates/_helpers.tpl
+++ b/apps/apicurio-registry/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/*
+Nome curto do release. Apicurio não tem peculiaridades de naming;
+segue pattern padrão Helm (release.Chart) com truncate p/ DNS-1123.
+*/}}
+{{- define "apicurioRegistry.fullname" -}}
+{{- if .Values.apicurioRegistry.fullnameOverride -}}
+{{- .Values.apicurioRegistry.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.apicurioRegistry.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Selector labels (subset estável dos commonLabels — match.io.k.s/name e
+match.io.k.s/instance só; version e managed-by mudam entre releases e
+quebrariam selectors se incluídos).
+*/}}
+{{- define "apicurioRegistry.selectorLabels" -}}
+app.kubernetes.io/name: {{ default .Chart.Name .Values.apicurioRegistry.nameOverride }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Labels padrão Uni+ + chart info, aplicados a TODOS os recursos do chart.
+*/}}
+{{- define "apicurioRegistry.labels" -}}
+{{ include "apicurioRegistry.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ServiceAccount name — usa Values.serviceAccount.name se setado, senão
+fullname com sufixo "-sa".
+*/}}
+{{- define "apicurioRegistry.serviceAccountName" -}}
+{{- if .Values.apicurioRegistry.serviceAccount.create -}}
+{{- default (printf "%s-sa" (include "apicurioRegistry.fullname" .)) .Values.apicurioRegistry.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.apicurioRegistry.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Nome do Secret K8s sintetizado pelo ESO `dbCreds` — JDBC password do role
+`apicurio` no Postgres standalone.
+*/}}
+{{- define "apicurioRegistry.dbCredsSecretName" -}}
+{{ include "apicurioRegistry.fullname" . }}-db
+{{- end -}}
+
+{{/*
+Nome do Secret K8s sintetizado pelo ESO `oidcClient` — client_secret do
+client confidential `apicurio-registry` no realm uniplus.
+*/}}
+{{- define "apicurioRegistry.oidcClientSecretName" -}}
+{{ include "apicurioRegistry.fullname" . }}-oidc-client
+{{- end -}}
+
+{{/*
+JDBC URL completa para o Postgres standalone. Storage host/port/database
+vêm de values; postgresql é o único SQL kind suportado em produção
+(H2 fica fora — só para dev local).
+*/}}
+{{- define "apicurioRegistry.jdbcUrl" -}}
+jdbc:postgresql://{{ .Values.apicurioRegistry.storage.host }}:{{ .Values.apicurioRegistry.storage.port }}/{{ .Values.apicurioRegistry.storage.database }}
+{{- end -}}

--- a/apps/apicurio-registry/templates/certificate.yaml
+++ b/apps/apicurio-registry/templates/certificate.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.apicurioRegistry.enabled .Values.apicurioRegistry.ingress.enabled .Values.apicurioRegistry.ingress.tls.enabled .Values.apicurioRegistry.ingress.tls.certManager.enabled -}}
+{{- if not .Values.apicurioRegistry.ingress.tls.certManager.clusterIssuer -}}
+{{- fail "apicurioRegistry.ingress.tls.certManager.clusterIssuer é obrigatório quando certManager.enabled=true (issuerRef.name vazio produz Certificate inválido/não-emissível, TLS secret nunca é provisionado e HTTPS ingress fica quebrado). Configurar em environments/<env>/values.yaml (ex.: letsencrypt-prod ou letsencrypt-staging)." -}}
+{{- end -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/apps/apicurio-registry/templates/certificate.yaml
+++ b/apps/apicurio-registry/templates/certificate.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.apicurioRegistry.enabled .Values.apicurioRegistry.ingress.enabled .Values.apicurioRegistry.ingress.tls.enabled .Values.apicurioRegistry.ingress.tls.certManager.enabled -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "apicurioRegistry.fullname" . }}
+  labels:
+    {{- include "apicurioRegistry.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.apicurioRegistry.ingress.tls.secretName | default (printf "%s-tls" (include "apicurioRegistry.fullname" .)) }}
+  commonName: {{ .Values.apicurioRegistry.ingress.host }}
+  dnsNames:
+    - {{ .Values.apicurioRegistry.ingress.host }}
+  issuerRef:
+    name: {{ .Values.apicurioRegistry.ingress.tls.certManager.clusterIssuer }}
+    kind: ClusterIssuer
+{{- end }}

--- a/apps/apicurio-registry/templates/deployment.yaml
+++ b/apps/apicurio-registry/templates/deployment.yaml
@@ -2,8 +2,8 @@
 {{- if not .Values.apicurioRegistry.storage.host -}}
 {{- fail "apicurioRegistry.storage.host é obrigatório quando enabled=true (sem isso, JDBC URL renderiza 'jdbc:postgresql://:5432/apicurio' inválida e pod não sobe). Configurar em environments/<env>/values.yaml." -}}
 {{- end -}}
-{{- if and .Values.apicurioRegistry.oidc.enabled (not .Values.apicurioRegistry.externalSecrets.enabled) -}}
-{{- fail "apicurioRegistry.oidc.enabled=true requer externalSecrets.enabled=true (QUARKUS_OIDC_CREDENTIALS_SECRET é injetado via ESO; sem ele o pod entra em CreateContainerConfigError silenciosamente). Habilite externalSecrets ou desabilite oidc." -}}
+{{- if not .Values.apicurioRegistry.externalSecrets.enabled -}}
+{{- fail "apicurioRegistry.enabled=true requer externalSecrets.enabled=true. O Deployment lê DB_PASSWORD do Secret `<fullname>-db` (sintetizado pelo ESO) via secretKeyRef e, quando OIDC está on, também QUARKUS_OIDC_CREDENTIALS_SECRET de `<fullname>-oidc-client`. Sem ESO, ambos os Secrets não existem e o pod entra em CreateContainerConfigError silenciosamente. Habilite externalSecrets ou desabilite o chart." -}}
 {{- end -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/apps/apicurio-registry/templates/deployment.yaml
+++ b/apps/apicurio-registry/templates/deployment.yaml
@@ -5,6 +5,9 @@
 {{- if not .Values.apicurioRegistry.externalSecrets.enabled -}}
 {{- fail "apicurioRegistry.enabled=true requer externalSecrets.enabled=true. O Deployment lê DB_PASSWORD do Secret `<fullname>-db` (sintetizado pelo ESO) via secretKeyRef e, quando OIDC está on, também QUARKUS_OIDC_CREDENTIALS_SECRET de `<fullname>-oidc-client`. Sem ESO, ambos os Secrets não existem e o pod entra em CreateContainerConfigError silenciosamente. Habilite externalSecrets ou desabilite o chart." -}}
 {{- end -}}
+{{- if and .Values.apicurioRegistry.oidc.enabled (not .Values.apicurioRegistry.oidc.issuerUri) -}}
+{{- fail "apicurioRegistry.oidc.enabled=true requer oidc.issuerUri não-vazio. Sem isso, o fallback `http://localhost:9999/oidc-disabled` (que existe APENAS para o caso oidc.enabled=false) seria usado e o pod nunca completa OIDC discovery — silently inativo. Configurar issuerUri em environments/<env>/values.yaml (ex.: https://standalone.portaluni.com.br/auth/realms/uniplus)." -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/apicurio-registry/templates/deployment.yaml
+++ b/apps/apicurio-registry/templates/deployment.yaml
@@ -1,0 +1,171 @@
+{{- if .Values.apicurioRegistry.enabled -}}
+{{- if not .Values.apicurioRegistry.storage.host -}}
+{{- fail "apicurioRegistry.storage.host é obrigatório quando enabled=true (sem isso, JDBC URL renderiza 'jdbc:postgresql://:5432/apicurio' inválida e pod não sobe). Configurar em environments/<env>/values.yaml." -}}
+{{- end -}}
+{{- if and .Values.apicurioRegistry.oidc.enabled (not .Values.apicurioRegistry.externalSecrets.enabled) -}}
+{{- fail "apicurioRegistry.oidc.enabled=true requer externalSecrets.enabled=true (QUARKUS_OIDC_CREDENTIALS_SECRET é injetado via ESO; sem ele o pod entra em CreateContainerConfigError silenciosamente). Habilite externalSecrets ou desabilite oidc." -}}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "apicurioRegistry.fullname" . }}
+  labels:
+    {{- include "apicurioRegistry.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.apicurioRegistry.replicas }}
+  # Stateless app — RollingUpdate sem maxSurge para 1-at-a-time. Apicurio
+  # multi-réplica é seguro porque todo state vai pro Postgres único.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      {{- include "apicurioRegistry.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "apicurioRegistry.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "apicurioRegistry.serviceAccountName" . }}
+      {{- with .Values.apicurioRegistry.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.apicurioRegistry.podSecurityContext | nindent 8 }}
+      containers:
+        - name: apicurio-registry
+          image: "{{ .Values.apicurioRegistry.image.registry }}/{{ .Values.apicurioRegistry.image.repository }}:{{ .Values.apicurioRegistry.image.tag }}"
+          imagePullPolicy: {{ .Values.apicurioRegistry.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.apicurioRegistry.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            # === Storage SQL (Postgres) ===
+            # APICURIO_STORAGE_KIND=sql + APICURIO_STORAGE_SQL_KIND=postgresql
+            # selecionam o backend; URL/user/password vêm separadamente.
+            # Apicurio 3.x usa simultaneamente APICURIO_DATASOURCE_* (nomes
+            # legacy 2.x preservados) e QUARKUS_DATASOURCE_* (Quarkus nativo).
+            # Setamos as duas para evitar dependência de qual path o código
+            # consulta primeiro (varia entre 3.0 e 3.2 release notes).
+            - name: APICURIO_STORAGE_KIND
+              value: {{ .Values.apicurioRegistry.storage.kind | quote }}
+            - name: APICURIO_STORAGE_SQL_KIND
+              value: {{ .Values.apicurioRegistry.storage.sqlKind | quote }}
+            - name: APICURIO_DATASOURCE_URL
+              value: {{ include "apicurioRegistry.jdbcUrl" . | quote }}
+            - name: APICURIO_DATASOURCE_USERNAME
+              value: {{ .Values.apicurioRegistry.storage.username | quote }}
+            - name: APICURIO_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "apicurioRegistry.dbCredsSecretName" . }}
+                  key: DB_PASSWORD
+            # Quarkus mirror (nomes nativos consultados pelo runtime).
+            - name: QUARKUS_DATASOURCE_JDBC_URL
+              value: {{ include "apicurioRegistry.jdbcUrl" . | quote }}
+            - name: QUARKUS_DATASOURCE_USERNAME
+              value: {{ .Values.apicurioRegistry.storage.username | quote }}
+            - name: QUARKUS_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "apicurioRegistry.dbCredsSecretName" . }}
+                  key: DB_PASSWORD
+            # === OIDC issuer URL (SEMPRE setado, mesmo com oidc.enabled=false) ===
+            # Apicurio 3.2.4 vem com default
+            # `QUARKUS_OIDC_AUTH_SERVER_URL=https://auth.apicur.io/auth/realms/apicurio-local`
+            # apontando para Keycloak demo público da Red Hat. Quarkus pode
+            # consultar essa config durante init mesmo com oidc.enabled=false
+            # em alguns paths do bootstrap — qualquer call out leak para
+            # auth.apicur.io vaza nosso DNS interno + topologia para terceiro.
+            #
+            # Fallback `localhost:9999` quando OIDC desligado força failure
+            # local óbvio se OIDC for ativado por engano via env override.
+            # Code-reviewer P1 round 1.
+            - name: QUARKUS_OIDC_AUTH_SERVER_URL
+              value: {{ .Values.apicurioRegistry.oidc.issuerUri | default "http://localhost:9999/oidc-disabled" | quote }}
+            {{- if .Values.apicurioRegistry.oidc.enabled }}
+            # === OIDC (Quarkus) — auth ativa ===
+            - name: APICURIO_AUTH_ENABLED
+              value: "true"
+            - name: QUARKUS_OIDC_ENABLED
+              value: "true"
+            - name: QUARKUS_OIDC_TENANT_ENABLED
+              value: "true"
+            - name: QUARKUS_OIDC_CLIENT_ID
+              value: {{ .Values.apicurioRegistry.oidc.clientId | quote }}
+            # Path do claim do JWT que carrega os groups/roles. Default
+            # `groups` casa com o mapper `oidc-group-membership-mapper` do
+            # client `apicurio-registry` no realm uniplus (configurado com
+            # full.path=true → values são "/admins/kafka", "/users/uniplus").
+            - name: QUARKUS_OIDC_ROLES_ROLE_CLAIM_PATH
+              value: {{ .Values.apicurioRegistry.oidc.rolesClaimPath | quote }}
+            {{- if .Values.apicurioRegistry.roleBasedAuth.enabled }}
+            # === Role-based authorization ===
+            # APICURIO_AUTH_ROLE_SOURCE=token: Apicurio extrai roles do
+            # claim JWT (path = QUARKUS_OIDC_ROLES_ROLE_CLAIM_PATH acima).
+            # APICURIO_AUTH_ROLES_<ROLE>=<value>: mapping do valor exato no
+            # claim para a role interna. Reusamos os groups do realm uniplus
+            # (/admins/kafka → sr-admin, /users/uniplus → sr-developer).
+            - name: APICURIO_AUTH_ROLE_BASED_AUTHORIZATION
+              value: "true"
+            - name: APICURIO_AUTH_ROLE_SOURCE
+              value: "token"
+            {{- if .Values.apicurioRegistry.roleBasedAuth.adminClaim }}
+            - name: APICURIO_AUTH_ROLES_ADMIN
+              value: {{ .Values.apicurioRegistry.roleBasedAuth.adminClaim | quote }}
+            {{- end }}
+            {{- if .Values.apicurioRegistry.roleBasedAuth.developerClaim }}
+            - name: APICURIO_AUTH_ROLES_DEVELOPER
+              value: {{ .Values.apicurioRegistry.roleBasedAuth.developerClaim | quote }}
+            {{- end }}
+            {{- if .Values.apicurioRegistry.roleBasedAuth.readonlyClaim }}
+            - name: APICURIO_AUTH_ROLES_READONLY
+              value: {{ .Values.apicurioRegistry.roleBasedAuth.readonlyClaim | quote }}
+            {{- end }}
+            # Acesso anônimo OFF — qualquer request sem JWT válido = 401.
+            # Defesa em profundidade: mesmo que role mapping falhe, ninguém
+            # entra sem autenticar. Override via extraEnv se necessário.
+            - name: APICURIO_AUTH_ANONYMOUS_READ_ACCESS_ENABLED
+              value: "false"
+            {{- end }}
+            {{- end }}
+            # Quarkus HTTP — 8080 default, explicit para evitar surpresa
+            # se imagem futura mudar.
+            - name: QUARKUS_HTTP_PORT
+              value: "8080"
+            - name: QUARKUS_HTTP_HOST
+              value: "0.0.0.0"
+            {{- with .Values.apicurioRegistry.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.apicurioRegistry.oidc.enabled }}
+          envFrom:
+            # QUARKUS_OIDC_CREDENTIALS_SECRET — único campo, envFrom seguro.
+            - secretRef:
+                name: {{ include "apicurioRegistry.oidcClientSecretName" . }}
+          {{- end }}
+          startupProbe:
+            httpGet:
+              path: /q/health/started
+              port: http
+            failureThreshold: {{ .Values.apicurioRegistry.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.apicurioRegistry.startupProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /q/health/live
+              port: http
+            periodSeconds: {{ .Values.apicurioRegistry.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /q/health/ready
+              port: http
+            periodSeconds: {{ .Values.apicurioRegistry.readinessProbe.periodSeconds }}
+          resources:
+            {{- toYaml .Values.apicurioRegistry.resources | nindent 12 }}
+{{- end }}

--- a/apps/apicurio-registry/templates/externalsecret.yaml
+++ b/apps/apicurio-registry/templates/externalsecret.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.apicurioRegistry.enabled .Values.apicurioRegistry.externalSecrets.enabled -}}
+# ESO 1: senha do role `apicurio` no Postgres standalone. Sintetiza Secret
+# K8s `<fullname>-db` com 1 key DB_PASSWORD, consumido via env.valueFrom no
+# deployment (interpolado em APICURIO_DATASOURCE_PASSWORD + QUARKUS_DATASOURCE_PASSWORD
+# — Apicurio 3.x usa as duas em paths diferentes do código).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "apicurioRegistry.dbCredsSecretName" . }}
+  labels:
+    {{- include "apicurioRegistry.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.apicurioRegistry.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ .Values.apicurioRegistry.externalSecrets.secretStoreRef.kind }}
+    name: {{ .Values.apicurioRegistry.externalSecrets.secretStoreRef.name }}
+  target:
+    name: {{ include "apicurioRegistry.dbCredsSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: {{ .Values.apicurioRegistry.externalSecrets.dbCreds.vaultPath }}
+        property: {{ .Values.apicurioRegistry.externalSecrets.dbCreds.passwordKey }}
+{{- if .Values.apicurioRegistry.oidc.enabled }}
+---
+# ESO 2: OIDC client_secret do client `apicurio-registry` no realm uniplus.
+# Custodiado em Vault (operador one-shot ou via Keycloak Admin API durante
+# setup do realm — RUNBOOKS §15.1). Disponibilizado via env
+# QUARKUS_OIDC_CREDENTIALS_SECRET (Quarkus default param name).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "apicurioRegistry.oidcClientSecretName" . }}
+  labels:
+    {{- include "apicurioRegistry.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.apicurioRegistry.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ .Values.apicurioRegistry.externalSecrets.secretStoreRef.kind }}
+    name: {{ .Values.apicurioRegistry.externalSecrets.secretStoreRef.name }}
+  target:
+    name: {{ include "apicurioRegistry.oidcClientSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: QUARKUS_OIDC_CREDENTIALS_SECRET
+      remoteRef:
+        key: {{ .Values.apicurioRegistry.externalSecrets.oidcClient.vaultPath }}
+        property: {{ .Values.apicurioRegistry.externalSecrets.oidcClient.clientSecretKey }}
+{{- end }}
+{{- end }}

--- a/apps/apicurio-registry/templates/ingressroute.yaml
+++ b/apps/apicurio-registry/templates/ingressroute.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.apicurioRegistry.enabled .Values.apicurioRegistry.ingress.enabled -}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "apicurioRegistry.fullname" . }}
+  labels:
+    {{- include "apicurioRegistry.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.apicurioRegistry.ingress.entryPoint }}
+  routes:
+    - match: Host(`{{ .Values.apicurioRegistry.ingress.host }}`)
+      kind: Rule
+      services:
+        - name: {{ include "apicurioRegistry.fullname" . }}
+          port: 8080
+          # Apicurio UI requer X-Forwarded-{Host,Proto} para Quarkus OIDC
+          # redirect URI bater com o registrado no realm. Traefik faz por
+          # default — não precisamos de middleware extra.
+  {{- if .Values.apicurioRegistry.ingress.tls.enabled }}
+  tls:
+    secretName: {{ .Values.apicurioRegistry.ingress.tls.secretName | default (printf "%s-tls" (include "apicurioRegistry.fullname" .)) }}
+  {{- end }}
+{{- end }}

--- a/apps/apicurio-registry/templates/ingressroute.yaml
+++ b/apps/apicurio-registry/templates/ingressroute.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.apicurioRegistry.enabled .Values.apicurioRegistry.ingress.enabled -}}
+{{- if not .Values.apicurioRegistry.ingress.host -}}
+{{- fail "apicurioRegistry.ingress.host é obrigatório quando ingress.enabled=true (Traefik IngressRoute requer Host(...) válido; host vazio produz rule não-funcional e propaga em Certificate dnsNames vazio). Configurar em environments/<env>/values.yaml (ex.: schema-registry.standalone.portaluni.com.br)." -}}
+{{- end -}}
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:

--- a/apps/apicurio-registry/templates/networkpolicy.yaml
+++ b/apps/apicurio-registry/templates/networkpolicy.yaml
@@ -1,0 +1,82 @@
+{{- if and .Values.apicurioRegistry.enabled .Values.apicurioRegistry.networkPolicy.enabled -}}
+{{- if not .Values.apicurioRegistry.networkPolicy.dataHostCIDR -}}
+{{- fail "apicurioRegistry.networkPolicy.dataHostCIDR é obrigatório quando networkPolicy.enabled=true (sem isso o egress para Postgres data-host fica em default-deny silencioso). Configurar em environments/<env>/values.yaml." -}}
+{{- end -}}
+{{- if and .Values.apicurioRegistry.oidc.enabled (not .Values.apicurioRegistry.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "apicurioRegistry.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (Quarkus OIDC chama discovery/token endpoints em HTTPS contra o issuer público; sem essa entrada o egress fica em default-deny e auth flows falham silenciosamente). Configurar para o IP público do k8s-host /32 em environments/<env>/values.yaml." -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "apicurioRegistry.fullname" . }}
+  labels:
+    {{- include "apicurioRegistry.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "apicurioRegistry.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # HTTP do Traefik (apenas pods do namespace traefik).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.apicurioRegistry.networkPolicy.traefikNamespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- if and .Values.apicurioRegistry.metrics.enabled .Values.apicurioRegistry.serviceMonitor.enabled }}
+    # Prometheus scrape em /q/metrics (mesma porta 8080).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.apicurioRegistry.networkPolicy.monitoringNamespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- end }}
+  egress:
+    # DNS (CoreDNS).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Postgres data-host (subnet privada VCN).
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.apicurioRegistry.networkPolicy.dataHostCIDR }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.apicurioRegistry.networkPolicy.dataHostPort }}
+    # Keycloak in-cluster (fallback útil se issuerUri for Service DNS).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.apicurioRegistry.networkPolicy.keycloakNamespace }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: keycloak-replica
+      ports:
+        - protocol: TCP
+          port: {{ .Values.apicurioRegistry.networkPolicy.keycloakPort }}
+    {{- if .Values.apicurioRegistry.oidc.enabled }}
+    # OIDC issuer público (HTTPS). Em standalone, Apicurio chama
+    # `https://standalone.portaluni.com.br/auth/realms/uniplus` que
+    # resolve para o public IP do k8s-host (164.152.53.29) e entra via
+    # Traefik IngressRoute do Keycloak. Sem este egress, o OIDC discovery
+    # falha em default-deny (TLS handshake never completes).
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.apicurioRegistry.networkPolicy.oidcIssuerCIDR }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.apicurioRegistry.networkPolicy.oidcIssuerPort }}
+    {{- end }}
+{{- end }}

--- a/apps/apicurio-registry/templates/service.yaml
+++ b/apps/apicurio-registry/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.apicurioRegistry.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "apicurioRegistry.fullname" . }}
+  labels:
+    {{- include "apicurioRegistry.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "apicurioRegistry.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/apps/apicurio-registry/templates/serviceaccount.yaml
+++ b/apps/apicurio-registry/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.apicurioRegistry.enabled .Values.apicurioRegistry.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "apicurioRegistry.serviceAccountName" . }}
+  labels:
+    {{- include "apicurioRegistry.labels" . | nindent 4 }}
+{{- end }}

--- a/apps/apicurio-registry/templates/servicemonitor.yaml
+++ b/apps/apicurio-registry/templates/servicemonitor.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.apicurioRegistry.enabled .Values.apicurioRegistry.metrics.enabled .Values.apicurioRegistry.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "apicurioRegistry.fullname" . }}
+  labels:
+    {{- include "apicurioRegistry.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "apicurioRegistry.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /q/metrics
+      interval: {{ .Values.apicurioRegistry.serviceMonitor.interval }}
+{{- end }}

--- a/apps/apicurio-registry/values.schema.json
+++ b/apps/apicurio-registry/values.schema.json
@@ -43,8 +43,8 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "kind": { "enum": ["sql", "kafkasql"] },
-            "sqlKind": { "enum": ["postgresql", "h2"] },
+            "kind": { "enum": ["sql"] },
+            "sqlKind": { "enum": ["postgresql"] },
             "host": { "type": "string" },
             "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
             "database": { "type": "string", "minLength": 1 },

--- a/apps/apicurio-registry/values.schema.json
+++ b/apps/apicurio-registry/values.schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "commonLabels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "apicurioRegistry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "registry": { "type": "string" },
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "enum": ["Always", "IfNotPresent", "Never"] }
+          },
+          "required": ["registry", "repository", "tag", "pullPolicy"]
+        },
+        "imagePullSecrets": { "type": "array" },
+        "fullnameOverride": { "type": "string" },
+        "nameOverride": { "type": "string" },
+        "replicas": { "type": "integer", "minimum": 1 },
+        "resources": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "serviceAccount": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "create": { "type": "boolean" },
+            "name": { "type": "string" }
+          }
+        },
+        "storage": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "enum": ["sql", "kafkasql"] },
+            "sqlKind": { "enum": ["postgresql", "h2"] },
+            "host": { "type": "string" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "database": { "type": "string", "minLength": 1 },
+            "username": { "type": "string", "minLength": 1 }
+          },
+          "required": ["kind", "sqlKind", "database", "username"]
+        },
+        "oidc": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "issuerUri": { "type": "string" },
+            "clientId": { "type": "string", "minLength": 1 },
+            "rolesClaimPath": { "type": "string" }
+          },
+          "required": ["enabled", "clientId", "rolesClaimPath"]
+        },
+        "roleBasedAuth": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "adminClaim": { "type": "string" },
+            "developerClaim": { "type": "string" },
+            "readonlyClaim": { "type": "string" }
+          },
+          "required": ["enabled"]
+        },
+        "externalSecrets": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "refreshInterval": { "type": "string" },
+            "secretStoreRef": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "kind": { "enum": ["ClusterSecretStore", "SecretStore"] },
+                "name": { "type": "string" }
+              },
+              "required": ["kind", "name"]
+            },
+            "dbCreds": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "vaultPath": { "type": "string" },
+                "passwordKey": { "type": "string" }
+              },
+              "required": ["vaultPath", "passwordKey"]
+            },
+            "oidcClient": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "vaultPath": { "type": "string" },
+                "clientSecretKey": { "type": "string" }
+              },
+              "required": ["vaultPath", "clientSecretKey"]
+            }
+          }
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "entryPoint": { "type": "string" },
+            "host": { "type": "string" },
+            "tls": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "secretName": { "type": "string" },
+                "certManager": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "clusterIssuer": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "networkPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "traefikNamespace": { "type": "string" },
+            "monitoringNamespace": { "type": "string" },
+            "dataHostCIDR": { "type": "string" },
+            "dataHostPort": { "type": "integer" },
+            "keycloakService": { "type": "string" },
+            "keycloakNamespace": { "type": "string" },
+            "keycloakPort": { "type": "integer" },
+            "oidcIssuerCIDR": { "type": "string" },
+            "oidcIssuerPort": { "type": "integer" }
+          }
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "interval": { "type": "string" }
+          }
+        },
+        "startupProbe": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "livenessProbe": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "readinessProbe": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "podSecurityContext": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "containerSecurityContext": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "extraEnv": {
+          "type": "array"
+        }
+      },
+      "required": ["enabled", "image", "storage", "oidc"]
+    }
+  }
+}

--- a/apps/apicurio-registry/values.yaml
+++ b/apps/apicurio-registry/values.yaml
@@ -1,0 +1,188 @@
+# Defaults do chart apps/apicurio-registry/.
+# Cada environment (environments/<env>/values.yaml) sobrescreve apenas o
+# necessário. Por padrão o chart fica DESABILITADO — só os ambientes que
+# precisam de Schema Registry (ex.: standalone) ligam via
+# `apicurioRegistry.enabled: true`.
+
+commonLabels:
+  app.kubernetes.io/part-of: uniplus
+  app.kubernetes.io/component: data-admin
+
+apicurioRegistry:
+  # Liga/desliga o chart inteiro. Default false.
+  enabled: false
+
+  image:
+    registry: docker.io
+    repository: apicurio/apicurio-registry
+    # Versão estável validada (Mar/2026). Bumps de patch seguros;
+    # majors requerem revisão das envs APICURIO_* (renomes recorrentes
+    # entre 2.x → 3.x; checar release notes).
+    tag: "3.2.4"
+    pullPolicy: IfNotPresent
+
+  imagePullSecrets: []
+
+  # Apicurio é stateless (todo state vai pro Postgres externo). 1 réplica
+  # é suficiente em standalone — DB faz single-source-of-truth. HA real
+  # exige Postgres replicado (Fase prod com Patroni).
+  replicas: 1
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+  serviceAccount:
+    create: true
+    name: ""
+
+  # === Storage SQL (Postgres standalone) ===
+  # DB e role provisionados pelo step_data_setup_apicurio_db do
+  # bootstrap-standalone.sh. Senha em Vault — ver externalSecrets.dbCreds.
+  storage:
+    kind: sql
+    sqlKind: postgresql
+    # Hostname/IP do Postgres no data-host. Ex: 10.0.2.87 (subnet privada).
+    host: ""
+    port: 5432
+    database: apicurio
+    username: apicurio
+
+  # === OIDC (Keycloak realm uniplus) ===
+  # Apicurio usa Quarkus OIDC. Confidential client `apicurio-registry` no
+  # realm — client_secret custodiado em Vault e injetado via ExternalSecret.
+  #
+  # IMPORTANTE: Apicurio Registry vem com default
+  # `QUARKUS_OIDC_AUTH_SERVER_URL=https://auth.apicur.io/auth/realms/apicurio-local`
+  # apontando pro Keycloak demo público da Red Hat. SEMPRE override com
+  # issuerUri do nosso Keycloak — sem isso, Apicurio confia em IdP externo
+  # sem SLA/controle.
+  oidc:
+    enabled: true
+    issuerUri: ""                # ex.: https://standalone.portaluni.com.br/auth/realms/uniplus
+    clientId: apicurio-registry
+    # Path do claim do JWT que carrega as roles/groups. Pattern reusa
+    # `groups` do mapper já existente no realm (full path: /admins/kafka).
+    rolesClaimPath: groups
+
+  # === Role-based authorization ===
+  # Apicurio define 3 roles internas: sr-admin (full RW + admin), sr-developer
+  # (CRUD em artifacts próprios), sr-readonly (leitura). Mapeamento via
+  # APICURIO_AUTH_ROLES_<role> = valor exato do claim. Reusamos os groups
+  # já validados para AKHQ (/admins/kafka, /users/uniplus) — admins de Kafka
+  # também são admins de schemas; users uniplus default são developers.
+  # Sem grupo (claim vazio) o behavior depende de auth.anonymous-read-access:
+  # mantemos OFF para que requests anônimas sejam 401 (defesa em profundidade).
+  roleBasedAuth:
+    enabled: true
+    # Claim values que mapeiam pra cada role Apicurio.
+    adminClaim: "/admins/kafka"
+    developerClaim: "/users/uniplus"
+    # Vazio: nenhum grupo automaticamente vira readonly — usuário sem
+    # /admins/kafka e sem /users/uniplus simplesmente não tem role.
+    # Ajustar para "/users/external" futuramente se quisermos guests.
+    readonlyClaim: ""
+
+  # === ExternalSecrets (Vault → K8s Secret) ===
+  externalSecrets:
+    enabled: true
+    refreshInterval: "1h"
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: vault-default
+
+    # Senha do role `apicurio` no Postgres. Gerada pelo
+    # step_data_setup_apicurio_db do bootstrap-standalone.sh em
+    # .bootstrap-creds-apicurio; operador custodia em Vault path abaixo
+    # via §15.2 do RUNBOOKS após primeira execução.
+    dbCreds:
+      vaultPath: secret/standalone/postgres/apicurio
+      passwordKey: password
+
+    # client_secret OIDC do confidential client `apicurio-registry` no realm
+    # uniplus. Gerado pelo Keycloak no import inicial; operador recupera via
+    # kcadm.sh e custodia em Vault (RUNBOOKS §15.1).
+    oidcClient:
+      vaultPath: secret/standalone/keycloak/clients/apicurio-registry
+      clientSecretKey: client_secret
+
+  # === Exposição externa via Traefik IngressRoute ===
+  ingress:
+    enabled: false
+    entryPoint: websecure
+    host: ""                     # ex.: schema-registry.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: ""             # criado pelo cert-manager se certManager.enabled
+      certManager:
+        enabled: false
+        clusterIssuer: ""        # ex.: letsencrypt-staging | letsencrypt-prod
+
+  # === NetworkPolicy ===
+  # Egress: Postgres data-host (10.0.2.87:5432) + DNS + Keycloak in-cluster
+  # + OIDC issuer público (HTTPS port 443).
+  # Ingress: Traefik + Prometheus (se ServiceMonitor on).
+  networkPolicy:
+    enabled: true
+    traefikNamespace: traefik
+    monitoringNamespace: observability-prometheus
+    # CIDR da subnet privada VCN onde o Postgres data-host vive. Mesmo
+    # CIDR usado pelo keycloak-replica (storage compartilhado).
+    dataHostCIDR: ""
+    dataHostPort: 5432
+    # Service do Keycloak local (in-cluster). Default casa com release name
+    # padrão do chart keycloak-replica em standalone.
+    keycloakService: keycloak-replica-uniplus-standalone
+    keycloakNamespace: uniplus
+    keycloakPort: 8080
+    # CIDR do endpoint público do OIDC issuer. Apicurio chama
+    # `.well-known/openid-configuration`, `/token`, `/userinfo` em HTTPS
+    # port 443 contra o issuer URL público (entra via Traefik IngressRoute
+    # do Keycloak). Sem essa entrada, o pod resolve o DNS mas o handshake
+    # TLS é bloqueado pelo default-deny do egress (mesmo bug Codex P1
+    # round 1 do kafka-ui).
+    oidcIssuerCIDR: ""
+    oidcIssuerPort: 443
+
+  # === ServiceMonitor (Prometheus) ===
+  # Apicurio expõe métricas em /q/metrics (Quarkus Micrometer). Gateado em
+  # `serviceMonitor.enabled AND metrics.enabled`.
+  metrics:
+    enabled: true
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+
+  # === Probes ===
+  # Apicurio usa Quarkus health endpoints: /q/health/started (startup),
+  # /q/health/live (liveness), /q/health/ready (readiness — retorna 503
+  # enquanto JDBC/OIDC discovery não completarem).
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 5
+  livenessProbe:
+    periodSeconds: 10
+  readinessProbe:
+    periodSeconds: 5
+
+  # === SecurityContext ===
+  # apicurio/apicurio-registry:3.2.4 roda como uid 1001 (apicurio).
+  podSecurityContext:
+    fsGroup: 1001
+  containerSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    # Quarkus escreve em /tmp; rootfs poderia ser readOnly montando /tmp
+    # como emptyDir. Out of scope deste PR (deploy em prod hardening).
+    readOnlyRootFilesystem: false
+
+  # Env vars adicionais (lista de `{name, value}` ou `{name, valueFrom}`).
+  extraEnv: []

--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -97,6 +97,49 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "apicurio-registry",
+      "name": "Apicurio Registry — Schema Registry (Confluent SR API)",
+      "description": "Cliente OIDC do Apicurio Registry (apps/apicurio-registry). Confidential client — Apicurio é backend Quarkus, mantém client_secret no Vault em secret/standalone/keycloak/clients/apicurio-registry (RUNBOOKS §15.1). Após import inicial, operador deve recuperar o secret gerado pelo Keycloak via kcadm.sh e custodiar.",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "frontchannelLogout": true,
+      "redirectUris": [
+        "https://schema-registry.standalone.portaluni.com.br/*",
+        "https://schema-registry.standalone.portaluni.com.br/ui/*"
+      ],
+      "webOrigins": ["https://schema-registry.standalone.portaluni.com.br"],
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "groups"
+          }
+        }
+      ]
     }
   ],
   "groups": [

--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -101,13 +101,13 @@
     {
       "clientId": "apicurio-registry",
       "name": "Apicurio Registry — Schema Registry (Confluent SR API)",
-      "description": "Cliente OIDC do Apicurio Registry (apps/apicurio-registry). Confidential client — Apicurio é backend Quarkus, mantém client_secret no Vault em secret/standalone/keycloak/clients/apicurio-registry (RUNBOOKS §15.1). Após import inicial, operador deve recuperar o secret gerado pelo Keycloak via kcadm.sh e custodiar.",
+      "description": "Cliente OIDC do Apicurio Registry (apps/apicurio-registry). Confidential client — Apicurio é backend Quarkus, mantém client_secret no Vault em secret/standalone/keycloak/clients/apicurio-registry (RUNBOOKS §15.1). Após import inicial, operador deve recuperar o secret gerado pelo Keycloak via kcadm.sh e custodiar. directAccessGrantsEnabled=true habilita password grant para smoke test documentado (§15.4); em prod o admin deve usar authorization code + PKCE via UI ou kcadm direto e este flag deve ser revisado.",
       "enabled": true,
       "protocol": "openid-connect",
       "publicClient": false,
       "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
+      "directAccessGrantsEnabled": true,
       "serviceAccountsEnabled": true,
       "frontchannelLogout": true,
       "redirectUris": [

--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -39,6 +39,7 @@ spec:
                 - app: clamav-scanner
                 - app: keycloak-replica
                 - app: kafka-ui
+                - app: apicurio-registry
 
   template:
     metadata:

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2592,7 +2592,10 @@ kc() { sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "$@"; }
 # No host data (10.0.2.87), executar a etapa apicurio do bootstrap.
 # Role correto é `standalone-data` (validation do script aceita apenas
 # `standalone-k8s` ou `standalone-data`).
-ssh ubuntu@10.0.2.87 "cd /opt/uniplus-infra && sudo ./scripts/bootstrap-standalone.sh \
+# IMPORTANTE: NÃO usar `sudo ./scripts/bootstrap-standalone.sh` — o script
+# aborta com `check_not_root` quando EUID=0 (usa sudo internamente para
+# operações específicas). Executar como user normal (ubuntu).
+ssh ubuntu@10.0.2.87 "cd /opt/uniplus-infra && ./scripts/bootstrap-standalone.sh \
   --role=standalone-data"
 ```
 
@@ -2702,8 +2705,9 @@ EOF
 sudo chmod 600 /var/lib/uniplus/postgres/.bootstrap-creds-apicurio
 sudo chown root:root /var/lib/uniplus/postgres/.bootstrap-creds-apicurio"
 
-# Agora pode rodar o bootstrap normalmente:
-ssh ubuntu@10.0.2.87 "cd /opt/uniplus-infra && sudo ./scripts/bootstrap-standalone.sh --role=standalone-data"
+# Agora pode rodar o bootstrap normalmente (sem sudo — script aborta
+# com check_not_root se EUID=0; usa sudo internamente).
+ssh ubuntu@10.0.2.87 "cd /opt/uniplus-infra && ./scripts/bootstrap-standalone.sh --role=standalone-data"
 
 # Após confirmar success, shred novamente (idempotente).
 ```

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2568,4 +2568,203 @@ unset NEW_SECRET TKN
 
 ---
 
+## 15. Apicurio Registry — Schema Registry (standalone)
+
+Schema/API artifact registry compatível com a Confluent Schema Registry API — chart `apps/apicurio-registry/` (issue #152). Apicurio 3.2.4, storage SQL no Postgres standalone (DB `apicurio`), autenticação OIDC via realm `uniplus` com role-based authorization. Pré-requisitos: §9 Postgres ativo + §10 Keycloak ativo (realm `uniplus` importado).
+
+### 15.1 Pré-flight: DB + client OIDC + custódia
+
+3 itens precisam estar prontos antes do ArgoCD reconciliar o chart apicurio-registry:
+
+1. **DB `apicurio`** — provisionada pelo `step_data_setup_apicurio_db` do `bootstrap-standalone.sh`
+2. **`secret/standalone/postgres/apicurio`** — senha do role `apicurio` (custodiar a partir de `.bootstrap-creds-apicurio`)
+3. **`secret/standalone/keycloak/clients/apicurio-registry`** — `client_secret` (gerado pelo realm import)
+
+Sem (2) ou (3), os ESOs ficam em `SecretNotFound` e o pod trava em `CreateContainerConfigError`.
+
+```bash
+kc() { sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "$@"; }
+```
+
+**Passo 1 — Provisionar DB no Postgres data-host.**
+
+```bash
+# No host data (10.0.2.87), executar a etapa apicurio do bootstrap.
+ssh ubuntu@10.0.2.87 "cd /opt/uniplus-infra && sudo ./scripts/bootstrap-standalone.sh \
+  --role data-host --skip-k3s --skip-docker"
+```
+
+O step idempotente `step_data_setup_apicurio_db` cria role + database e preserva senhas existentes. Após primeira execução:
+
+```bash
+# Custodiar senha em Vault (mesmo pattern do §9.2):
+ssh ubuntu@10.0.2.87 "sudo cat /var/lib/uniplus/postgres/.bootstrap-creds-apicurio"
+# apicurio_pw=<HEX_64>
+
+VAULT_TOKEN=hvs.xxx \
+  vault kv put secret/standalone/postgres/apicurio \
+    username=apicurio \
+    password=<HEX_64>
+
+# Após custódia confirmada (vault kv get OK), apagar o arquivo do data-host:
+ssh ubuntu@10.0.2.87 "sudo shred -u /var/lib/uniplus/postgres/.bootstrap-creds-apicurio"
+```
+
+**Passo 2 — Adicionar client `apicurio-registry` ao realm uniplus** (idempotente — Keycloak skipa import se realm já existe).
+
+Como em §14.1 do AKHQ, usar `kcadm.sh` para operação cirúrgica:
+
+```bash
+kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c '
+  set -e
+  /opt/keycloak/bin/kcadm.sh config credentials \
+    --server http://localhost:8080/auth \
+    --realm master \
+    --user "$KC_BOOTSTRAP_ADMIN_USERNAME" \
+    --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" >/dev/null
+
+  # Cria client se não existe (idempotente via grep)
+  if ! /opt/keycloak/bin/kcadm.sh get clients -r uniplus --fields clientId 2>/dev/null \
+       | grep -q apicurio-registry; then
+    /opt/keycloak/bin/kcadm.sh create clients -r uniplus \
+      -s clientId=apicurio-registry \
+      -s name="Apicurio Registry" \
+      -s enabled=true \
+      -s publicClient=false \
+      -s standardFlowEnabled=true \
+      -s "redirectUris=[\"https://schema-registry.standalone.portaluni.com.br/*\"]" \
+      -s "webOrigins=[\"https://schema-registry.standalone.portaluni.com.br\"]" \
+      -s frontchannelLogout=true
+  fi
+
+  # Adiciona mapper groups (full path)
+  CID=$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus -q clientId=apicurio-registry --fields id --format csv --noquotes | tail -1)
+  if ! /opt/keycloak/bin/kcadm.sh get clients/$CID/protocol-mappers/models -r uniplus 2>/dev/null \
+       | grep -q "\"name\" : \"groups\""; then
+    /opt/keycloak/bin/kcadm.sh create clients/$CID/protocol-mappers/models -r uniplus \
+      -s name=groups \
+      -s protocol=openid-connect \
+      -s protocolMapper=oidc-group-membership-mapper \
+      -s "config.\"full.path\"=true" \
+      -s "config.\"id.token.claim\"=true" \
+      -s "config.\"access.token.claim\"=true" \
+      -s "config.\"userinfo.token.claim\"=true" \
+      -s "config.\"claim.name\"=groups"
+  fi
+'
+```
+
+**Passo 3 — Recuperar `client_secret` e custodiar em Vault.**
+
+```bash
+SECRET=$(kc exec -n uniplus deploy/keycloak-replica-uniplus-standalone -- \
+  /opt/keycloak/bin/kcadm.sh get clients -r uniplus \
+  -q clientId=apicurio-registry --fields secret --format csv --noquotes | tail -1)
+
+VAULT_TOKEN=hvs.xxx \
+  vault kv put secret/standalone/keycloak/clients/apicurio-registry \
+    client_secret="$SECRET"
+```
+
+### 15.2 Custódia: rotação de senha do DB
+
+Caso a senha do role `apicurio` precise ser rotacionada (compromise, política de rotação 90d):
+
+```bash
+# 1. Gerar nova senha
+NEW_PW=$(openssl rand -hex 32)
+
+# 2. Atualizar role no Postgres
+ssh ubuntu@10.0.2.87 "sudo docker exec -e PGPASSWORD=<super_pw> uniplus-postgres \
+  psql -U postgres -c \"ALTER ROLE apicurio WITH PASSWORD '$NEW_PW';\""
+
+# 3. Atualizar Vault
+VAULT_TOKEN=hvs.xxx \
+  vault kv put secret/standalone/postgres/apicurio username=apicurio password="$NEW_PW"
+
+# 4. Forçar refresh do ESO (default refreshInterval=1h)
+kc annotate -n uniplus externalsecret apicurio-registry-db \
+  force-sync=$(date +%s) --overwrite
+
+# 5. Restart do deployment para o pod pegar a nova senha (env é cacheada)
+kc rollout restart -n uniplus deployment/apicurio-registry
+```
+
+### 15.3 Smoke test pós-deploy
+
+```bash
+# 1. Pod healthy
+kc get pods -n uniplus -l app.kubernetes.io/name=apicurio-registry
+# READY 1/1, STATUS Running
+
+# 2. Health endpoints
+kc exec -n uniplus deploy/apicurio-registry -- \
+  curl -s http://localhost:8080/q/health/ready
+# {"status":"UP","checks":[...]}
+
+# 3. OIDC discovery alcançável (deve retornar 200 com issuer)
+kc exec -n uniplus deploy/apicurio-registry -- \
+  curl -s https://standalone.portaluni.com.br/auth/realms/uniplus/.well-known/openid-configuration | head -c 200
+
+# 4. UI externa
+curl -sk https://schema-registry.standalone.portaluni.com.br/ui/ -o /dev/null -w "%{http_code}\n"
+# 200 (HTML)
+
+# 5. API V3 — listar artifacts (anonymous OFF, deve retornar 401 sem JWT)
+curl -sk https://schema-registry.standalone.portaluni.com.br/apis/registry/v3/groups/default/artifacts -o /dev/null -w "%{http_code}\n"
+# 401 (esperado — auth obrigatória)
+
+# 6. Confluent SR API V2 (compat) — mesmo path, retorna 401
+curl -sk https://schema-registry.standalone.portaluni.com.br/apis/ccompat/v7/subjects -o /dev/null -w "%{http_code}\n"
+# 401 (esperado)
+```
+
+Para teste de smoke autenticado (com JWT), seguir §15.4.
+
+### 15.4 Bootstrap inicial: registrar primeiro schema
+
+Apicurio aceita JWT do realm `uniplus` no header `Authorization: Bearer <token>`. Obter token via password grant (apenas em ambiente standalone — em prod usar service account com client credentials):
+
+```bash
+# Token via password grant — user em /admins/kafka tem role sr-admin
+TOKEN=$(curl -sk -X POST \
+  https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/token \
+  -d "grant_type=password" \
+  -d "client_id=apicurio-registry" \
+  -d "client_secret=$CLIENT_SECRET" \
+  -d "username=jeferson.ferreira" \
+  -d "password=$PW" \
+  -d "scope=openid" \
+  | jq -r .access_token)
+
+# Registrar primeiro Avro schema via Confluent SR compat API
+curl -sk -X POST \
+  https://schema-registry.standalone.portaluni.com.br/apis/ccompat/v7/subjects/uniplus.events.smoke-value/versions \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+  -d '{"schemaType":"AVRO","schema":"{\"type\":\"record\",\"name\":\"Smoke\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"}]}"}'
+# {"id":1}
+
+# Listar subjects
+curl -sk -H "Authorization: Bearer $TOKEN" \
+  https://schema-registry.standalone.portaluni.com.br/apis/ccompat/v7/subjects
+# ["uniplus.events.smoke-value"]
+```
+
+### 15.5 Troubleshooting
+
+| Sintoma | Causa provável | Resolução |
+|---|---|---|
+| Pod `CreateContainerConfigError` | ESO não sintetizou Secret (Vault offline ou path errado) | `kc describe externalsecret -n uniplus apicurio-registry-{db,oidc-client}` — checar `status.conditions`. Se `SecretNotFound`: confirmar Vault unsealed + path correto |
+| Pod `CrashLoopBackOff`, log `Connection refused (...:5432)` | Egress Postgres bloqueado por NetworkPolicy | Validar `dataHostCIDR` em `environments/standalone/values.yaml` cobre `10.0.2.0/24` (default). Confirmar `uniplus-postgres` ativo no data-host |
+| Pod `CrashLoopBackOff`, log `password authentication failed for user "apicurio"` | Senha em Vault diferente da no Postgres | Recuperar `apicurio_pw` do data-host (`.bootstrap-creds-apicurio` se ainda existe) ou rotacionar via §15.2 |
+| Pod up mas `/q/health/ready` retorna 503 com `OIDC discovery failed` | Egress OIDC issuer bloqueado (default-deny) | Validar `oidcIssuerCIDR=164.152.53.29/32` em `environments/standalone/values.yaml`. Mesmo bug que §14.4 do AKHQ |
+| 401 mesmo com JWT válido em `/admins/kafka` | Mapper groups não aplicado no client | `kc exec deploy/keycloak-replica-... -- /opt/keycloak/bin/kcadm.sh get clients/$CID/protocol-mappers/models -r uniplus` — adicionar mapper conforme §15.1 passo 2 |
+| 403 "user has no roles" mesmo após login | `APICURIO_AUTH_ROLE_BASED_AUTHORIZATION` true mas claim path errado | Decode JWT (`jwt.io`) — verificar claim `groups` presente. Se ausente, mapper groups não está incluindo no access_token (config.access.token.claim=true falta) |
+| UI carrega mas botões "Create artifact" cinza | Role mapeada como `sr-readonly` em vez de `sr-admin` | Verificar group do user no Keycloak: `Users → jeferson.ferreira → Groups`. Adicionar a `/admins/kafka` se ausente |
+| `auth.apicur.io` aparece em logs OIDC | `QUARKUS_OIDC_AUTH_SERVER_URL` não setado — caiu no default Keycloak demo Red Hat | Validar `oidc.issuerUri` em `environments/standalone/values.yaml`. Sempre obrigatório — sem isso, Apicurio confia em IdP externo público |
+| Browser warning "Not secure" no `schema-registry.standalone.portaluni.com.br` | Cert LE staging | Promover para `letsencrypt-prod` em `ingress.tls.certManager.clusterIssuer` (já é default no `environments/standalone/values.yaml` — checar override por engano) |
+
+---
+
 *Documento mantido pelo CTIC/UNIFESSPA. Atualizações via Pull Request.*

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2590,8 +2590,10 @@ kc() { sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "$@"; }
 
 ```bash
 # No host data (10.0.2.87), executar a etapa apicurio do bootstrap.
+# Role correto é `standalone-data` (validation do script aceita apenas
+# `standalone-k8s` ou `standalone-data`).
 ssh ubuntu@10.0.2.87 "cd /opt/uniplus-infra && sudo ./scripts/bootstrap-standalone.sh \
-  --role data-host --skip-k3s --skip-docker"
+  --role=standalone-data"
 ```
 
 O step idempotente `step_data_setup_apicurio_db` cria role + database e preserva senhas existentes. Após primeira execução:
@@ -2656,14 +2658,31 @@ kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c '
 
 **Passo 3 — Recuperar `client_secret` e custodiar em Vault.**
 
+O endpoint `clients/$CID/client-secret` é o único que retorna o valor efetivo do confidential client secret — `get clients --fields secret` retorna vazio (Keycloak não expõe o secret no list). Mesmo pattern do AKHQ §14.1.
+
 ```bash
-SECRET=$(kc exec -n uniplus deploy/keycloak-replica-uniplus-standalone -- \
-  /opt/keycloak/bin/kcadm.sh get clients -r uniplus \
-  -q clientId=apicurio-registry --fields secret --format csv --noquotes | tail -1)
+kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c '
+  set -e
+  /opt/keycloak/bin/kcadm.sh config credentials \
+    --server http://localhost:8080/auth \
+    --realm master \
+    --user "$KC_BOOTSTRAP_ADMIN_USERNAME" \
+    --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" >/dev/null
+
+  CID=$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus \
+    -q clientId=apicurio-registry --fields id --format csv --noquotes | tail -1)
+
+  /opt/keycloak/bin/kcadm.sh get clients/$CID/client-secret -r uniplus \
+    --fields value --format csv --noquotes | tail -1
+' > /tmp/apicurio-cs
+
+SECRET=$(cat /tmp/apicurio-cs)
 
 VAULT_TOKEN=hvs.xxx \
   vault kv put secret/standalone/keycloak/clients/apicurio-registry \
     client_secret="$SECRET"
+
+shred -u /tmp/apicurio-cs
 ```
 
 ### 15.2 Custódia: rotação de senha do DB

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2634,9 +2634,14 @@ kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c '
       -s enabled=true \
       -s publicClient=false \
       -s standardFlowEnabled=true \
+      -s directAccessGrantsEnabled=true \
+      -s serviceAccountsEnabled=true \
       -s "redirectUris=[\"https://schema-registry.standalone.portaluni.com.br/*\"]" \
       -s "webOrigins=[\"https://schema-registry.standalone.portaluni.com.br\"]" \
       -s frontchannelLogout=true
+    # Nota: directAccessGrantsEnabled=true habilita password grant para o
+    # smoke do §15.4. Em prod, revisar — admin deve usar authorization code
+    # + PKCE via UI ou kcadm direto. Espelha o realm.json do PR #155.
   fi
 
   # Adiciona mapper groups (full path)

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2701,28 +2701,39 @@ ssh ubuntu@10.0.2.87 "sudo docker exec -e PGPASSWORD=<super_pw> uniplus-postgres
 VAULT_TOKEN=hvs.xxx \
   vault kv put secret/standalone/postgres/apicurio username=apicurio password="$NEW_PW"
 
-# 4. Forçar refresh do ESO (default refreshInterval=1h)
-kc annotate -n uniplus externalsecret apicurio-registry-db \
+# 4. Forçar refresh do ESO (default refreshInterval=1h).
+# Nota sobre nomes: Helm renderiza fullname como
+# `<Release.Name>-<Chart.Name>`. Em standalone o ApplicationSet
+# (argocd/applicationset.yaml) gera release name `apicurio-registry-uniplus-standalone`,
+# então o ExternalSecret de DB é
+# `apicurio-registry-uniplus-standalone-apicurio-registry-db`. Mesmo
+# pattern do keycloak-replica/AKHQ vistos em §10/§14.
+kc annotate -n uniplus externalsecret apicurio-registry-uniplus-standalone-apicurio-registry-db \
   force-sync=$(date +%s) --overwrite
 
 # 5. Restart do deployment para o pod pegar a nova senha (env é cacheada)
-kc rollout restart -n uniplus deployment/apicurio-registry
+kc rollout restart -n uniplus deployment/apicurio-registry-uniplus-standalone-apicurio-registry
 ```
 
 ### 15.3 Smoke test pós-deploy
 
 ```bash
-# 1. Pod healthy
+# Helm fullname em standalone: apicurio-registry-uniplus-standalone-apicurio-registry
+# (Release.Name `apicurio-registry-uniplus-standalone` + Chart.Name `apicurio-registry`)
+APICURIO_DEPLOY=apicurio-registry-uniplus-standalone-apicurio-registry
+
+# 1. Pod healthy. Label seletor `app.kubernetes.io/name=apicurio-registry`
+# (chart name) bate em qualquer release — não precisa do fullname.
 kc get pods -n uniplus -l app.kubernetes.io/name=apicurio-registry
 # READY 1/1, STATUS Running
 
 # 2. Health endpoints
-kc exec -n uniplus deploy/apicurio-registry -- \
+kc exec -n uniplus "deploy/$APICURIO_DEPLOY" -- \
   curl -s http://localhost:8080/q/health/ready
 # {"status":"UP","checks":[...]}
 
 # 3. OIDC discovery alcançável (deve retornar 200 com issuer)
-kc exec -n uniplus deploy/apicurio-registry -- \
+kc exec -n uniplus "deploy/$APICURIO_DEPLOY" -- \
   curl -s https://standalone.portaluni.com.br/auth/realms/uniplus/.well-known/openid-configuration | head -c 200
 
 # 4. UI externa
@@ -2774,7 +2785,7 @@ curl -sk -H "Authorization: Bearer $TOKEN" \
 
 | Sintoma | Causa provável | Resolução |
 |---|---|---|
-| Pod `CreateContainerConfigError` | ESO não sintetizou Secret (Vault offline ou path errado) | `kc describe externalsecret -n uniplus apicurio-registry-{db,oidc-client}` — checar `status.conditions`. Se `SecretNotFound`: confirmar Vault unsealed + path correto |
+| Pod `CreateContainerConfigError` | ESO não sintetizou Secret (Vault offline ou path errado) | `kc describe externalsecret -n uniplus apicurio-registry-uniplus-standalone-apicurio-registry-{db,oidc-client}` — checar `status.conditions`. Se `SecretNotFound`: confirmar Vault unsealed + path correto |
 | Pod `CrashLoopBackOff`, log `Connection refused (...:5432)` | Egress Postgres bloqueado por NetworkPolicy | Validar `dataHostCIDR` em `environments/standalone/values.yaml` cobre `10.0.2.0/24` (default). Confirmar `uniplus-postgres` ativo no data-host |
 | Pod `CrashLoopBackOff`, log `password authentication failed for user "apicurio"` | Senha em Vault diferente da no Postgres | Recuperar `apicurio_pw` do data-host (`.bootstrap-creds-apicurio` se ainda existe) ou rotacionar via §15.2 |
 | Pod up mas `/q/health/ready` retorna 503 com `OIDC discovery failed` | Egress OIDC issuer bloqueado (default-deny) | Validar `oidcIssuerCIDR=164.152.53.29/32` em `environments/standalone/values.yaml`. Mesmo bug que §14.4 do AKHQ |

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2690,9 +2690,25 @@ VAULT_TOKEN=hvs.xxx \
 shred -u /tmp/apicurio-cs
 ```
 
-### 15.2 Custódia: rotação de senha do DB
+### 15.2 Custódia: rotação ou restore de senha do DB
 
-Caso a senha do role `apicurio` precise ser rotacionada (compromise, política de rotação 90d):
+**Restore (manutenção/upgrade após shred):** se você executou `shred -u $DATA_BASE/postgres/.bootstrap-creds-apicurio` após custódia em Vault e precisa rodar `bootstrap-standalone.sh --role=standalone-data` de novo (manutenção, upgrade), o step Apicurio aborta com `role apicurio já existe mas .bootstrap-creds-apicurio ausente` (Codex P1 round 5 do PR #155). Restaure o arquivo a partir do Vault antes:
+
+```bash
+APICURIO_PW=$(VAULT_TOKEN=hvs.xxx vault kv get -field=password secret/standalone/postgres/apicurio)
+ssh ubuntu@10.0.2.87 "sudo tee /var/lib/uniplus/postgres/.bootstrap-creds-apicurio > /dev/null <<EOF
+apicurio_pw=$APICURIO_PW
+EOF
+sudo chmod 600 /var/lib/uniplus/postgres/.bootstrap-creds-apicurio
+sudo chown root:root /var/lib/uniplus/postgres/.bootstrap-creds-apicurio"
+
+# Agora pode rodar o bootstrap normalmente:
+ssh ubuntu@10.0.2.87 "cd /opt/uniplus-infra && sudo ./scripts/bootstrap-standalone.sh --role=standalone-data"
+
+# Após confirmar success, shred novamente (idempotente).
+```
+
+**Rotação (compromise ou política 90d):**
 
 ```bash
 # 1. Gerar nova senha

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -469,6 +469,58 @@ kafkaUi:
     enabled: false
 
 # ----------------------------------------------------------------------------
+# Apicurio Registry — schema/API artifact registry, Confluent SR API compatível.
+# Integração: Postgres data-host (DB `apicurio`) + Keycloak realm uniplus
+# (client `apicurio-registry`). Reusa groups /admins/kafka e /users/uniplus
+# para mapping de roles sr-admin/sr-developer.
+# ----------------------------------------------------------------------------
+apicurioRegistry:
+  enabled: true
+
+  storage:
+    # Mesmo data-host dos demais services. DB `apicurio` provisionado pelo
+    # step_data_setup_apicurio_db do bootstrap-standalone.sh.
+    host: 10.0.2.87
+
+  oidc:
+    enabled: true
+    issuerUri: https://standalone.portaluni.com.br/auth/realms/uniplus
+
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    host: schema-registry.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: apicurio-registry-tls
+      certManager:
+        enabled: true
+        # LE prod desde o primeiro deploy (LE staging já foi promovido para
+        # Keycloak + AKHQ; novo subdomínio entra direto em prod sem warning
+        # de browser).
+        clusterIssuer: letsencrypt-prod
+
+  networkPolicy:
+    enabled: true
+    traefikNamespace: traefik
+    monitoringNamespace: observability-prometheus
+    # /24 da subnet privada VCN. Mesmo CIDR do kafkaUi (egress só para 5432
+    # neste chart, mas mantemos o mesmo bloco por consistência).
+    dataHostCIDR: 10.0.2.0/24
+    dataHostPort: 5432
+    keycloakService: keycloak-replica-uniplus-standalone
+    keycloakNamespace: uniplus
+    keycloakPort: 8080
+    # IP público do k8s-host OCI standalone — Quarkus OIDC chama
+    # `.well-known/openid-configuration` contra standalone.portaluni.com.br
+    # que resolve para esse IP. Mesmo pattern do kafkaUi (Codex P1 round 1).
+    oidcIssuerCIDR: 164.152.53.29/32
+    oidcIssuerPort: 443
+
+  serviceMonitor:
+    enabled: false
+
+# ----------------------------------------------------------------------------
 # Componentes stateful no data-host (Postgres, Kafka, MinIO, Redis) rodam
 # FORA do K8s, gerenciados por systemd em /var/lib/uniplus/* (ADR-002 +
 # ADR-005). Endpoints chegam às apps via External Secrets sintetizados a

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -1770,11 +1770,41 @@ step_data_setup_apicurio_db() {
         return
     fi
 
-    # ---- Decisão 1: .bootstrap-creds-apicurio (preservar / gerar) ----
+    # Detecta se o role `apicurio` já existe no Postgres. Pattern: idempotência
+    # operacional — em manutenção/upgrade re-executar bootstrap, role já está
+    # provisionada. Sem essa detecção a Decisão 1 abaixo regenera senha e a
+    # Decisão 2 ALTER ROLE silenciosamente — desincronizando Postgres do Vault
+    # (Codex P1 round 5).
+    local role_exists=false
+    if ! $DRY_RUN; then
+        local super_pw_check
+        super_pw_check=$(sudo grep '^super_pw=' "$pg_creds" | cut -d= -f2)
+        if [[ -n "$super_pw_check" ]] && \
+           sudo docker exec -e PGPASSWORD="$super_pw_check" uniplus-postgres \
+             psql -U postgres -tAc "SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='apicurio'" 2>/dev/null \
+             | grep -q '^1$'; then
+            role_exists=true
+        fi
+        unset super_pw_check
+    fi
+
+    # ---- Decisão 1: .bootstrap-creds-apicurio (preservar / gerar / abortar) ----
     if sudo test -f "$apicurio_creds" 2>/dev/null; then
         log_success "Bootstrap creds Apicurio já existentes — preservando senha."
     elif $DRY_RUN; then
         log_warn "Dry-run: senha apicurio seria gerada em $apicurio_creds"
+    elif $role_exists; then
+        # Guard: role `apicurio` existe no Postgres mas .bootstrap-creds-apicurio
+        # foi shredded (provavelmente após custódia em Vault — runbook §15.2).
+        # Regenerar senha agora rodaria ALTER ROLE silencioso, desincronizando
+        # Postgres da custódia em `secret/standalone/postgres/apicurio` no Vault.
+        # Apicurio ficaria com `password authentication failed for user
+        # "apicurio"` na próxima reconciliação. Mesmo pattern do Postgres §9.4
+        # / Redis §11.4. Codex P1 round 5.
+        log_error "$apicurio_creds ausente, mas role Postgres 'apicurio' já existe."
+        log_error "Regenerar senha agora desincronizaria Postgres do Vault."
+        log_error "Restaure $apicurio_creds a partir do Vault — ver docs/RUNBOOKS.md §15.2."
+        exit 1
     else
         log_info "Gerando senha Apicurio DB (256 bits)..."
         local apicurio_pw

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -1735,6 +1735,118 @@ UNIT
     fi
 }
 
+# Cria database `apicurio` + role `apicurio` no Postgres standalone para
+# servir como storage backend do Apicurio Schema Registry (issue #152).
+#
+# Decisão: storage Postgres em vez de KafkaSQL — single-broker standalone
+# não vira SPOF para schema metadata; separação clara do data plane Kafka.
+# Migração para KafkaSQL viável em hml/prod (3-broker cluster).
+#
+# Pré-condição: step_data_setup_postgres já rodou (uniplus-postgres ativo
+# + .bootstrap-creds com super_pw para criar role/db).
+#
+# Idempotência:
+#   - .bootstrap-creds-apicurio: preserva se existe; gera apicurio_pw se ausente
+#   - DB role/database: CREATE IF NOT EXISTS (psql IF NOT EXISTS é tricky;
+#     usar pattern de idempotência via SELECT pg_catalog.pg_roles + gosh)
+step_data_setup_apicurio_db() {
+    if $SKIP_DOCKER && ! command -v docker &>/dev/null; then
+        log_warn "Docker indisponível e --skip-docker ativo — pulando setup do Apicurio DB."
+        return
+    fi
+
+    if ! sudo systemctl is-active --quiet uniplus-postgres 2>/dev/null && ! $DRY_RUN; then
+        log_warn "uniplus-postgres não está ativo — pulando setup Apicurio DB."
+        return
+    fi
+
+    log_info "Configurando Apicurio Registry database no Postgres standalone..."
+
+    local pg_creds="$DATA_BASE/postgres/.bootstrap-creds"
+    local apicurio_creds="$DATA_BASE/postgres/.bootstrap-creds-apicurio"
+
+    if ! sudo test -f "$pg_creds" 2>/dev/null && ! $DRY_RUN; then
+        log_warn "$pg_creds ausente — Apicurio DB exige super_pw do Postgres. Restaure via §9.4 do RUNBOOKS antes."
+        return
+    fi
+
+    # ---- Decisão 1: .bootstrap-creds-apicurio (preservar / gerar) ----
+    if sudo test -f "$apicurio_creds" 2>/dev/null; then
+        log_success "Bootstrap creds Apicurio já existentes — preservando senha."
+    elif $DRY_RUN; then
+        log_warn "Dry-run: senha apicurio seria gerada em $apicurio_creds"
+    else
+        log_info "Gerando senha Apicurio DB (256 bits)..."
+        local apicurio_pw
+        apicurio_pw=$(openssl rand -hex 32)
+        sudo tee "$apicurio_creds" >/dev/null <<EOF
+apicurio_pw=$apicurio_pw
+EOF
+        sudo chown root:root "$apicurio_creds"
+        sudo chmod 600 "$apicurio_creds"
+        log_warn "Senha Apicurio gerada em $apicurio_creds. Custódia obrigatória — runbook §15.2."
+    fi
+
+    # ---- Decisão 2: criar role + database (idempotente) ----
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Criaria role + database 'apicurio' via psql"
+        return
+    fi
+
+    local super_pw apicurio_pw
+    super_pw=$(sudo grep '^super_pw=' "$pg_creds" | cut -d= -f2)
+    apicurio_pw=$(sudo grep '^apicurio_pw=' "$apicurio_creds" | cut -d= -f2)
+
+    if [[ -z "$super_pw" || -z "$apicurio_pw" ]]; then
+        log_error "super_pw ou apicurio_pw vazio nos creds files. Abortando."
+        exit 1
+    fi
+
+    # CREATE ROLE / CREATE DATABASE não suportam IF NOT EXISTS direto.
+    # Pattern: psql DO block que checa pg_roles antes de criar role;
+    # CREATE DATABASE falha silenciosamente se já existe (catch via || true).
+    #
+    # Senhas NUNCA em argv (vazaria via /proc/<pid>/cmdline world-readable).
+    # Ambas via env vars do `docker exec`:
+    #   - PGPASSWORD: especial do libpq (auth do connect)
+    #   - APICURIO_PW: lida pelo psql via meta-comando \getenv (psql ≥ 14 —
+    #     OK em Postgres 18 do uniplus-standalone) e interpolada como
+    #     variável de sessão :'apicurio_pw' no SQL.
+    # Env vars ficam em /proc/<pid>/environ (root-only, mode 400) ao invés
+    # de /proc/<pid>/cmdline (mode 444). Code-reviewer P1 round 1.
+    sudo docker exec \
+        -e PGPASSWORD="$super_pw" \
+        -e APICURIO_PW="$apicurio_pw" \
+        -i uniplus-postgres \
+        psql -U postgres -v ON_ERROR_STOP=1 <<'SQL' 2>&1 | tail -10
+\getenv apicurio_pw APICURIO_PW
+DO $$
+BEGIN
+   IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'apicurio') THEN
+      CREATE ROLE apicurio WITH LOGIN PASSWORD :'apicurio_pw' NOSUPERUSER NOCREATEDB NOCREATEROLE;
+   ELSE
+      ALTER ROLE apicurio WITH LOGIN PASSWORD :'apicurio_pw';
+   END IF;
+END
+$$;
+SELECT 'apicurio role ok' AS status;
+SQL
+
+    # CREATE DATABASE não pode rodar dentro de transaction block — separar.
+    # Erro 'already exists' ignorado silenciosamente via || true.
+    sudo docker exec -e PGPASSWORD="$super_pw" uniplus-postgres \
+        psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'apicurio'" 2>/dev/null \
+        | grep -q 1 \
+      || sudo docker exec -e PGPASSWORD="$super_pw" uniplus-postgres \
+        psql -U postgres -c "CREATE DATABASE apicurio OWNER apicurio ENCODING 'UTF8' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0" 2>&1 | tail -3
+
+    sudo docker exec -e PGPASSWORD="$super_pw" uniplus-postgres \
+        psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE apicurio TO apicurio" >/dev/null 2>&1
+
+    log_success "Apicurio DB pronta: role apicurio + database apicurio (owner=apicurio)."
+    unset super_pw apicurio_pw
+}
+
 summary_data() {
     echo ""
     echo "============================================"
@@ -1818,6 +1930,7 @@ case "$ROLE" in
         step_data_setup_minio
         step_data_bootstrap_minio_buckets
         step_data_setup_kafka
+        step_data_setup_apicurio_db
         summary_data
         ;;
 esac

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -1802,16 +1802,21 @@ EOF
         exit 1
     fi
 
-    # CREATE ROLE / CREATE DATABASE não suportam IF NOT EXISTS direto.
-    # Pattern: psql DO block que checa pg_roles antes de criar role;
-    # CREATE DATABASE falha silenciosamente se já existe (catch via || true).
+    # CREATE ROLE não suporta IF NOT EXISTS antes do PG 16. Pattern:
+    # psql `\if` block que checa pg_roles primeiro e despacha ALTER vs CREATE.
+    #
+    # IMPORTANTE: NÃO usar DO $$ ... $$ block aqui — psql NÃO interpola
+    # `:'var'` dentro de dollar-quoted strings (literais), gerando
+    # `syntax error at or near ":"`. Reproduzido em runtime contra
+    # postgres:18-alpine (Codex P1 round 2). Solução: meta-commands `\if`
+    # processados pelo psql ANTES do SQL chegar no server, onde
+    # `:'apicurio_pw'` é interpolado como SQL literal corretamente.
     #
     # Senhas NUNCA em argv (vazaria via /proc/<pid>/cmdline world-readable).
     # Ambas via env vars do `docker exec`:
     #   - PGPASSWORD: especial do libpq (auth do connect)
     #   - APICURIO_PW: lida pelo psql via meta-comando \getenv (psql ≥ 14 —
-    #     OK em Postgres 18 do uniplus-standalone) e interpolada como
-    #     variável de sessão :'apicurio_pw' no SQL.
+    #     OK em Postgres 18 do uniplus-standalone)
     # Env vars ficam em /proc/<pid>/environ (root-only, mode 400) ao invés
     # de /proc/<pid>/cmdline (mode 444). Code-reviewer P1 round 1.
     sudo docker exec \
@@ -1820,15 +1825,12 @@ EOF
         -i uniplus-postgres \
         psql -U postgres -v ON_ERROR_STOP=1 <<'SQL' 2>&1 | tail -10
 \getenv apicurio_pw APICURIO_PW
-DO $$
-BEGIN
-   IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'apicurio') THEN
-      CREATE ROLE apicurio WITH LOGIN PASSWORD :'apicurio_pw' NOSUPERUSER NOCREATEDB NOCREATEROLE;
-   ELSE
-      ALTER ROLE apicurio WITH LOGIN PASSWORD :'apicurio_pw';
-   END IF;
-END
-$$;
+SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'apicurio') AS role_exists \gset
+\if :role_exists
+   ALTER ROLE apicurio WITH LOGIN PASSWORD :'apicurio_pw';
+\else
+   CREATE ROLE apicurio WITH LOGIN PASSWORD :'apicurio_pw' NOSUPERUSER NOCREATEDB NOCREATEROLE;
+\endif
 SELECT 'apicurio role ok' AS status;
 SQL
 


### PR DESCRIPTION
## Resumo

Adiciona **Apicurio Registry 3.2.4** (Confluent SR API compatível) à stack standalone Uni+, fechando a lacuna de schema registry (issue #152). Reusa toda a stack existente — sem novo Keycloak, sem novo DB, sem novo IdP.

## O que entrega

| Item | Onde |
|---|---|
| Chart Helm | `apps/apicurio-registry/` (Deployment + Service + SA + 2× ExternalSecret + IngressRoute + Certificate + NetworkPolicy + ServiceMonitor) |
| Bootstrap DB | `step_data_setup_apicurio_db` em `scripts/bootstrap-standalone.sh` |
| Client OIDC | `apicurio-registry` em `apps/keycloak-replica/files/uniplus-realm.json` |
| Env standalone | bloco `apicurioRegistry` em `environments/standalone/values.yaml` |
| GitOps | entry em `argocd/applicationset.yaml` |
| Runbook | §15 completo em `docs/RUNBOOKS.md` |

## Decisões arquiteturais relevantes

### Override do default `auth.apicur.io`

A imagem `apicurio/apicurio-registry:3.2.4` traz `QUARKUS_OIDC_AUTH_SERVER_URL=https://auth.apicur.io/auth/realms/apicurio-local` por padrão — Keycloak demo público mantido pela Red Hat. **Sempre** sobrescrevemos com nosso Keycloak local. O env é setado **fora** do bloco `oidc.enabled` com fallback `localhost:9999/oidc-disabled` — nunca há call leak para o IdP externo, mesmo se OIDC for desligado por engano.

### Reuso de groups Keycloak

Em vez de criar grupos novos para Apicurio, reusamos os existentes (validados via AKHQ no PR #142):

| Apicurio role | Mapeado de | User exemplo |
|---|---|---|
| `sr-admin` | `/admins/kafka` | `jeferson.ferreira` |
| `sr-developer` | `/users/uniplus` | usuários gerais |
| `sr-readonly` | (nenhum — anon OFF) | — |

Anonymous read access OFF (defesa em profundidade).

### Storage SQL no Postgres existente

Em vez de KafkaSQL (storage no próprio Kafka), escolhemos SQL no Postgres standalone:

- Single-broker Kafka standalone não vira SPOF para schema metadata
- Separação clara do data plane Kafka
- Migração para KafkaSQL viável em hml/prod (3-broker cluster)

## Pre-PR review (subagent code-reviewer)

3 P1 corrigidos antes do push:

1. **Vazamento de senha** — `apicurio_pw` saía via `psql -v` (argv → `/proc/<pid>/cmdline` world-readable). Fix: `\getenv apicurio_pw APICURIO_PW` lendo da env (modo 400 em `/proc/.../environ`)
2. **`QUARKUS_OIDC_AUTH_SERVER_URL` opcional** — quando `oidc.enabled=false` ficaria unset, Quarkus pode consultar config durante init e cair no default Red Hat. Fix: env sempre setado com fallback local
3. **Combinações inválidas** — `oidc.enabled=true` + `externalSecrets.enabled=false` causava `CreateContainerConfigError` silencioso. Fix: `{{- fail }}` guard explícito

P2 #4 (storage.host vazio) também aplicado via `{{- fail }}`.
P2 #5 (redirect URIs hardcoded no realm.json) deferido — mesmo pattern do `kafka-ui` PR #142; refazer ambos em PR separado seria mais consistente.

## Test plan

- [x] `helm lint apps/apicurio-registry` (enabled=false e enabled=true full overlay) ✓
- [x] `helm template` renderiza 8 recursos esperados (NetworkPolicy, SA, Service, Deployment, Certificate, 2× ExternalSecret, IngressRoute, ServiceMonitor) ✓
- [x] Env vars críticas renderizam com valores corretos (`jdbc:postgresql://10.0.2.87:5432/apicurio`, issuer = nosso Keycloak, role mapping = `/admins/kafka`/`/users/uniplus`) ✓
- [x] `{{- fail }}` guards disparam para `storage.host` vazio e `oidc+externalSecrets` inconsistente ✓
- [x] `bash -n scripts/bootstrap-standalone.sh` ✓
- [x] `yamllint -c .yamllint.yaml` clean ✓
- [ ] Pós-merge: rodar `bootstrap-standalone.sh` no data-host (ARGO sync após custódia em Vault)
- [ ] Pós-merge: smoke test §15.3 (health + UI + 401 sem JWT)
- [ ] Pós-merge: bootstrap inicial schema §15.4 (Avro + listar subjects)

## Lições registradas

- Code-reviewer subagent ficou no fluxo (workflow §9, lição PR #131)
- Smoke E2E real ainda exige fresh data dir test pós-merge — nem reviewer nem Codex pegam bugs de runtime/integração (lição PRs #140→#149)

Closes #152