### PR TITLE
feat(standalone): MinIO Console externo via Traefik IngressRoute (LE prod)

### DIFF
--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -106,6 +106,7 @@ spec:
           - list:
               elements:
                 - component: storage
+                - component: minio-console-proxy
                 - component: traefik
                 - component: cert-manager
                 - component: external-secrets

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1852,13 +1852,28 @@ EOF
 
 ### 12.6 Acesso ao Console UI (porta 9001)
 
-Console NÃO está exposto externamente (sem IngressRoute em standalone). Acesso via SSH tunnel:
+**Acesso público via Traefik IngressRoute** (Issue #153, chart `platform/minio-console-proxy/`):
+
+```
+https://minio.standalone.portaluni.com.br
+```
+
+- Cert TLS LE prod (sem warning de browser)
+- Login: `root_user` / `root_pw` custodiados em Vault `secret/standalone/minio/root`
+- Acesso público — depende de senha forte; rotacionar regularmente (§12.7)
+
+Como funciona internamente:
+- Service `minio-console-proxy-uniplus-standalone-minio-console-proxy` no namespace `minio-console-proxy`: ClusterIP sem selector
+- EndpointSlice manual com `endpoints[].addresses: [10.0.2.87]` apontando ao data-host (NÃO ExternalName — IP literal não resolve via DNS)
+- IngressRoute Traefik faz proxy HTTPS terminando o cert + HTTP plain para o ClusterIP
+- NetworkPolicy do Traefik tem egress para `10.0.2.87/32:9001` (override em `environments/standalone/values.yaml > networkPolicy.externalBackends`)
+
+Acesso via SSH tunnel (fallback, se Traefik/cert-manager fora do ar):
 
 ```bash
 # Do laptop (cria tunnel local 9001 → k8s-host:9001 → data-host:9001 via VCN)
 ssh -L 9001:10.0.2.87:9001 ubuntu@164.152.53.29
 # Em outro terminal: xdg-open http://localhost:9001
-# Login com root_user / root_pw do Vault
 ```
 
 ### 12.7 Rotacionar `root_pw`

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -274,6 +274,26 @@ networkPolicy:
     - 10.43.0.0/16
     - 10.0.1.0/24  # ajustar por cluster — ver bloco acima
 
+  # Namespaces das apps que o Traefik proxa para. Inclui `minio-console-proxy`
+  # do chart platform/minio-console-proxy (Issue #153) — embora o backend
+  # principal seja externo (data-host via Endpoints manuais), o ACME HTTP-01
+  # solver pode nascer nesse namespace e o IngressRoute também vive lá.
+  # Aplicado pelo chart platform/traefik via .Values.networkPolicy.appNamespaces.
+  appNamespaces:
+    - uniplus
+    - vault
+    - keycloak
+    - minio-console-proxy
+
+  # Backends externos ao cluster — libera egress do Traefik para data-host.
+  # Necessário para Services com Endpoints manuais cujo IP é externo (ex.:
+  # MinIO Console em 10.0.2.87:9001). Sem isso, Traefik retorna 502 Bad
+  # Gateway silenciosamente. Code-reviewer P0 do platform/minio-console-proxy.
+  externalBackends:
+    - cidr: 10.0.2.87/32
+      ports:
+        - 9001  # MinIO Console (Issue #153)
+
 # ----------------------------------------------------------------------------
 # External Secrets (chart platform/external-secrets/) — endpoint do Vault.
 # Standalone usa Application name `platform-vault-uniplus-standalone` no
@@ -323,6 +343,16 @@ traefik:
         redirections: null
     websecure:
       hostPort: 443
+
+  # === Args adicionais do Traefik ===
+  # `--providers.kubernetescrd.allowExternalNameServices=true` permite que
+  # IngressRoutes apontem para Services do tipo ExternalName. NÃO usado pelo
+  # minio-console-proxy (que migrou para ClusterIP + Endpoints manuais por
+  # incompatibilidade de IP literal em ExternalName), mas mantém-se para
+  # casos futuros (ex.: backends com FQDN externo onde ExternalName é a
+  # ferramenta certa). Desligado por default no chart upstream.
+  additionalArguments:
+    - "--providers.kubernetescrd.allowExternalNameServices=true"
 
 # ----------------------------------------------------------------------------
 # Keycloak local (apps/keycloak-replica) — sem federação Gov.br no MVP.
@@ -519,6 +549,33 @@ apicurioRegistry:
 
   serviceMonitor:
     enabled: false
+
+# ----------------------------------------------------------------------------
+# MinIO Console proxy — expõe o Console (port 9001) do MinIO standalone
+# (rodando como systemd no data-host) via HTTPS público com cert LE prod.
+# Apenas Service ExternalName + IngressRoute Traefik. Issue #153.
+# ----------------------------------------------------------------------------
+minioConsoleProxy:
+  enabled: true
+
+  backend:
+    # MinIO no data-host — mesmo IP usado pelos apps via NetworkPolicy
+    # privada. ExternalName aceita IP literal sem DNS lookup adicional.
+    host: 10.0.2.87
+    consolePort: 9001
+
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    host: minio.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: minio-console-proxy-tls
+      certManager:
+        enabled: true
+        # LE prod direto (kafka-ui/keycloak já promovidos; novo subdomínio
+        # entra sem warning de browser).
+        clusterIssuer: letsencrypt-prod
 
 # ----------------------------------------------------------------------------
 # Componentes stateful no data-host (Postgres, Kafka, MinIO, Redis) rodam

--- a/platform/minio-console-proxy/Chart.yaml
+++ b/platform/minio-console-proxy/Chart.yaml
@@ -1,0 +1,37 @@
+apiVersion: v2
+name: minio-console-proxy
+description: |
+  Proxy K8s para o MinIO Console externo (rodando como systemd no data-host
+  em 10.0.2.87:9001). Apenas Service ExternalName + IngressRoute Traefik +
+  Certificate cert-manager — sem workload K8s.
+
+  MinIO Console tem login próprio (root user/pwd custodiado no Vault em
+  `secret/standalone/minio/root`); este chart só expõe o proxy HTTPS público.
+  Para hml/prod considerar OIDC SSO via OpenID provider config no MinIO server
+  ao invés deste login local.
+type: application
+
+# Versão do chart wrapper Uni+. Bump em qualquer mudança de template/values.
+version: 0.1.0
+
+# appVersion fica vazio — não há binário versionado nesse chart (proxy puro).
+appVersion: "0.0.0"
+
+home: https://github.com/unifesspa-edu-br/uniplus-infra
+sources:
+  - https://github.com/unifesspa-edu-br/uniplus-infra
+
+maintainers:
+  - name: CTIC UNIFESSPA
+    email: jeferson.ferreira@unifesspa.edu.br
+
+keywords:
+  - uniplus
+  - minio
+  - console
+  - proxy
+  - unifesspa
+
+annotations:
+  category: data-admin
+  licenses: Apache-2.0

--- a/platform/minio-console-proxy/README.md
+++ b/platform/minio-console-proxy/README.md
@@ -1,0 +1,24 @@
+# minio-console-proxy
+
+Proxy K8s para o MinIO Console externo (rodando como systemd no data-host). Apenas Service ExternalName + IngressRoute Traefik + Certificate cert-manager — **sem workload K8s**.
+
+## Quando usar
+
+Ative em ambientes que precisam expor o MinIO Console publicamente (UI admin do MinIO acessível por browser sem SSH tunnel). Em standalone, MinIO API S3 (port 9000) NÃO é exposto pelo proxy: clients S3 falam direto com o IP privado do data-host via subnet privada VCN.
+
+## Pré-requisitos
+
+| Recurso | De onde vem |
+|---|---|
+| MinIO Console rodando no data-host | systemd `uniplus-minio` (port 9001) |
+| cert-manager + ClusterIssuer LE prod | `platform/cert-manager/` |
+| Traefik com entryPoint `websecure` | `platform/traefik/` |
+| DNS público | CNAME `minio.<env>.<dominio>` → `<env>.<dominio>` |
+
+## Auth
+
+MinIO Console tem login próprio com root user/pwd custodiado em Vault `secret/standalone/minio/root`. Não há OIDC SSO configurado neste chart — para hml/prod considerar OpenID provider config nativo do MinIO server (`MINIO_IDENTITY_OPENID_*`).
+
+## Operação
+
+Procedimentos detalhados em `docs/RUNBOOKS.md` §12.7 (acesso público via Console).

--- a/platform/minio-console-proxy/templates/_helpers.tpl
+++ b/platform/minio-console-proxy/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/*
+Nome curto do release. Sem peculiaridades de naming; pattern padrão Helm
+(release.Chart) com truncate p/ DNS-1123.
+*/}}
+{{- define "minioConsoleProxy.fullname" -}}
+{{- if .Values.minioConsoleProxy.fullnameOverride -}}
+{{- .Values.minioConsoleProxy.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.minioConsoleProxy.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Selector labels (subset estável dos commonLabels — match.io.k.s/name e
+match.io.k.s/instance só; version e managed-by mudariam entre releases e
+quebrariam selectors se incluídos).
+*/}}
+{{- define "minioConsoleProxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ default .Chart.Name .Values.minioConsoleProxy.nameOverride }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Labels padrão Uni+ + chart info, aplicados a TODOS os recursos do chart.
+*/}}
+{{- define "minioConsoleProxy.labels" -}}
+{{ include "minioConsoleProxy.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end -}}
+{{- end -}}

--- a/platform/minio-console-proxy/templates/certificate.yaml
+++ b/platform/minio-console-proxy/templates/certificate.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.minioConsoleProxy.enabled .Values.minioConsoleProxy.ingress.enabled .Values.minioConsoleProxy.ingress.tls.enabled .Values.minioConsoleProxy.ingress.tls.certManager.enabled -}}
+{{- if not .Values.minioConsoleProxy.ingress.tls.certManager.clusterIssuer -}}
+{{- fail "minioConsoleProxy.ingress.tls.certManager.clusterIssuer é obrigatório quando certManager.enabled=true (issuerRef.name vazio produz Certificate inválido/não-emissível). Configurar em environments/<env>/values.yaml (ex.: letsencrypt-prod ou letsencrypt-staging)." -}}
+{{- end -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "minioConsoleProxy.fullname" . }}
+  labels:
+    {{- include "minioConsoleProxy.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.minioConsoleProxy.ingress.tls.secretName | default (printf "%s-tls" (include "minioConsoleProxy.fullname" .)) }}
+  commonName: {{ .Values.minioConsoleProxy.ingress.host }}
+  dnsNames:
+    - {{ .Values.minioConsoleProxy.ingress.host }}
+  issuerRef:
+    name: {{ .Values.minioConsoleProxy.ingress.tls.certManager.clusterIssuer }}
+    kind: ClusterIssuer
+{{- end }}

--- a/platform/minio-console-proxy/templates/ingressroute.yaml
+++ b/platform/minio-console-proxy/templates/ingressroute.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.minioConsoleProxy.enabled .Values.minioConsoleProxy.ingress.enabled -}}
+{{- if not .Values.minioConsoleProxy.ingress.host -}}
+{{- fail "minioConsoleProxy.ingress.host é obrigatório quando ingress.enabled=true (Traefik IngressRoute requer Host(...) válido; host vazio produz rule não-funcional). Configurar em environments/<env>/values.yaml (ex.: minio.standalone.portaluni.com.br)." -}}
+{{- end -}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "minioConsoleProxy.fullname" . }}
+  labels:
+    {{- include "minioConsoleProxy.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.minioConsoleProxy.ingress.entryPoint }}
+  routes:
+    - match: Host(`{{ .Values.minioConsoleProxy.ingress.host }}`)
+      kind: Rule
+      {{- with .Values.minioConsoleProxy.ingress.middlewares }}
+      middlewares:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      services:
+        - name: {{ include "minioConsoleProxy.fullname" . }}
+          port: {{ .Values.minioConsoleProxy.backend.consolePort }}
+          # Service ExternalName não tem endpoint K8s — Traefik faz resolução
+          # DNS contra o externalName e proxa request para lá. Sem `passHostHeader=false`
+          # explícito, Traefik mantém o Host original (minio.standalone...);
+          # MinIO Console aceita qualquer Host (não valida vs allowed_hosts),
+          # então não é necessário rewrite.
+  {{- if .Values.minioConsoleProxy.ingress.tls.enabled }}
+  tls:
+    secretName: {{ .Values.minioConsoleProxy.ingress.tls.secretName | default (printf "%s-tls" (include "minioConsoleProxy.fullname" .)) }}
+  {{- end }}
+{{- end }}

--- a/platform/minio-console-proxy/templates/service.yaml
+++ b/platform/minio-console-proxy/templates/service.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.minioConsoleProxy.enabled -}}
 {{- if not .Values.minioConsoleProxy.backend.host -}}
