### PR TITLE
fix(redis-ui): tag correta da imagem — 3.4.2 (não 2.74.0)

### DIFF
--- a/apps/redis-ui/Chart.yaml
+++ b/apps/redis-ui/Chart.yaml
@@ -12,7 +12,7 @@ type: application
 
 version: 0.1.0
 
-appVersion: "2.74.0"
+appVersion: "3.4.2"
 
 home: https://github.com/unifesspa-edu-br/uniplus-infra
 sources:

--- a/apps/redis-ui/values.yaml
+++ b/apps/redis-ui/values.yaml
@@ -17,7 +17,7 @@ redisUi:
     # Versão estável validada (Mar/2026). Bumps de minor seguros;
     # majors requerem revisão das envs RI_* (renomes recorrentes
     # entre versões).
-    tag: "2.74.0"
+    tag: "3.4.2"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
## Hotfix do PR #158

Smoke pós-merge: pod `redis-ui` entrou em `ImagePullBackOff` porque a tag `2.74.0` não existe no Docker Hub.

```
Failed to pull image "docker.io/redis/redisinsight:2.74.0": rpc error: code = NotFound
```

## Tags disponíveis (validado via Docker Hub API)

```
latest
3.4
3.4.2  ← latest stable amd64
3.4.1
3.2
3.2.0
```

A versão `2.74` é da release antiga `redislabs/redisinsight` (repositório descontinuado). Confundi com a versão atual.

## Fix

Bump para `3.4.2` em values.yaml + Chart.yaml.

## Lição

Mais um caso para `feedback_bootstrap_smoke_fresh.md`:
- helm lint não valida existência de imagem upstream
- Codex 👍 direto sem threads também não pegou
- Smoke deploy-pós-merge é etapa irredutível

## Test plan

- [x] helm lint ✓
- [ ] Pós-merge: ApplicationSet sync, pod fica Ready
- [ ] Pós-merge: smoke §16.2
EOF
)