### PR TITLE
feat(standalone): RedisInsight UI com Traefik basicAuth + Redis pre-setup

### DIFF
--- a/apps/redis-ui/Chart.yaml
+++ b/apps/redis-ui/Chart.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+name: redis-ui
+description: |
+  Web UI para o Redis standalone — RedisInsight (Redis Inc., Apache 2.0).
+  Inspeção/admin de keys, TTL, memory usage, RESP commands. Conecta ao
+  Redis 8.6.3 systemd no data-host (10.0.2.87:6379).
+
+  Auth: RedisInsight 2.x NÃO tem auth nativo. Protegido via Traefik
+  basicAuth middleware (htpasswd custodiado em Vault). Para SSO via
+  Keycloak considerar futuro Traefik forwardAuth + oauth2-proxy.
+type: application
+
+version: 0.1.0
+
+appVersion: "2.74.0"
+
+home: https://github.com/unifesspa-edu-br/uniplus-infra
+sources:
+  - https://github.com/unifesspa-edu-br/uniplus-infra
+  - https://github.com/RedisInsight/RedisInsight
+
+maintainers:
+  - name: CTIC UNIFESSPA
+    email: jeferson.ferreira@unifesspa.edu.br
+
+keywords:
+  - uniplus
+  - redis
+  - redisinsight
+  - admin
+  - unifesspa
+
+annotations:
+  category: data-admin
+  licenses: Apache-2.0

--- a/apps/redis-ui/README.md
+++ b/apps/redis-ui/README.md
@@ -1,0 +1,35 @@
+# redis-ui
+
+RedisInsight 2.x (Redis Inc., Apache 2.0) como UI de admin/inspect para o Redis 8.6.3 standalone (`10.0.2.87:6379`).
+
+## Quando usar
+
+Ative apenas em ambientes que precisam de UI Redis (debug operacional, ver keys/TTL/memory). Em standalone roda 1 réplica conectando ao Redis systemd no data-host via subnet privada VCN.
+
+## Auth
+
+RedisInsight 2.x **não tem auth nativa**. Proteção via Traefik `basicAuth` middleware (htpasswd bcrypt custodiado em Vault em `secret/standalone/redis-ui/basic-auth`). Operador gera uma vez:
+
+```bash
+htpasswd -nbB <username> <senha>
+# saída: username:$2y$05$<bcrypt_hash>
+```
+
+Custodia em Vault e o ESO sintetiza Secret K8s no formato Traefik espera.
+
+Para SSO via Keycloak no futuro, considerar Traefik `forwardAuth` middleware + oauth2-proxy.
+
+## Connection pré-setup
+
+Backend Redis pré-cadastrado via env vars `RI_REDIS_*`. Aparece automaticamente no UI no primeiro acesso. Em standalone:
+
+| Env | Valor |
+|---|---|
+| `RI_REDIS_HOST` | `10.0.2.87` |
+| `RI_REDIS_PORT` | `6379` |
+| `RI_REDIS_USERNAME` | `default` |
+| `RI_REDIS_PASSWORD` | (do Vault `secret/standalone/redis/default`) |
+
+## Operação
+
+Procedimentos detalhados em `docs/RUNBOOKS.md` §16.