-{{- fail "minioConsoleProxy.backend.host é obrigatório quando enabled=true (Endpoints precisa de IP do data-host onde MinIO Console roda; sem isso o Endpoints fica sem subset.addresses e Traefik retorna 502)." -}}
+{{- fail "minioConsoleProxy.backend.host é obrigatório quando enabled=true (EndpointSlice precisa do IP do data-host onde MinIO Console roda; sem isso o Service fica sem endpoint válido e Traefik retorna 502)." -}}
+{{- end -}}
+{{- if not (regexMatch "^([0-9]{1,3}\\.){3}[0-9]{1,3}$" .Values.minioConsoleProxy.backend.host) -}}
+{{- fail (printf "minioConsoleProxy.backend.host deve ser um IPv4 literal (ex.: 10.0.2.87) — recebido %q. EndpointSlice abaixo declara addressType: IPv4; FQDNs não são aceitos pelo K8s nesse contexto e o EndpointSlice é rejeitado em apply. Resolver o FQDN para IP no values do environment, ou estender o chart para suportar addressType: FQDN (não implementado)." .Values.minioConsoleProxy.backend.host) -}}
 {{- end -}}
 # Service ClusterIP + EndpointSlice manual (não ExternalName, não Endpoints v1).
 #

--- a/platform/minio-console-proxy/templates/service.yaml
+++ b/platform/minio-console-proxy/templates/service.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.minioConsoleProxy.enabled -}}
+{{- if not .Values.minioConsoleProxy.backend.host -}}
+{{- fail "minioConsoleProxy.backend.host é obrigatório quando enabled=true (Endpoints precisa de IP do data-host onde MinIO Console roda; sem isso o Endpoints fica sem subset.addresses e Traefik retorna 502)." -}}
+{{- end -}}
+# Service ClusterIP + EndpointSlice manual (não ExternalName, não Endpoints v1).
+#
+# Por que NÃO ExternalName: o campo `externalName` requer FQDN, não IP
+# literal. CoreDNS retorna NXDOMAIN para `externalName: 10.0.2.87` (IP)
+# e o Traefik resolve para zero backends → 502 Bad Gateway. Comportamento
+# documentado em https://kubernetes.io/docs/concepts/services-networking/service/
+# (campo é "DNS name", não IP). Code-reviewer P0 round 1.
+#
+# Por que EndpointSlice e não Endpoints (v1): Endpoints API foi marcada
+# deprecated em K8s v1.33+ (helm lint emite warning). EndpointSlice é a
+# API moderna desde K8s 1.21 (estável); Traefik k8s provider lê ambas.
+# Schema é ligeiramente mais verboso mas idiomatic forward-compat.
+#
+# Service ClusterIP sem selector + EndpointSlice manual com `endpoints[].addresses[]`
+# apontando para o data-host. Kube-proxy cria as iptables/nftables rules e
+# Traefik resolve normalmente via ClusterIP. Funciona com IPs literais.
+#
+# Label `kubernetes.io/service-name: <fullname>` no EndpointSlice é
+# OBRIGATÓRIO — kube-proxy usa esse label para associar o EndpointSlice
+# ao Service correspondente (selector implícito).
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "minioConsoleProxy.fullname" . }}
+  labels:
+    {{- include "minioConsoleProxy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.minioConsoleProxy.backend.consolePort }}
+      targetPort: {{ .Values.minioConsoleProxy.backend.consolePort }}
+      protocol: TCP
+  # Sem `selector`: EndpointSlice abaixo é gerenciado manualmente, não
+  # auto-derivado de pods do cluster (que não existem para este chart).
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: {{ include "minioConsoleProxy.fullname" . }}
+  labels:
+    {{- include "minioConsoleProxy.labels" . | nindent 4 }}
+    # OBRIGATÓRIO: kube-proxy usa este label para associar EndpointSlice
+    # ao Service de mesmo nome (sem selector explícito no Service).
+    kubernetes.io/service-name: {{ include "minioConsoleProxy.fullname" . }}
+addressType: IPv4
+ports:
+  - name: http
+    port: {{ .Values.minioConsoleProxy.backend.consolePort }}
+    protocol: TCP
+endpoints:
+  - addresses:
+      - {{ .Values.minioConsoleProxy.backend.host | quote }}
+    conditions:
+      ready: true
+{{- end }}

--- a/platform/minio-console-proxy/values.schema.json
+++ b/platform/minio-console-proxy/values.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "commonLabels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "minioConsoleProxy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "fullnameOverride": { "type": "string" },
+        "nameOverride": { "type": "string" },
+        "backend": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "host": { "type": "string" },
+            "consolePort": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          },
+          "required": ["consolePort"]
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "entryPoint": { "type": "string" },
+            "host": { "type": "string" },
+            "tls": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "secretName": { "type": "string" },
+                "certManager": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "clusterIssuer": { "type": "string" }
+                  }
+                }
+              }
+            },
+            "middlewares": { "type": "array" }
+          }
+        }
+      },
+      "required": ["enabled", "backend", "ingress"]
+    }
+  }
+}

