### PR TITLE
fix(apicurio): health probes — Apicurio 3.x não expõe /q/health/*

### DIFF
--- a/apps/apicurio-registry/templates/deployment.yaml
+++ b/apps/apicurio-registry/templates/deployment.yaml
@@ -153,20 +153,34 @@ spec:
             - secretRef:
                 name: {{ include "apicurioRegistry.oidcClientSecretName" . }}
           {{- end }}
+          # Health probes: Apicurio Registry 3.2.4 NÃO expõe `/q/health/*`
+          # do Quarkus SmallRye Health por default — esses paths retornam 404
+          # mesmo com pod totalmente up (validado runtime no cluster standalone
+          # 2026-05-08). A imagem `apicurio/apicurio-registry:3.2.4` desabilita
+          # ou move os endpoints health internos.
+          #
+          # Workaround: usar `/apis/registry/v3/system/info` que sempre retorna
+          # 200 quando o backend SQL está conectado (testa cold path básico:
+          # HTTP server up + JDBC pool inicializado + REST routing OK). Auth
+          # NÃO requerido nesse path (system info é público).
+          #
+          # Mesmo path para start/live/ready é OK em standalone (1 réplica,
+          # sem rolling restart agressivo); diferenciar entre fases requer
+          # health endpoints separados que Apicurio 3.x não expõe.
           startupProbe:
             httpGet:
-              path: /q/health/started
+              path: /apis/registry/v3/system/info
               port: http
             failureThreshold: {{ .Values.apicurioRegistry.startupProbe.failureThreshold }}
             periodSeconds: {{ .Values.apicurioRegistry.startupProbe.periodSeconds }}
           livenessProbe:
             httpGet:
-              path: /q/health/live
+              path: /apis/registry/v3/system/info
               port: http
             periodSeconds: {{ .Values.apicurioRegistry.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /q/health/ready
+              path: /apis/registry/v3/system/info
               port: http
             periodSeconds: {{ .Values.apicurioRegistry.readinessProbe.periodSeconds }}
           resources:

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2752,10 +2752,12 @@ APICURIO_DEPLOY=apicurio-registry-uniplus-standalone-apicurio-registry
 kc get pods -n uniplus -l app.kubernetes.io/name=apicurio-registry
 # READY 1/1, STATUS Running
 
-# 2. Health endpoints
+# 2. System info (substitui /q/health/* — Apicurio 3.2.4 desabilita
+# esses paths Quarkus default; use system/info como liveness/readiness
+# proxy: 200 quando JDBC pool ativo + REST routing up).
 kc exec -n uniplus "deploy/$APICURIO_DEPLOY" -- \
-  curl -s http://localhost:8080/q/health/ready
-# {"status":"UP","checks":[...]}
+  curl -s http://localhost:8080/apis/registry/v3/system/info
+# {"name":"Apicurio Registry (SQL)","description":"...","version":"3.2.4",...}
 
 # 3. OIDC discovery alcançável (deve retornar 200 com issuer)
 kc exec -n uniplus "deploy/$APICURIO_DEPLOY" -- \


### PR DESCRIPTION
## Hotfix do PR #155 — descoberto em smoke fresh deploy

Após merge do PR #155 + provisionamento operacional do Apicurio (DB no Postgres + custódia em Vault + criação manual do client OIDC via kcadm), o pod entrou em `Running` mas `startupProbe` falhava com 404 indefinidamente.

## Root cause

Imagem `apicurio/apicurio-registry:3.2.4` **NÃO expõe** os endpoints Quarkus SmallRye Health padrão. Validado no cluster standalone:

```
GET /q/health/started -> 404
GET /q/health/live    -> 404
GET /q/health/ready   -> 404
GET /q/health         -> 404
GET /q/metrics        -> 404
GET /health           -> 404
```

Mesmo no management port `9000`. A imagem upstream desabilita ou move esses endpoints — não há env var para reabilitar.

## Fix

`/apis/registry/v3/system/info` retorna 200 sempre quando o app está up:

```
{"name":"Apicurio Registry (SQL)","description":"...","version":"3.2.4","builtOn":"2026-05-04T14:07:42Z"}
```

Testa cold path canônico: HTTP server up + JDBC pool inicializado + REST routing OK. Sem auth requerido (system info é público — não viola anonymous-read OFF do app).

Mesmo path para start/live/ready é aceitável em standalone (1 réplica, sem rolling agressivo). Quando Apicurio 3.x expor health endpoints diferenciados por fase, refinar.

## Por que escapou do review

Mais um caso de bug que **só smoke fresh deploy mostra** (lição [`feedback_bootstrap_smoke_fresh.md`](https://github.com/unifesspa-edu-br/uniplus-infra/blob/main/docs/) — Codex/code-reviewer pegam código mas não cobrem comportamento runtime do upstream).

PR #155 passou:
- 3 P1 + 2 P2 do code-reviewer subagent (pré-PR)
- 8 P1 + 5 P2 do Codex em 9 rounds (com 1 bug runtime psql DO block reproduzido)
- 7/7 CI checks
- Codex 👍 final

Nenhum desses caminhos toca runtime do container Apicurio. Helm lint só valida sintaxe; CI não roda o pod.

## Test plan

- [x] `helm lint` ✓
- [x] `helm template` renderiza com novos paths ✓
- [ ] Pós-merge: ApplicationSet sincroniza, pod fica Ready
- [ ] Pós-merge: smoke completo §15.3 (UI 200 + 401 sem JWT) + §15.4 (token + register schema)