--- a/apps/redis-ui/templates/_helpers.tpl
+++ b/apps/redis-ui/templates/_helpers.tpl
@@ -1,0 +1,59 @@
+{{/*
+Nome curto do release. RedisInsight não tem peculiaridades de naming;
+pattern padrão Helm (release.Chart) com truncate p/ DNS-1123.
+*/}}
+{{- define "redisUi.fullname" -}}
+{{- if .Values.redisUi.fullnameOverride -}}
+{{- .Values.redisUi.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.redisUi.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Selector labels (subset estável).
+*/}}
+{{- define "redisUi.selectorLabels" -}}
+app.kubernetes.io/name: {{ default .Chart.Name .Values.redisUi.nameOverride }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Labels padrão Uni+ + chart info.
+*/}}
+{{- define "redisUi.labels" -}}
+{{ include "redisUi.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "redisUi.serviceAccountName" -}}
+{{- if .Values.redisUi.serviceAccount.create -}}
+{{- default (printf "%s-sa" (include "redisUi.fullname" .)) .Values.redisUi.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.redisUi.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Nomes dos Secrets sintetizados pelo ESO.
+*/}}
+{{- define "redisUi.redisDefaultSecretName" -}}
+{{ include "redisUi.fullname" . }}-redis
+{{- end -}}
+
+{{- define "redisUi.basicAuthSecretName" -}}
+{{ include "redisUi.fullname" . }}-basic-auth
+{{- end -}}
+
+{{- define "redisUi.basicAuthMiddlewareName" -}}
+{{ include "redisUi.fullname" . }}-basic-auth
+{{- end -}}

--- a/apps/redis-ui/templates/certificate.yaml
+++ b/apps/redis-ui/templates/certificate.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.redisUi.enabled .Values.redisUi.ingress.enabled .Values.redisUi.ingress.tls.enabled .Values.redisUi.ingress.tls.certManager.enabled -}}
+{{- if not .Values.redisUi.ingress.tls.certManager.clusterIssuer -}}
+{{- fail "redisUi.ingress.tls.certManager.clusterIssuer é obrigatório quando certManager.enabled=true. Configurar em environments/<env>/values.yaml (ex.: letsencrypt-prod ou letsencrypt-staging)." -}}
+{{- end -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "redisUi.fullname" . }}
+  labels:
+    {{- include "redisUi.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.redisUi.ingress.tls.secretName | default (printf "%s-tls" (include "redisUi.fullname" .)) }}
+  commonName: {{ .Values.redisUi.ingress.host }}
+  dnsNames:
+    - {{ .Values.redisUi.ingress.host }}
+  issuerRef:
+    name: {{ .Values.redisUi.ingress.tls.certManager.clusterIssuer }}
+    kind: ClusterIssuer
+{{- end }}

--- a/apps/redis-ui/templates/deployment.yaml
+++ b/apps/redis-ui/templates/deployment.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.redisUi.enabled -}}
+{{- if not .Values.redisUi.backend.host -}}
+{{- fail "redisUi.backend.host é obrigatório quando enabled=true (sem isso, RedisInsight pre-setup connection fica inválida e a UI sobe sem conexão pré-cadastrada). Configurar em environments/<env>/values.yaml." -}}
+{{- end -}}
+{{- if not .Values.redisUi.externalSecrets.enabled -}}
+{{- fail "redisUi.enabled=true requer externalSecrets.enabled=true. Deployment lê REDIS_PASSWORD do Secret `<fullname>-redis` via secretKeyRef (sem ele o pod entra em CreateContainerConfigError). Habilite externalSecrets ou desabilite o chart." -}}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "redisUi.fullname" . }}
+  labels:
+    {{- include "redisUi.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.redisUi.replicas }}
+  # RedisInsight tem state local (SQLite em /data) — Recreate para evitar
+  # contention de SQLite entre pods. Single-replica é o pattern correto;
+  # multi-replica não dá ganho (cada pod tem state isolado em emptyDir).
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "redisUi.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "redisUi.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "redisUi.serviceAccountName" . }}
+      {{- with .Values.redisUi.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.redisUi.podSecurityContext | nindent 8 }}
+      containers:
+        - name: redisinsight
+          image: "{{ .Values.redisUi.image.registry }}/{{ .Values.redisUi.image.repository }}:{{ .Values.redisUi.image.tag }}"
+          imagePullPolicy: {{ .Values.redisUi.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.redisUi.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 5540
+              protocol: TCP
+          env:
+            # Server config — RedisInsight 2.x roda em port 5540.
+            - name: RI_APP_PORT
+              value: "5540"
+            - name: RI_APP_HOST
+              value: "0.0.0.0"
+            # Aceita EULA explicitamente (sem isso UI exibe banner consent
+            # bloqueando primeiro acesso). Comportamento documentado em
+            # https://redis.io/docs/latest/operate/redisinsight/configuration/.
+            - name: RI_ACCEPT_TERMS_AND_CONDITIONS
+              value: "true"
+            # Pre-setup connection (sem ID = conexão única default).
+            # Ao bootar, RedisInsight cria essa conexão automaticamente
+            # apontando para o Redis standalone no data-host.
+            - name: RI_REDIS_HOST
+              value: {{ .Values.redisUi.backend.host | quote }}
+            - name: RI_REDIS_PORT
+              value: {{ .Values.redisUi.backend.port | quote }}
+            - name: RI_REDIS_ALIAS
+              value: {{ .Values.redisUi.backend.alias | quote }}
+            - name: RI_REDIS_USERNAME
+              value: {{ .Values.redisUi.backend.username | quote }}
+            - name: RI_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "redisUi.redisDefaultSecretName" . }}
+                  key: REDIS_PASSWORD
+            # TLS=false: Redis standalone aceita conexões plaintext na
+            # subnet privada VCN. NetworkPolicy restringe egress para
+            # 10.0.2.87:6379 apenas — sem exposição externa.
+            - name: RI_REDIS_TLS
+              value: "false"
+            {{- with .Values.redisUi.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            # SQLite local + connections persistidas durante lifetime do pod.
+            # emptyDir é OK — env vars RI_REDIS_* re-aplicam pre-setup em
+            # cada restart.
+            - name: data
+              mountPath: /data
+          startupProbe:
+            httpGet:
+              path: /api/health/
+              port: http
+            failureThreshold: {{ .Values.redisUi.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.redisUi.startupProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /api/health/
+              port: http
+            periodSeconds: {{ .Values.redisUi.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /api/health/
+              port: http
+            periodSeconds: {{ .Values.redisUi.readinessProbe.periodSeconds }}
+          resources:
+            {{- toYaml .Values.redisUi.resources | nindent 12 }}
+      volumes:
+        - name: data
+          emptyDir: {}
+{{- end }}

--- a/apps/redis-ui/templates/externalsecret.yaml
+++ b/apps/redis-ui/templates/externalsecret.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.redisUi.enabled .Values.redisUi.externalSecrets.enabled -}}
+# ESO 1: senha do role `default` do Redis standalone (custodiada em PR #133).
+# Sintetizado em Secret K8s com 1 key REDIS_PASSWORD, consumida via env
+# RI_REDIS_PASSWORD no Deployment (RedisInsight pre-setup connection).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "redisUi.redisDefaultSecretName" . }}
+  labels:
+    {{- include "redisUi.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.redisUi.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ .Values.redisUi.externalSecrets.secretStoreRef.kind }}
+    name: {{ .Values.redisUi.externalSecrets.secretStoreRef.name }}
+  target:
+    name: {{ include "redisUi.redisDefaultSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: REDIS_PASSWORD
+      remoteRef:
+        key: {{ .Values.redisUi.externalSecrets.redisDefault.vaultPath }}
+        property: {{ .Values.redisUi.externalSecrets.redisDefault.passwordKey }}
+---
+# ESO 2: htpasswd para basic auth via Traefik middleware. Operador gera
+# uma vez (`htpasswd -nbB user senha`) e custodia em Vault no path do
+# values. Formato esperado pelo Traefik: linhas no formato
+# `username:$2y$05$<bcrypt_hash>` (uma linha por usuário). Bcrypt é
+# obrigatório — Traefik não aceita md5/sha (Apache htpasswd defaults).
+#
+# Secret sintetizado tem key `users` (convenção Traefik basicAuth
+# middleware com `secret:` referência — campo `users` é lido como linha
+# unica multi-user separada por \n).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "redisUi.basicAuthSecretName" . }}
+  labels:
+    {{- include "redisUi.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.redisUi.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ .Values.redisUi.externalSecrets.secretStoreRef.kind }}
+    name: {{ .Values.redisUi.externalSecrets.secretStoreRef.name }}
+  target:
+    name: {{ include "redisUi.basicAuthSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: users
+      remoteRef:
+        key: {{ .Values.redisUi.externalSecrets.basicAuth.vaultPath }}
+        property: {{ .Values.redisUi.externalSecrets.basicAuth.htpasswdKey }}
+{{- end }}

--- a/apps/redis-ui/templates/ingressroute.yaml
+++ b/apps/redis-ui/templates/ingressroute.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.redisUi.enabled .Values.redisUi.ingress.enabled -}}
+{{- if not .Values.redisUi.ingress.host -}}
+{{- fail "redisUi.ingress.host é obrigatório quando ingress.enabled=true (Traefik IngressRoute requer Host(...) válido). Configurar em environments/<env>/values.yaml (ex.: redis-ui.standalone.portaluni.com.br)." -}}
+{{- end -}}
+{{- if not .Values.redisUi.externalSecrets.enabled -}}
+{{- fail "redisUi.ingress.enabled=true requer externalSecrets.enabled=true. IngressRoute referencia o middleware basicAuth, que depende do Secret htpasswd sintetizado pelo ESO. Sem ESO, o middleware fica sem Secret válido e Traefik rejeita o IngressRoute. (Defense-in-depth: o deployment.yaml também tem este guard.)" -}}
+{{- end -}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "redisUi.fullname" . }}
+  labels:
+    {{- include "redisUi.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.redisUi.ingress.entryPoint }}
+  routes:
+    - match: Host(`{{ .Values.redisUi.ingress.host }}`)
+      kind: Rule
+      middlewares:
+        # basicAuth obrigatório — RedisInsight 2.x não tem auth nativa.
+        # Middleware vive no mesmo namespace que o IngressRoute (uniplus
+        # via ApplicationSet uniplus-apps). Ref: templates/middleware.yaml.
+        - name: {{ include "redisUi.basicAuthMiddlewareName" . }}
+      services:
+        - name: {{ include "redisUi.fullname" . }}
+          port: 5540
+  {{- if .Values.redisUi.ingress.tls.enabled }}
+  tls:
+    secretName: {{ .Values.redisUi.ingress.tls.secretName | default (printf "%s-tls" (include "redisUi.fullname" .)) }}
+  {{- end }}
+{{- end }}

--- a/apps/redis-ui/templates/middleware.yaml
+++ b/apps/redis-ui/templates/middleware.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.redisUi.enabled .Values.redisUi.ingress.enabled .Values.redisUi.externalSecrets.enabled -}}
+# Traefik middleware basicAuth — protege o IngressRoute do RedisInsight UI.
+# RedisInsight 2.x não tem auth nativa, então a proteção fica na borda do
+# Traefik. Senha em htpasswd format (bcrypt) custodiada em Vault e
+# sintetizada como Secret K8s com key `users` pelo ESO acima.
+#
+# Traefik referencia o Secret pelo nome no campo `basicAuth.secret`.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "redisUi.basicAuthMiddlewareName" . }}
+  labels:
+    {{- include "redisUi.labels" . | nindent 4 }}
+spec:
+  basicAuth:
+    secret: {{ include "redisUi.basicAuthSecretName" . }}
+    realm: "RedisInsight Uni+"
+    # removeHeader=true tira o header Authorization antes de proxar pro
+    # backend. RedisInsight ignora Authorization (não tem auth nativa)
+    # mas remover é boa prática (evita leak de credenciais para o app).
+    removeHeader: true
+{{- end }}

--- a/apps/redis-ui/templates/networkpolicy.yaml
+++ b/apps/redis-ui/templates/networkpolicy.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.redisUi.enabled .Values.redisUi.networkPolicy.enabled -}}
+{{- if not .Values.redisUi.networkPolicy.dataHostCIDR -}}
+{{- fail "redisUi.networkPolicy.dataHostCIDR é obrigatório quando networkPolicy.enabled=true (sem isso o egress para Redis data-host fica em default-deny silencioso e RedisInsight nunca consegue conectar ao backend pré-cadastrado). Configurar em environments/<env>/values.yaml." -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "redisUi.fullname" . }}
+  labels:
+    {{- include "redisUi.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "redisUi.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # HTTP do Traefik (apenas pods do namespace traefik).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.redisUi.networkPolicy.traefikNamespace }}
+      ports:
+        - protocol: TCP
+          port: 5540
+  egress:
+    # DNS (CoreDNS).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Redis data-host (subnet privada VCN).
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.redisUi.networkPolicy.dataHostCIDR }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.redisUi.networkPolicy.dataHostPort }}
+{{- end }}

--- a/apps/redis-ui/templates/service.yaml
+++ b/apps/redis-ui/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.redisUi.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "redisUi.fullname" . }}
+  labels:
+    {{- include "redisUi.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 5540
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "redisUi.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/apps/redis-ui/templates/serviceaccount.yaml
+++ b/apps/redis-ui/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.redisUi.enabled .Values.redisUi.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "redisUi.serviceAccountName" . }}
+  labels:
+    {{- include "redisUi.labels" . | nindent 4 }}
+{{- end }}

--- a/apps/redis-ui/values.schema.json
+++ b/apps/redis-ui/values.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "commonLabels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "redisUi": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "registry": { "type": "string" },
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "enum": ["Always", "IfNotPresent", "Never"] }
+          },
+          "required": ["registry", "repository", "tag", "pullPolicy"]
+        },
+        "imagePullSecrets": { "type": "array" },
+        "fullnameOverride": { "type": "string" },
+        "nameOverride": { "type": "string" },
+        "replicas": { "type": "integer", "minimum": 1 },
+        "resources": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "serviceAccount": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "create": { "type": "boolean" },
+            "name": { "type": "string" }
+          }
+        },
+        "backend": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "host": { "type": "string" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "alias": { "type": "string", "minLength": 1 },
+            "username": { "type": "string", "minLength": 1 }
+          },
+          "required": ["port", "alias", "username"]
+        },
+        "externalSecrets": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "refreshInterval": { "type": "string" },
+            "secretStoreRef": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "kind": { "enum": ["ClusterSecretStore", "SecretStore"] },
+                "name": { "type": "string" }
+              },
+              "required": ["kind", "name"]
+            },
+            "redisDefault": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "vaultPath": { "type": "string" },
+                "passwordKey": { "type": "string" }
+              },
+              "required": ["vaultPath", "passwordKey"]
+            },
+            "basicAuth": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "vaultPath": { "type": "string" },
+                "htpasswdKey": { "type": "string" }
+              },
+              "required": ["vaultPath", "htpasswdKey"]
+            }
+          }
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "entryPoint": { "type": "string" },
+            "host": { "type": "string" },
+            "tls": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "secretName": { "type": "string" },
+                "certManager": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "clusterIssuer": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "networkPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "traefikNamespace": { "type": "string" },
+            "dataHostCIDR": { "type": "string" },
+            "dataHostPort": { "type": "integer" }
+          }
+        },
+        "startupProbe": { "type": "object", "additionalProperties": true },
+        "livenessProbe": { "type": "object", "additionalProperties": true },
+        "readinessProbe": { "type": "object", "additionalProperties": true },
+        "podSecurityContext": { "type": "object", "additionalProperties": true },
+        "containerSecurityContext": { "type": "object", "additionalProperties": true },
+        "extraEnv": { "type": "array" }
+      },
+      "required": ["enabled", "image", "backend"]
+    }
+  }
+}