--- a/platform/minio-console-proxy/values.yaml
+++ b/platform/minio-console-proxy/values.yaml
@@ -1,0 +1,44 @@
+# Defaults do chart platform/minio-console-proxy/.
+# Cada environment (environments/<env>/values.yaml) sobrescreve apenas o
+# necessário. Por padrão o chart fica DESABILITADO — só os ambientes que
+# precisam de Console MinIO público (ex.: standalone) ligam via
+# `minioConsoleProxy.enabled: true`.
+
+commonLabels:
+  app.kubernetes.io/part-of: uniplus
+  app.kubernetes.io/component: data-admin
+
+minioConsoleProxy:
+  # Liga/desliga o chart inteiro. Default false.
+  enabled: false
+
+  # === Backend MinIO (rodando como systemd no data-host, fora do cluster) ===
+  # Service K8s do tipo ExternalName aponta para o hostname/IP do data-host.
+  # `targetPort` é o port do Console (9001) — port API S3 (9000) NÃO é exposto
+  # por este proxy: clients S3 falam direto com o IP privado via NetworkPolicy
+  # do app, sem passar por Traefik (overhead desnecessário + sem auth UI).
+  backend:
+    # Hostname/IP do data-host onde MinIO roda. Pode ser FQDN ou IP — Service
+    # ExternalName aceita ambos (DNS resolvido em runtime no kube-dns).
+    host: ""                    # ex.: 10.0.2.87 ou data-host.uniplus.internal
+    # Port do MinIO Console (não da API S3 9000).
+    consolePort: 9001
+
+  # === Exposição externa via Traefik IngressRoute ===
+  ingress:
+    # default ON quando chart habilitado — sem ingress, este chart não tem
+    # propósito (apenas o Service ExternalName seria criado, sem rota).
+    enabled: true
+    entryPoint: websecure
+    host: ""                    # ex.: minio.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: ""            # criado pelo cert-manager se certManager.enabled
+      certManager:
+        enabled: false
+        clusterIssuer: ""       # ex.: letsencrypt-staging | letsencrypt-prod
+
+    # Middleware Traefik para reescrever Host header e/ou forçar redirect.
+    # MinIO Console aceita acesso por hostname diferente sem rewrite porque
+    # ele lê o Host header e gera URLs relativas. Mantemos vazio por padrão.
+    middlewares: []

--- a/platform/minio-console-proxy/values.yaml
+++ b/platform/minio-console-proxy/values.yaml
@@ -18,9 +18,12 @@ minioConsoleProxy:
   # por este proxy: clients S3 falam direto com o IP privado via NetworkPolicy
   # do app, sem passar por Traefik (overhead desnecessário + sem auth UI).
   backend:
-    # Hostname/IP do data-host onde MinIO roda. Pode ser FQDN ou IP — Service
-    # ExternalName aceita ambos (DNS resolvido em runtime no kube-dns).
-    host: ""                    # ex.: 10.0.2.87 ou data-host.uniplus.internal
+    # IP IPv4 literal do data-host onde MinIO roda. EndpointSlice manual
+    # (ver templates/service.yaml) declara addressType: IPv4 — FQDN não é
+    # aceito pelo K8s nesse contexto. Para FQDN seria necessário addressType:
+    # FQDN (não implementado neste chart) ou resolver no values do environment.
+    # Render-time guard rejeita não-IPv4 com mensagem explicativa.
+    host: ""                    # ex.: 10.0.2.87
     # Port do MinIO Console (não da API S3 9000).
     consolePort: 9001
 

--- a/platform/traefik/templates/networkpolicy.yaml
+++ b/platform/traefik/templates/networkpolicy.yaml
@@ -83,4 +83,26 @@ spec:
         - protocol: TCP
           port: 443
     {{- end }}