--- a/apps/redis-ui/values.yaml
+++ b/apps/redis-ui/values.yaml
@@ -1,0 +1,130 @@
+# Defaults do chart apps/redis-ui/.
+# Cada environment (environments/<env>/values.yaml) sobrescreve apenas o
+# necessário. Por padrão DESABILITADO — só ambientes que precisam de UI
+# Redis (ex.: standalone) ligam via `redisUi.enabled: true`.
+
+commonLabels:
+  app.kubernetes.io/part-of: uniplus
+  app.kubernetes.io/component: data-admin
+
+redisUi:
+  # Liga/desliga o chart inteiro. Default false.
+  enabled: false
+
+  image:
+    registry: docker.io
+    repository: redis/redisinsight
+    # Versão estável validada (Mar/2026). Bumps de minor seguros;
+    # majors requerem revisão das envs RI_* (renomes recorrentes
+    # entre versões).
+    tag: "2.74.0"
+    pullPolicy: IfNotPresent
+
+  imagePullSecrets: []
+
+  # RedisInsight é stateful (SQLite local em /data — connections, settings,
+  # query history). Single-replica é o pattern correto. emptyDir é OK em
+  # standalone porque a connection pré-setup é re-aplicada em restart via
+  # env vars; perda de query history é aceitável.
+  replicas: 1
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+  serviceAccount:
+    create: true
+    name: ""
+
+  # === Backend Redis (pré-setup via env vars) ===
+  # Conexão pré-cadastrada que aparece automaticamente no UI no primeiro
+  # acesso. Pattern: RI_REDIS_* (sem ID = conexão única, ID padrão 0).
+  # Documentação: https://redis.io/docs/latest/operate/redisinsight/configuration/
+  backend:
+    # IP/host do Redis no data-host. Pode ser IP literal ou FQDN
+    # (RedisInsight resolve via getaddrinfo do container — sem restrição
+    # como o EndpointSlice do MinIO Console).
+    host: ""                    # ex.: 10.0.2.87
+    port: 6379
+    # Alias mostrado na lista de connections do UI (puramente cosmético).
+    alias: standalone
+    # Username Redis ACL. Redis standalone usa `default` (sem ACL custom);
+    # password do role `default` vem do ESO `redisDefault`.
+    username: default
+
+  # === ExternalSecrets (Vault → K8s Secret) ===
+  externalSecrets:
+    enabled: true
+    refreshInterval: "1h"
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: vault-default
+
+    # Password do role `default` do Redis standalone (custodiado em
+    # Vault em PR #133). Sintetizado em Secret K8s e injetado como
+    # env RI_REDIS_PASSWORD via secretKeyRef.
+    redisDefault:
+      vaultPath: secret/standalone/redis/default
+      passwordKey: password
+
+    # Basic auth do Traefik middleware (proteção do UI). Custodiado em
+    # Vault em path dedicado (operador gera via `htpasswd -nbB user senha`
+    # uma vez e custodia). ESO sintetiza Secret no formato Traefik espera
+    # (key `users` com linhas no formato htpasswd).
+    basicAuth:
+      vaultPath: secret/standalone/redis-ui/basic-auth
+      # Nome da key no Vault contendo o htpasswd completo
+      # (formato: "user:$2y$05$<bcrypt_hash>" — uma linha por usuário).
+      htpasswdKey: htpasswd
+
+  # === Exposição externa via Traefik IngressRoute ===
+  ingress:
+    enabled: false
+    entryPoint: websecure
+    host: ""                    # ex.: redis-ui.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: ""            # criado pelo cert-manager se certManager.enabled
+      certManager:
+        enabled: false
+        clusterIssuer: ""       # ex.: letsencrypt-prod | letsencrypt-staging
+
+  # === NetworkPolicy ===
+  # Egress: Redis data-host (10.0.2.87:6379) + DNS.
+  # Ingress: somente Traefik.
+  networkPolicy:
+    enabled: true
+    traefikNamespace: traefik
+    # CIDR da subnet privada VCN onde o Redis data-host vive.
+    dataHostCIDR: ""
+    dataHostPort: 6379
+
+  # === Probes ===
+  # RedisInsight Quarkus-based; startup ~10-20s.
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 5
+  livenessProbe:
+    periodSeconds: 10
+  readinessProbe:
+    periodSeconds: 5
+
+  # === SecurityContext ===
+  # redis/redisinsight roda como uid 1000 (não-root).
+  podSecurityContext:
+    fsGroup: 1000
+  containerSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false
+
+  # Env vars adicionais (lista de `{name, value}` ou `{name, valueFrom}`).
+  extraEnv: []