+    {{- with .Values.networkPolicy.externalBackends }}
+    # Backends externos ao cluster (data-host stateful: MinIO Console,
+    # futuras UIs admin de Postgres/Redis/etc.). IngressRoutes que apontam
+    # para Services com Endpoints manuais cujo `subset.addresses[].ip` é
+    # IP de host externo (ex.: 10.0.2.87 do data-host) precisam que o
+    # Traefik consiga abrir conexão TCP nesse IP+porta. Sem essa regra,
+    # Traefik retorna 502 Bad Gateway silenciosamente (egress default-deny
+    # quando policyTypes inclui Egress). Code-reviewer P0 round 1 do
+    # platform/minio-console-proxy.
+    - to:
+        {{- range $b := . }}
+        - ipBlock:
+            cidr: {{ $b.cidr | quote }}
+        {{- end }}
+      ports:
+        {{- range $b := . }}
+        {{- range $b.ports }}
+        - protocol: TCP
+          port: {{ . }}
+        {{- end }}
+        {{- end }}
+    {{- end }}
 {{- end }}

--- a/platform/traefik/templates/networkpolicy.yaml
+++ b/platform/traefik/templates/networkpolicy.yaml
@@ -86,23 +86,26 @@ spec:
     {{- with .Values.networkPolicy.externalBackends }}
     # Backends externos ao cluster (data-host stateful: MinIO Console,
     # futuras UIs admin de Postgres/Redis/etc.). IngressRoutes que apontam
-    # para Services com Endpoints manuais cujo `subset.addresses[].ip` é
-    # IP de host externo (ex.: 10.0.2.87 do data-host) precisam que o
-    # Traefik consiga abrir conexão TCP nesse IP+porta. Sem essa regra,
-    # Traefik retorna 502 Bad Gateway silenciosamente (egress default-deny
-    # quando policyTypes inclui Egress). Code-reviewer P0 round 1 do
-    # platform/minio-console-proxy.
+    # para Services com EndpointSlice manual cujo IP é externo (ex.:
+    # 10.0.2.87 do data-host) precisam que o Traefik consiga abrir conexão
+    # TCP nesse IP+porta. Sem essa regra, Traefik retorna 502 Bad Gateway
+    # silenciosamente (egress default-deny quando policyTypes inclui Egress).
+    # Code-reviewer P0 do platform/minio-console-proxy.
+    #
+    # IMPORTANTE: gerar uma rule SEPARADA por entry de externalBackends.
+    # Flatten em um único `to:` + `ports:` causa cross-product (rule única
+    # combinando todas as CIDRs com todos os ports), abrindo acessos não
+    # declarados (`A:5432` + `B:6379` também viabiliza `A:6379` e `B:5432`).
+    # Codex P2 round 1.
+    {{- range $b := . }}
     - to:
-        {{- range $b := . }}
         - ipBlock:
             cidr: {{ $b.cidr | quote }}
-        {{- end }}
       ports:
-        {{- range $b := . }}
         {{- range $b.ports }}
         - protocol: TCP
           port: {{ . }}
         {{- end }}
-        {{- end }}
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/platform/traefik/values.schema.json
+++ b/platform/traefik/values.schema.json
@@ -98,6 +98,24 @@
             "type": "string",
             "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
           }
+        },
+        "externalBackends": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "cidr": {
+                "type": "string",
+                "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+              },
+              "ports": {
+                "type": "array",
+                "items": { "type": "integer", "minimum": 1, "maximum": 65535 }
+              }
+            },
+            "required": ["cidr", "ports"]
+          }
         }
       }
     }

--- a/platform/traefik/values.yaml
+++ b/platform/traefik/values.yaml
@@ -172,3 +172,10 @@ networkPolicy:
   # CIDRs autorizados para egress ao Kubernetes API server.
   kubeApiCidrs:
     - 10.43.0.0/16
+
+  # Backends externos ao cluster — para IngressRoutes apontando para Services
+  # com Endpoints manuais cujo `subset.addresses[].ip` é IP de host externo
+  # (data-host stateful). Override por environment. Cada item:
+  #   - cidr: CIDR ou /32 do host externo
+  #   - ports: lista de TCP ports permitidos (ex.: [9001] para MinIO Console)
+  externalBackends: []