--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -40,6 +40,7 @@ spec:
                 - app: keycloak-replica
                 - app: kafka-ui
                 - app: apicurio-registry
+                - app: redis-ui
 
   template:
     metadata:

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2839,4 +2839,113 @@ curl -sk -H "Authorization: Bearer $TOKEN" \
 
 ---
 
+## 16. RedisInsight UI (standalone)
+
+UI para inspecionar/admin o Redis standalone — chart `apps/redis-ui/` (issue #154). RedisInsight 2.74 com connection pré-setup via env vars apontando para o Redis systemd no data-host (`10.0.2.87:6379`). Pré-requisitos: §11 Redis ativo + Vault unsealed + Traefik com IngressRoute funcionando.
+
+### 16.1 Pré-flight: htpasswd + custódia
+
+RedisInsight 2.x **não tem auth nativa**. Proteção via Traefik `basicAuth` middleware com htpasswd custodiado em Vault.
+
+**Passo 1 — Gerar htpasswd (bcrypt):**
+
+```bash
+# Gerar usuário + senha forte. Bcrypt obrigatório (Traefik não aceita md5/sha).
+USERNAME=admin
+PASSWORD=$(openssl rand -base64 24)
+HTPASSWD=$(htpasswd -nbB "$USERNAME" "$PASSWORD")
+echo "user=$USERNAME pass=$PASSWORD"
+echo "htpasswd=$HTPASSWD"
+```
+
+**Passo 2 — Custodiar em Vault:**
+
+```bash
+kc() { sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "$@"; }
+
+kc -n vault exec platform-vault-uniplus-standalone-0 -- \
+  env VAULT_TOKEN=hvs.xxx \
+  vault kv put -tls-skip-verify secret/standalone/redis-ui/basic-auth \
+    username="$USERNAME" \
+    password="$PASSWORD" \
+    htpasswd="$HTPASSWD"
+```
+
+A senha cleartext (`password`) fica como referência operacional para login no UI; a chave usada pelo ESO é `htpasswd` (sintetizada como `users` no Secret K8s consumido pelo middleware).
+
+**Passo 3 — Forçar refresh do ESO + verificar pod:**
+
+```bash
+kc annotate -n uniplus externalsecret \
+  redis-ui-uniplus-standalone-redis-ui-redis \
+  redis-ui-uniplus-standalone-redis-ui-basic-auth \
+  force-sync=$(date +%s) --overwrite
+
+# Pod fica Ready quando ambos secrets sincronizam:
+kc get pods -n uniplus -l app.kubernetes.io/name=redis-ui
+```
+
+### 16.2 Smoke test
+
+```bash
+# 1. Pod healthy
+kc get pods -n uniplus -l app.kubernetes.io/name=redis-ui
+# READY 1/1, STATUS Running
+
+# 2. Health endpoint via port-forward (sem basic auth no path interno)
+kc port-forward -n uniplus deploy/redis-ui-uniplus-standalone-redis-ui 5540:5540 &
+sleep 2
+curl -s http://localhost:5540/api/health
+# {"status":"UP",...}
+kill %1
+
+# 3. UI HTTPS externa retorna 401 sem credenciais (basic auth ativo)
+curl -sk https://redis-ui.standalone.portaluni.com.br/ -o /dev/null -w "%{http_code}\n"
+# 401
+
+# 4. Login funciona com user/pass do Vault
+curl -sk -u "admin:<PASSWORD>" https://redis-ui.standalone.portaluni.com.br/api/health -w "\n%{http_code}\n"
+# 200 (UI responde)
+
+# 5. Conexão Redis pré-setup aparece no UI (browser)
+xdg-open https://redis-ui.standalone.portaluni.com.br
+# Login admin / <PASSWORD>
+# Lista de databases mostra "standalone" (alias) com host=10.0.2.87:6379
+```
+
+### 16.3 Rotacionar senha basic auth
+
+```bash
+# 1. Gerar nova senha + htpasswd
+NEW_PW=$(openssl rand -base64 24)
+NEW_HTPASSWD=$(htpasswd -nbB admin "$NEW_PW")
+
+# 2. Update Vault
+kc -n vault exec platform-vault-uniplus-standalone-0 -- \
+  env VAULT_TOKEN=hvs.xxx \
+  vault kv put -tls-skip-verify secret/standalone/redis-ui/basic-auth \
+    username=admin password="$NEW_PW" htpasswd="$NEW_HTPASSWD"
+
+# 3. Force ESO refresh
+kc annotate -n uniplus externalsecret \
+  redis-ui-uniplus-standalone-redis-ui-basic-auth \
+  force-sync=$(date +%s) --overwrite
+
+# Traefik recarrega Middleware automaticamente (provider K8s watches CRDs).
+# Browser exige re-login com nova senha em ~30s.
+```
+
+### 16.4 Troubleshooting
+
+| Sintoma | Causa provável | Resolução |
+|---|---|---|
+| Pod `CreateContainerConfigError` | ESO não sintetizou Secret (Vault offline ou htpasswd ausente) | `kc describe externalsecret -n uniplus redis-ui-uniplus-standalone-redis-ui-{redis,basic-auth}` — checar `status.conditions`. Se `SecretNotFound`: confirmar Vault unsealed + paths corretos |
+| Pod `CrashLoopBackOff`, log `Connection refused (...:6379)` | Egress Redis bloqueado por NetworkPolicy | Validar `dataHostCIDR=10.0.2.0/24` em `environments/standalone/values.yaml`. Confirmar `uniplus-redis` ativo no data-host |
+| 401 mesmo com credenciais corretas | htpasswd em formato errado (md5/sha em vez de bcrypt) | Re-gerar com `htpasswd -nbB` (-B = bcrypt). Re-custodiar + force ESO refresh + restart Middleware via `kc rollout restart -n traefik deploy/...` (raramente necessário) |
+| UI carrega mas conexão pré-setup ausente | RedisInsight não recriou conexões em restart (emptyDir limpo + env não foi re-aplicada) | `kc exec -n uniplus deploy/redis-ui-uniplus-standalone-redis-ui -- env \| grep RI_REDIS_` — confirmar env vars setadas. Se OK, `kc rollout restart deploy/redis-ui-uniplus-standalone-redis-ui` re-aplica setup |
+| Login na UI mas `Connection failed` ao clicar no DB | Senha Redis errada no ESO ou Redis exigindo TLS | Validar senha em Vault `secret/standalone/redis/default` bate com `/etc/uniplus-redis/users.acl`. Se ok, RedisInsight 2.x default `RI_REDIS_TLS=false` (nosso config) — Redis standalone aceita plaintext na subnet privada |
+| Browser warning "Not secure" | Cert LE staging ou expirado | Confirmar `clusterIssuer: letsencrypt-prod` em `environments/standalone/values.yaml`. `kc get certificate -n uniplus redis-ui-uniplus-standalone-redis-ui` deve estar `READY=True` |
+
+---
+
 *Documento mantido pelo CTIC/UNIFESSPA. Atualizações via Pull Request.*

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -551,6 +551,38 @@ apicurioRegistry:
     enabled: false
 
 # ----------------------------------------------------------------------------
+# RedisInsight — UI para Redis standalone (10.0.2.87:6379). Auth via Traefik
+# basicAuth middleware (htpasswd em Vault). Connection pré-setup via env vars.
+# Issue #154.
+# ----------------------------------------------------------------------------
+redisUi:
+  enabled: true
+
+  backend:
+    host: 10.0.2.87
+    port: 6379
+    alias: standalone
+    username: default
+
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    host: redis-ui.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: redis-ui-tls
+      certManager:
+        enabled: true
+        clusterIssuer: letsencrypt-prod
+
+  networkPolicy:
+    enabled: true
+    traefikNamespace: traefik
+    # /24 da subnet privada VCN — Redis listening em 10.0.2.87:6379.
+    dataHostCIDR: 10.0.2.0/24
+    dataHostPort: 6379
+
+# ----------------------------------------------------------------------------
 # MinIO Console proxy — expõe o Console (port 9001) do MinIO standalone
 # (rodando como systemd no data-host) via HTTPS público com cert LE prod.
 # Apenas Service ExternalName + IngressRoute Traefik. Issue #153.


### PR DESCRIPTION
## Resumo

Issue #154 — UI RedisInsight 2.74 (Apache 2.0) para inspeção/admin do Redis 8.6.3 standalone (\`10.0.2.87:6379\`). Conveniência operacional: ver keys, TTL, memory, RESP commands.

## Chart novo: \`apps/redis-ui/\`

Deployment + Service + 2 ESOs + Middleware + IngressRoute + Certificate + NetworkPolicy. SQLite local em emptyDir.

## Decisões arquiteturais

### Auth via Traefik basicAuth middleware (não app)

RedisInsight 2.x **não tem auth nativa** — validei via [doc oficial](https://redis.io/docs/latest/operate/redisinsight/configuration/). Solução: Traefik \`basicAuth\` middleware com Secret htpasswd bcrypt custodiado em Vault. Operador gera uma vez via \`htpasswd -nbB user senha\` (RUNBOOKS §16.1).

Para SSO via Keycloak no futuro: Traefik \`forwardAuth\` middleware + oauth2-proxy.

### Connection Redis pré-setup via env vars

RedisInsight aceita pre-setup connections via env (\`RI_REDIS_HOST/PORT/USERNAME/PASSWORD/ALIAS/TLS\`). Uma única conexão = mais simples que JSON file mount. Password via \`secretKeyRef\` do ESO \`redisDefault\` (Vault path já existente desde PR #133).

### emptyDir + Recreate strategy

SQLite local. Em single-replica standalone é OK — env vars re-aplicam pre-setup em cada restart. Query history/custom dashboards são perdidos em rolling (aceitável para debug operacional).

## Pre-PR review (subagent code-reviewer)

2 P1 + 1 P2 (defense-in-depth) corrigidos antes do PR:

1. **Probe path \`/api/health/\`** (com trailing slash) — sem o slash, RedisInsight 2.x retorna redirect 301 em algumas versões (issue redis/RedisInsight#4780 + Quarkus #26016). Bug runtime que escapa lint.
2. **\`monitoringNamespace\` dead** — campo declarado em values/schema mas nunca usado no NetworkPolicy. Removido (sem ServiceMonitor planejado para RedisInsight).
3. **Defense-in-depth IngressRoute** — guard para \`externalSecrets.enabled\` alinha com guard já existente no deployment.yaml.

P2 não-aplicado: sumário do RUNBOOKS sem §10-16 — é problema preexistente fora de escopo deste PR.

## Test plan

- [x] helm lint enabled=false + enabled=true full overlay ✓
- [x] helm template renderiza 9 recursos ✓
- [x] Probe paths \`/api/health/\` (3×) ✓
- [x] \`{{- fail }}\` guards: backend.host, externalSecrets, ingress.host, clusterIssuer, dataHostCIDR ✓
- [x] yamllint clean ✓
- [ ] Pós-merge: operador gera htpasswd e custodia em Vault (RUNBOOKS §16.1)
- [ ] Pós-merge: DNS OCI CNAME redis-ui.standalone → standalone
- [ ] Pós-merge: ApplicationSet sync, ESO sintetiza Secrets, pod fica Ready
- [ ] Pós-merge: smoke §16.2 (401 sem credenciais, login com Vault, conexão pré-setup visível no UI)

## Referências

- [RedisInsight K8s install](https://redis.io/docs/latest/operate/redisinsight/install/install-on-k8s/)
- [Traefik basicAuth middleware](https://doc.traefik.io/traefik/middlewares/http/basicauth/)

Closes #154