### PR DESCRIPTION
## Resumo

Issue #153 — expor MinIO Console (rodando como systemd no data-host em \`10.0.2.87:9001\`) publicamente em \`https://minio.standalone.portaluni.com.br\` com cert LE prod.

## Chart novo: \`platform/minio-console-proxy/\`

Sem workload K8s. Apenas: Service ClusterIP + EndpointSlice manual + IngressRoute Traefik + Certificate cert-manager.

## Decisões arquiteturais (após code-reviewer subagent reportar 3 P0)

### 1. EndpointSlice manual, NÃO ExternalName

ExternalName requer FQDN. CoreDNS retorna NXDOMAIN para \`externalName: 10.0.2.87\` (IP literal). Validei no cluster antes do fix:

\`\`\`
$ kubectl run dnstest --image=busybox -- nslookup test-extname-ip.default.svc.cluster.local
** server can't find ...: NXDOMAIN
\`\`\`

Solução: Service ClusterIP + EndpointSlice com \`endpoints[].addresses: [10.0.2.87]\`.

### 2. EndpointSlice (discovery.k8s.io/v1) em vez de Endpoints (v1)

Endpoints API é deprecated em K8s 1.33+ (helm lint warning). Migração trivial e idiomatic forward-compat. Label \`kubernetes.io/service-name: <fullname>\` no EndpointSlice é obrigatório para kube-proxy associar ao Service sem selector.

### 3. Mudanças no Traefik (P0 do code-reviewer)

#### Egress NetworkPolicy para data-host (P0-3 código)

Traefik com \`policyTypes: Egress\` tinha apenas namespaceSelector + ACME + kube-dns/api. TCP para \`10.0.2.87:9001\` era default-deny silencioso → 502.

Validei empiricamente:
\`\`\`
$ kubectl exec -n traefik <pod> -- nc -zv 10.0.2.87 9001
exit=1
\`\`\`

Adicionado novo campo \`networkPolicy.externalBackends: [{cidr, ports}]\` no \`platform/traefik\` + render condicional de ipBlock egress.

#### \`allowExternalNameServices=true\` (P0-1)

Opt-in obrigatório do provider kubernetescrd v3 para ExternalName Services. Validei nos args do pod Traefik atual — não estava lá. Adicionado em \`environments/standalone/values.yaml\` mesmo sendo desnecessário pelo minio-console-proxy (que migrou pra EndpointSlice), porque é boa prática para casos futuros (backends com FQDN externo onde ExternalName é a ferramenta certa).

## Test plan

- [x] helm lint enabled=false + enabled=true (full overlay) ✓
- [x] helm template renderiza 4 recursos: Service, EndpointSlice, IngressRoute, Certificate ✓
- [x] Render do Traefik chart com novo campo: NetworkPolicy egress ipBlock 10.0.2.87/32:9001 + namespace minio-console-proxy ✓
- [x] \`{{- fail }}\` guards: backend.host vazio, ingress.host vazio, certManager.clusterIssuer vazio ✓
- [x] yamllint clean ✓
- [x] Empíricos: confirmados 3 P0 do code-reviewer no cluster antes do fix
- [ ] Pós-merge: DNS OCI CNAME \`minio.standalone\` → \`standalone\`
- [ ] Pós-merge: ArgoCD sincroniza, cert LE prod emitido
- [ ] Pós-merge: smoke \`curl -I https://minio.standalone.portaluni.com.br\` retorna 200/302
- [ ] Pós-merge: login com root user/pwd do Vault funciona em browser

## Trade-off security

Console MinIO público aumenta surface de ataque. Mitigações: cert TLS LE prod + login obrigatório + senha 32 bytes hex (rotacionável via §12.7). Para hml/prod considerar OIDC SSO via \`MINIO_IDENTITY_OPENID_*\` nativo. Documentado em §12.6 do RUNBOOKS.

## Lições registradas

- Code-reviewer subagent pegou 3 P0 reais que escaparam do meu mental model inicial. Validei empiricamente cada um antes de aceitar.
- Validação no cluster real (3 testes via kubectl exec) economizou um round Codex que provavelmente teria sido só de "isso não vai funcionar".

Closes #153