### PR TITLE
feat(standalone): destrava Fase 5 — charts Helm das 3 APIs Uni+

### DIFF
--- a/apps/uniplus-api-ingresso/Chart.yaml
+++ b/apps/uniplus-api-ingresso/Chart.yaml
@@ -1,19 +1,33 @@
 apiVersion: v2
 name: uniplus-api-ingresso
-description: API .NET 10 do módulo Ingresso — matrícula e vínculo acadêmico
+description: |
+  API .NET 10 do módulo Ingresso Uni+ — conteúdo institucional e perfis.
+  Backend ASP.NET Core minimal API + Wolverine (CQRS/messaging) + Serilog.
+  OpenAPI 3.1 em /openapi/portal.json. Health: /health (readiness),
+  /health/live (liveness).
 type: application
+
 version: 0.1.0
-appVersion: "1.0.0"
-keywords:
-  - uniplus
-  - api
-  - unifesspa
+
+# Sincronizar com tag publicada em ghcr.io/unifesspa-edu-br/uniplus-api-ingresso.
+appVersion: "0.1.1"
+
 home: https://github.com/unifesspa-edu-br/uniplus-infra
 sources:
   - https://github.com/unifesspa-edu-br/uniplus-infra
+  - https://github.com/unifesspa-edu-br/uniplus-api
+
 maintainers:
   - name: CTIC UNIFESSPA
     email: jeferson.ferreira@unifesspa.edu.br
+
+keywords:
+  - uniplus
+  - api
+  - portal
+  - dotnet
+  - unifesspa
+
 annotations:
   category: api
   licenses: MIT

--- a/apps/uniplus-api-ingresso/README.md
+++ b/apps/uniplus-api-ingresso/README.md
@@ -1,6 +1,6 @@
 # uniplus-api-ingresso
 
-API .NET 10 do módulo Ingresso — matrícula e vínculo acadêmico
+API .NET 10 do módulo Ingresso — conteúdo institucional e perfis
 
 > ⚠️ **Status:** placeholder inicial. Implementação dos templates pendente.
 

--- a/apps/uniplus-api-ingresso/templates/_helpers.tpl
+++ b/apps/uniplus-api-ingresso/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/* Fullname com truncate DNS-1123. */}}
+{{- define "uniplusApiIngresso.fullname" -}}
+{{- if .Values.uniplusApiIngresso.fullnameOverride -}}
+{{- .Values.uniplusApiIngresso.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.uniplusApiIngresso.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "uniplusApiIngresso.selectorLabels" -}}
+app.kubernetes.io/name: {{ default .Chart.Name .Values.uniplusApiIngresso.nameOverride }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "uniplusApiIngresso.labels" -}}
+{{ include "uniplusApiIngresso.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end -}}
+{{- end -}}
+
+{{- define "uniplusApiIngresso.serviceAccountName" -}}
+{{- if .Values.uniplusApiIngresso.serviceAccount.create -}}
+{{- default (printf "%s-sa" (include "uniplusApiIngresso.fullname" .)) .Values.uniplusApiIngresso.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.uniplusApiIngresso.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Nomes dos Secrets sintetizados pelo ESO. */}}
+{{- define "uniplusApiIngresso.postgresSecretName" -}}
+{{ include "uniplusApiIngresso.fullname" . }}-postgres
+{{- end -}}
+
+{{- define "uniplusApiIngresso.redisSecretName" -}}
+{{ include "uniplusApiIngresso.fullname" . }}-redis
+{{- end -}}
+
+{{- define "uniplusApiIngresso.kafkaSecretName" -}}
+{{ include "uniplusApiIngresso.fullname" . }}-kafka
+{{- end -}}
+
+{{- define "uniplusApiIngresso.minioSecretName" -}}
+{{ include "uniplusApiIngresso.fullname" . }}-minio
+{{- end -}}
+
+{{- define "uniplusApiIngresso.oidcSecretName" -}}
+{{ include "uniplusApiIngresso.fullname" . }}-oidc-client
+{{- end -}}

--- a/apps/uniplus-api-ingresso/templates/certificate.yaml
+++ b/apps/uniplus-api-ingresso/templates/certificate.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.uniplusApiIngresso.enabled .Values.uniplusApiIngresso.ingress.enabled .Values.uniplusApiIngresso.ingress.tls.enabled .Values.uniplusApiIngresso.ingress.tls.certManager.enabled -}}
+{{- if not .Values.uniplusApiIngresso.ingress.tls.certManager.clusterIssuer -}}
+{{- fail "uniplusApiIngresso.ingress.tls.certManager.clusterIssuer é obrigatório quando certManager.enabled=true (ex.: letsencrypt-prod)." -}}
+{{- end -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "uniplusApiIngresso.fullname" . }}
+  labels:
+    {{- include "uniplusApiIngresso.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.uniplusApiIngresso.ingress.tls.secretName | default (printf "%s-tls" (include "uniplusApiIngresso.fullname" .)) }}
+  commonName: {{ .Values.uniplusApiIngresso.ingress.host }}
+  dnsNames:
+    - {{ .Values.uniplusApiIngresso.ingress.host }}
+  issuerRef:
+    name: {{ .Values.uniplusApiIngresso.ingress.tls.certManager.clusterIssuer }}
+    kind: ClusterIssuer
+{{- end }}

--- a/apps/uniplus-api-ingresso/templates/deployment.yaml
+++ b/apps/uniplus-api-ingresso/templates/deployment.yaml
@@ -1,0 +1,175 @@
+{{- if .Values.uniplusApiIngresso.enabled -}}
+{{- if not .Values.uniplusApiIngresso.database.host -}}
+{{- fail "uniplusApiIngresso.database.host é obrigatório quando enabled=true. Configurar em environments/<env>/values.yaml (ex.: 10.0.2.87)." -}}
+{{- end -}}
+{{- if not .Values.uniplusApiIngresso.redis.host -}}
+{{- fail "uniplusApiIngresso.redis.host é obrigatório quando enabled=true." -}}
+{{- end -}}
+{{- if not .Values.uniplusApiIngresso.storage.endpoint -}}
+{{- fail "uniplusApiIngresso.storage.endpoint é obrigatório quando enabled=true (MinIO endpoint)." -}}
+{{- end -}}
+{{- if and .Values.uniplusApiIngresso.oidc.enabled (not .Values.uniplusApiIngresso.oidc.issuerUri) -}}
+{{- fail "uniplusApiIngresso.oidc.issuerUri é obrigatório quando oidc.enabled=true." -}}
+{{- end -}}
+{{- if and .Values.uniplusApiIngresso.kafka.enabled (not .Values.uniplusApiIngresso.kafka.bootstrapServers) -}}
+{{- fail "uniplusApiIngresso.kafka.bootstrapServers é obrigatório quando kafka.enabled=true." -}}
+{{- end -}}
+{{- if not .Values.uniplusApiIngresso.externalSecrets.enabled -}}
+{{- fail "uniplusApiIngresso.enabled=true requer externalSecrets.enabled=true. Deployment depende dos Secrets sintetizados pelo ESO (Postgres password, Redis, MinIO, Kafka, OIDC)." -}}
+{{- end -}}
+{{- $cs := .Values.uniplusApiIngresso.database.connectionStringName -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "uniplusApiIngresso.fullname" . }}
+  labels:
+    {{- include "uniplusApiIngresso.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.uniplusApiIngresso.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      {{- include "uniplusApiIngresso.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "uniplusApiIngresso.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "uniplusApiIngresso.serviceAccountName" . }}
+      {{- with .Values.uniplusApiIngresso.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.uniplusApiIngresso.podSecurityContext | nindent 8 }}
+      containers:
+        - name: api
+          image: "{{ .Values.uniplusApiIngresso.image.registry }}/{{ .Values.uniplusApiIngresso.image.repository }}:{{ .Values.uniplusApiIngresso.image.tag }}"
+          imagePullPolicy: {{ .Values.uniplusApiIngresso.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.uniplusApiIngresso.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            # === ASP.NET Core base ===
+            - name: ASPNETCORE_ENVIRONMENT
+              value: {{ .Values.uniplusApiIngresso.aspnet.environment | quote }}
+            - name: ASPNETCORE_URLS
+              value: {{ .Values.uniplusApiIngresso.aspnet.urls | quote }}
+            # === Postgres (ConnectionStrings__<Name>Db via .NET binding) ===
+            # Composição via env: host/port/database em values, password
+            # injetado via secretKeyRef. .NET aceita connection string completa
+            # numa única env — montamos no formato Npgsql.
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiIngresso.postgresSecretName" . }}
+                  key: POSTGRES_PASSWORD
+            - name: ConnectionStrings__{{ $cs }}
+              value: "Host={{ .Values.uniplusApiIngresso.database.host }};Port={{ .Values.uniplusApiIngresso.database.port }};Database={{ .Values.uniplusApiIngresso.database.name }};Username={{ .Values.uniplusApiIngresso.database.username }};Password=$(POSTGRES_PASSWORD)"
+            # === Redis (Connection string formato StackExchange.Redis) ===
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiIngresso.redisSecretName" . }}
+                  key: REDIS_PASSWORD
+            - name: Redis__ConnectionString
+              value: "{{ .Values.uniplusApiIngresso.redis.host }}:{{ .Values.uniplusApiIngresso.redis.port }},user={{ .Values.uniplusApiIngresso.redis.username }},password=$(REDIS_PASSWORD)"
+            {{- if .Values.uniplusApiIngresso.kafka.enabled }}
+            # === Kafka (SASL_SSL + SCRAM via .NET nested binding) ===
+            # Confluent.Kafka client lê estas env como AdminClientConfig/
+            # ProducerConfig.SecurityProtocol/SaslMechanism/SaslUsername/etc
+            # quando bind via IConfiguration.GetSection("Kafka").
+            - name: Kafka__BootstrapServers
+              value: {{ .Values.uniplusApiIngresso.kafka.bootstrapServers | quote }}
+            - name: Kafka__SecurityProtocol
+              value: {{ .Values.uniplusApiIngresso.kafka.securityProtocol | quote }}
+            - name: Kafka__SaslMechanism
+              value: {{ .Values.uniplusApiIngresso.kafka.saslMechanism | quote }}
+            - name: Kafka__SaslUsername
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiIngresso.kafkaSecretName" . }}
+                  key: KAFKA_USERNAME
+            - name: Kafka__SaslPassword
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiIngresso.kafkaSecretName" . }}
+                  key: KAFKA_PASSWORD
+            - name: Kafka__SslCaLocation
+              value: {{ .Values.uniplusApiIngresso.kafka.caCertPath | quote }}
+            {{- end }}
+            # === MinIO (Storage:* binding) ===
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiIngresso.minioSecretName" . }}
+                  key: MINIO_ACCESS_KEY
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiIngresso.minioSecretName" . }}
+                  key: MINIO_SECRET_KEY
+            - name: Storage__Endpoint
+              value: {{ .Values.uniplusApiIngresso.storage.endpoint | quote }}
+            - name: Storage__AccessKey
+              value: "$(MINIO_ACCESS_KEY)"
+            - name: Storage__SecretKey
+              value: "$(MINIO_SECRET_KEY)"
+            - name: Storage__BucketName
+              value: {{ .Values.uniplusApiIngresso.storage.bucketName | quote }}
+            {{- if .Values.uniplusApiIngresso.oidc.enabled }}
+            # === OIDC (Auth:* binding — bearer validation) ===
+            - name: Auth__Authority
+              value: {{ .Values.uniplusApiIngresso.oidc.issuerUri | quote }}
+            - name: Auth__Audience
+              value: {{ .Values.uniplusApiIngresso.oidc.audience | quote }}
+            {{- end }}
+            {{- with .Values.uniplusApiIngresso.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.uniplusApiIngresso.kafka.enabled }}
+          volumeMounts:
+            # CA cert PEM do broker Kafka self-signed.
+            - name: kafka-ca
+              mountPath: /etc/uniplus-kafka/ca.crt
+              subPath: ca.crt
+              readOnly: true
+          {{- end }}
+          startupProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            failureThreshold: {{ .Values.uniplusApiIngresso.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.uniplusApiIngresso.startupProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            periodSeconds: {{ .Values.uniplusApiIngresso.livenessProbe.periodSeconds }}
+          # Readiness usa /health (agregado com checks externos: Postgres,
+          # Redis, etc.). Pod sai de Ready quando dependência está down —
+          # comportamento desejado pra service mesh remover do load balancer.
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: {{ .Values.uniplusApiIngresso.readinessProbe.periodSeconds }}
+          resources:
+            {{- toYaml .Values.uniplusApiIngresso.resources | nindent 12 }}
+      {{- if .Values.uniplusApiIngresso.kafka.enabled }}
+      volumes:
+        - name: kafka-ca
+          secret:
+            secretName: {{ include "uniplusApiIngresso.kafkaSecretName" . }}
+            items:
+              - key: ca.crt
+                path: ca.crt
+      {{- end }}
+{{- end }}

--- a/apps/uniplus-api-ingresso/templates/externalsecret.yaml
+++ b/apps/uniplus-api-ingresso/templates/externalsecret.yaml
@@ -1,0 +1,130 @@
+{{- if and .Values.uniplusApiIngresso.enabled .Values.uniplusApiIngresso.externalSecrets.enabled -}}
+{{- $top := . -}}
+{{- $es := .Values.uniplusApiIngresso.externalSecrets -}}
+# ESO 1: Postgres app password (DB dedicada — ex.: uniplus_ingresso/role portal).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiIngresso.postgresSecretName" . }}
+  labels:
+    {{- include "uniplusApiIngresso.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiIngresso.postgresSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: {{ $es.postgresApp.vaultPath }}
+        property: {{ $es.postgresApp.passwordKey }}
+---
+# ESO 2: Redis default user password.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiIngresso.redisSecretName" . }}
+  labels:
+    {{- include "uniplusApiIngresso.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiIngresso.redisSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: REDIS_PASSWORD
+      remoteRef:
+        key: {{ $es.redisDefault.vaultPath }}
+        property: {{ $es.redisDefault.passwordKey }}
+---
+# ESO 3: MinIO root credentials (compartilhado em standalone).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiIngresso.minioSecretName" . }}
+  labels:
+    {{- include "uniplusApiIngresso.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiIngresso.minioSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: MINIO_ACCESS_KEY
+      remoteRef:
+        key: {{ $es.minioRoot.vaultPath }}
+        property: {{ $es.minioRoot.usernameKey }}
+    - secretKey: MINIO_SECRET_KEY
+      remoteRef:
+        key: {{ $es.minioRoot.vaultPath }}
+        property: {{ $es.minioRoot.passwordKey }}
+{{- if .Values.uniplusApiIngresso.kafka.enabled }}
+---
+# ESO 4: Kafka SCRAM admin credentials + CA cert.
+# Em standalone usa SCRAM admin compartilhado (ADR-009 — em hml/prod migrar
+# para SCRAM users dedicados por app).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiIngresso.kafkaSecretName" . }}
+  labels:
+    {{- include "uniplusApiIngresso.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiIngresso.kafkaSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: KAFKA_USERNAME
+      remoteRef:
+        key: {{ $es.kafkaAdmin.vaultPath }}
+        property: {{ $es.kafkaAdmin.usernameKey }}
+    - secretKey: KAFKA_PASSWORD
+      remoteRef:
+        key: {{ $es.kafkaAdmin.vaultPath }}
+        property: {{ $es.kafkaAdmin.passwordKey }}
+    - secretKey: ca.crt
+      remoteRef:
+        key: {{ $es.kafkaAdmin.vaultPath }}
+        property: {{ $es.kafkaAdmin.caCertKey }}
+{{- end }}
+{{- if .Values.uniplusApiIngresso.oidc.enabled }}
+---
+# ESO 5: OIDC client_secret reservado para machine-to-machine (m2m)
+# FUTURO. Resource server bearer-only NÃO consome este Secret em runtime
+# — não há env var nem envFrom no Deployment referenciando-o. ESO antecipa
+# o cenário em que a API se autentica como service account contra outras
+# APIs (client_credentials grant). Mantido para parity com kafka-ui/apicurio-registry.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiIngresso.oidcSecretName" . }}
+  labels:
+    {{- include "uniplusApiIngresso.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiIngresso.oidcSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: {{ $es.oidcClient.vaultPath }}
+        property: {{ $es.oidcClient.clientSecretKey }}
+{{- end }}
+{{- end }}

--- a/apps/uniplus-api-ingresso/templates/ingressroute.yaml
+++ b/apps/uniplus-api-ingresso/templates/ingressroute.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.uniplusApiIngresso.enabled .Values.uniplusApiIngresso.ingress.enabled -}}
+{{- if not .Values.uniplusApiIngresso.ingress.host -}}
+{{- fail "uniplusApiIngresso.ingress.host é obrigatório quando ingress.enabled=true (ex.: api-portal.standalone.portaluni.com.br)." -}}
+{{- end -}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "uniplusApiIngresso.fullname" . }}
+  labels:
+    {{- include "uniplusApiIngresso.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.uniplusApiIngresso.ingress.entryPoint }}
+  routes:
+    - match: Host(`{{ .Values.uniplusApiIngresso.ingress.host }}`)
+      kind: Rule
+      services:
+        - name: {{ include "uniplusApiIngresso.fullname" . }}
+          port: 8080
+  {{- if .Values.uniplusApiIngresso.ingress.tls.enabled }}
+  tls:
+    secretName: {{ .Values.uniplusApiIngresso.ingress.tls.secretName | default (printf "%s-tls" (include "uniplusApiIngresso.fullname" .)) }}
+  {{- end }}
+{{- end }}

--- a/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
@@ -1,0 +1,85 @@
+{{- if and .Values.uniplusApiIngresso.enabled .Values.uniplusApiIngresso.networkPolicy.enabled -}}
+{{- if not .Values.uniplusApiIngresso.networkPolicy.dataHostCIDR -}}
+{{- fail "uniplusApiIngresso.networkPolicy.dataHostCIDR é obrigatório (egress para Postgres + Redis + Kafka + MinIO no data-host)." -}}
+{{- end -}}
+{{- if and .Values.uniplusApiIngresso.oidc.enabled (not .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (issuer público resolvido via Traefik no IP do k8s-host)." -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "uniplusApiIngresso.fullname" . }}
+  labels:
+    {{- include "uniplusApiIngresso.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "uniplusApiIngresso.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiIngresso.networkPolicy.traefikNamespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- if and .Values.uniplusApiIngresso.metrics.enabled .Values.uniplusApiIngresso.serviceMonitor.enabled }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiIngresso.networkPolicy.monitoringNamespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- end }}
+  egress:
+    # DNS (CoreDNS).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Data-host (Postgres 5432 + Redis 6379 + Kafka 9092 + MinIO 9000).
+    # Single rule by CIDR + multi-port (todos compartilham mesmo /24 em standalone).
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.uniplusApiIngresso.networkPolicy.dataHostCIDR }}
+      ports:
+        - protocol: TCP
+          port: 5432  # Postgres
+        - protocol: TCP
+          port: 6379  # Redis
+        - protocol: TCP
+          port: 9000  # MinIO API S3
+        {{- if .Values.uniplusApiIngresso.kafka.enabled }}
+        - protocol: TCP
+          port: 9092  # Kafka SASL_SSL
+        {{- end }}
+    # Keycloak in-cluster (fallback se issuerUri usar Service DNS).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiIngresso.networkPolicy.keycloakNamespace }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: keycloak-replica
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uniplusApiIngresso.networkPolicy.keycloakPort }}
+    {{- if .Values.uniplusApiIngresso.oidc.enabled }}
+    # OIDC issuer público — JWT validation chama jwks endpoint (HTTPS).
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uniplusApiIngresso.networkPolicy.oidcIssuerPort }}
+    {{- end }}
+{{- end }}

--- a/apps/uniplus-api-ingresso/templates/service.yaml
+++ b/apps/uniplus-api-ingresso/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.uniplusApiIngresso.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "uniplusApiIngresso.fullname" . }}
+  labels:
+    {{- include "uniplusApiIngresso.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "uniplusApiIngresso.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/apps/uniplus-api-ingresso/templates/serviceaccount.yaml
+++ b/apps/uniplus-api-ingresso/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.uniplusApiIngresso.enabled .Values.uniplusApiIngresso.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "uniplusApiIngresso.serviceAccountName" . }}
+  labels:
+    {{- include "uniplusApiIngresso.labels" . | nindent 4 }}
+{{- end }}

--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -1,22 +1,162 @@
-# Default values para uniplus-api-ingresso
-# TODO: implementar conforme estrutura do uniplus-web
-
-replicas: 2
-
-image:
-  registry: ghcr.io
-  repository: unifesspa-edu-br/uniplus-api-ingresso
-  pullPolicy: IfNotPresent
-  tag: ""
-
-resources:
-  requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 500m
-    memory: 256Mi
+# Defaults do chart apps/uniplus-api-ingresso/.
+# Cada environment (environments/<env>/values.yaml) sobrescreve apenas o
+# necessário. Por padrão DESABILITADO — só ambientes onde a imagem GHCR
+# estiver publicada e os pré-requisitos atendidos (DB, Vault paths, OIDC
+# client) ligam via `uniplusApiIngresso.enabled: true`.
 
 commonLabels:
   app.kubernetes.io/part-of: uniplus
   app.kubernetes.io/component: api
+
+uniplusApiIngresso:
+  enabled: false
+
+  image:
+    registry: ghcr.io
+    repository: unifesspa-edu-br/uniplus-api-ingresso
+    # Sincronizar com tag publicada em GHCR.
+    tag: "v0.1.1"
+    pullPolicy: IfNotPresent
+
+  imagePullSecrets: []
+
+  # API stateless. Em standalone 1 réplica para reduzir uso de recursos.
+  replicas: 1
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+
+  serviceAccount:
+    create: true
+    name: ""
+
+  aspnet:
+    environment: Production
+    urls: "http://+:8080"
+
+  # === Backend Postgres (DB dedicada por app) ===
+  database:
+    host: ""                    # ex.: 10.0.2.87
+    port: 5432
+    name: uniplus_ingresso
+    username: ingresso
+    # Nome em ConnectionStrings__<Name>Db (.NET config binding).
+    connectionStringName: IngressoDb
+
+  # === Backend Redis (default user) ===
+  redis:
+    host: ""                    # ex.: 10.0.2.87
+    port: 6379
+    username: default
+
+  # === Backend Kafka (SASL_SSL + SCRAM-SHA-512, ADR-009) ===
+  # Pode ser desligado em primeiro deploy se SCRAM users per-app ainda não
+  # foram provisionados. Em standalone usa SCRAM admin compartilhado.
+  kafka:
+    enabled: true
+    bootstrapServers: ""        # ex.: 10.0.2.87:9092
+    securityProtocol: SASL_SSL
+    saslMechanism: SCRAM-SHA-512
+    # CA cert PEM mountado de Secret kafka-admin (key ca_cert).
+    caCertPath: /etc/uniplus-kafka/ca.crt
+
+  # === Backend MinIO S3 ===
+  storage:
+    endpoint: ""                # ex.: 10.0.2.87:9000
+    bucketName: uniplus-storage
+
+  # === OIDC (Auth bearer) ===
+  oidc:
+    enabled: true
+    issuerUri: ""               # ex.: https://standalone.portaluni.com.br/auth/realms/uniplus
+    audience: uniplus
+
+  # === ExternalSecrets (Vault → K8s Secret) ===
+  externalSecrets:
+    enabled: true
+    refreshInterval: "1h"
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: vault-default
+
+    postgresApp:
+      vaultPath: secret/standalone/postgres/ingresso
+      passwordKey: password
+
+    redisDefault:
+      vaultPath: secret/standalone/redis/default
+      passwordKey: password
+
+    kafkaAdmin:
+      vaultPath: secret/standalone/kafka/admin
+      usernameKey: username
+      passwordKey: password
+      caCertKey: ca_cert
+
+    minioRoot:
+      vaultPath: secret/standalone/minio/root
+      usernameKey: username
+      passwordKey: password
+
+    oidcClient:
+      vaultPath: secret/standalone/keycloak/clients/uniplus-api-ingresso
+      clientSecretKey: client_secret
+
+  # === Exposição externa via Traefik IngressRoute ===
+  ingress:
+    enabled: false
+    entryPoint: websecure
+    host: ""                    # ex.: api-portal.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: ""
+      certManager:
+        enabled: false
+        clusterIssuer: ""       # ex.: letsencrypt-prod
+
+  # === NetworkPolicy ===
+  networkPolicy:
+    enabled: true
+    traefikNamespace: traefik
+    monitoringNamespace: observability-prometheus
+    dataHostCIDR: ""            # ex.: 10.0.2.0/24
+    keycloakService: keycloak-replica-uniplus-standalone
+    keycloakNamespace: uniplus
+    keycloakPort: 8080
+    oidcIssuerCIDR: ""          # ex.: 164.152.53.29/32
+    oidcIssuerPort: 443
+
+  metrics:
+    enabled: false
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+
+  # /health/live: dependency-free (sempre 200 enquanto processo respira).
+  # /health: agregado readiness — falha sob transient outage de deps.
+  startupProbe:
+    failureThreshold: 60
+    periodSeconds: 5
+  livenessProbe:
+    periodSeconds: 10
+  readinessProbe:
+    periodSeconds: 5
+
+  # Container roda como `appuser` (UID 999, Debian useradd default).
+  podSecurityContext:
+    fsGroup: 999
+  containerSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false
+
+  extraEnv: []

--- a/apps/uniplus-api-portal/Chart.yaml
+++ b/apps/uniplus-api-portal/Chart.yaml
@@ -1,19 +1,33 @@
 apiVersion: v2
 name: uniplus-api-portal
-description: API .NET 10 do módulo Portal — conteúdo institucional e perfis
+description: |
+  API .NET 10 do módulo Portal Uni+ — conteúdo institucional e perfis.
+  Backend ASP.NET Core minimal API + Wolverine (CQRS/messaging) + Serilog.
+  OpenAPI 3.1 em /openapi/portal.json. Health: /health (readiness),
+  /health/live (liveness).
 type: application
+
 version: 0.1.0
-appVersion: "1.0.0"
-keywords:
-  - uniplus
-  - api
-  - unifesspa
+
+# Sincronizar com tag publicada em ghcr.io/unifesspa-edu-br/uniplus-api-portal.
+appVersion: "0.1.1"
+
 home: https://github.com/unifesspa-edu-br/uniplus-infra
 sources:
   - https://github.com/unifesspa-edu-br/uniplus-infra
+  - https://github.com/unifesspa-edu-br/uniplus-api
+
 maintainers:
   - name: CTIC UNIFESSPA
     email: jeferson.ferreira@unifesspa.edu.br
+
+keywords:
+  - uniplus
+  - api
+  - portal
+  - dotnet
+  - unifesspa
+
 annotations:
   category: api
   licenses: MIT

--- a/apps/uniplus-api-portal/templates/_helpers.tpl
+++ b/apps/uniplus-api-portal/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/* Fullname com truncate DNS-1123. */}}
+{{- define "uniplusApiPortal.fullname" -}}
+{{- if .Values.uniplusApiPortal.fullnameOverride -}}
+{{- .Values.uniplusApiPortal.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.uniplusApiPortal.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "uniplusApiPortal.selectorLabels" -}}
+app.kubernetes.io/name: {{ default .Chart.Name .Values.uniplusApiPortal.nameOverride }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "uniplusApiPortal.labels" -}}
+{{ include "uniplusApiPortal.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end -}}
+{{- end -}}
+
+{{- define "uniplusApiPortal.serviceAccountName" -}}
+{{- if .Values.uniplusApiPortal.serviceAccount.create -}}
+{{- default (printf "%s-sa" (include "uniplusApiPortal.fullname" .)) .Values.uniplusApiPortal.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.uniplusApiPortal.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Nomes dos Secrets sintetizados pelo ESO. */}}
+{{- define "uniplusApiPortal.postgresSecretName" -}}
+{{ include "uniplusApiPortal.fullname" . }}-postgres
+{{- end -}}
+
+{{- define "uniplusApiPortal.redisSecretName" -}}
+{{ include "uniplusApiPortal.fullname" . }}-redis
+{{- end -}}
+
+{{- define "uniplusApiPortal.kafkaSecretName" -}}
+{{ include "uniplusApiPortal.fullname" . }}-kafka
+{{- end -}}
+
+{{- define "uniplusApiPortal.minioSecretName" -}}
+{{ include "uniplusApiPortal.fullname" . }}-minio
+{{- end -}}
+
+{{- define "uniplusApiPortal.oidcSecretName" -}}
+{{ include "uniplusApiPortal.fullname" . }}-oidc-client
+{{- end -}}

--- a/apps/uniplus-api-portal/templates/certificate.yaml
+++ b/apps/uniplus-api-portal/templates/certificate.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.uniplusApiPortal.enabled .Values.uniplusApiPortal.ingress.enabled .Values.uniplusApiPortal.ingress.tls.enabled .Values.uniplusApiPortal.ingress.tls.certManager.enabled -}}
+{{- if not .Values.uniplusApiPortal.ingress.tls.certManager.clusterIssuer -}}
+{{- fail "uniplusApiPortal.ingress.tls.certManager.clusterIssuer é obrigatório quando certManager.enabled=true (ex.: letsencrypt-prod)." -}}
+{{- end -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "uniplusApiPortal.fullname" . }}
+  labels:
+    {{- include "uniplusApiPortal.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.uniplusApiPortal.ingress.tls.secretName | default (printf "%s-tls" (include "uniplusApiPortal.fullname" .)) }}
+  commonName: {{ .Values.uniplusApiPortal.ingress.host }}
+  dnsNames:
+    - {{ .Values.uniplusApiPortal.ingress.host }}
+  issuerRef:
+    name: {{ .Values.uniplusApiPortal.ingress.tls.certManager.clusterIssuer }}
+    kind: ClusterIssuer
+{{- end }}

--- a/apps/uniplus-api-portal/templates/deployment.yaml
+++ b/apps/uniplus-api-portal/templates/deployment.yaml
@@ -1,0 +1,175 @@
+{{- if .Values.uniplusApiPortal.enabled -}}
+{{- if not .Values.uniplusApiPortal.database.host -}}
+{{- fail "uniplusApiPortal.database.host é obrigatório quando enabled=true. Configurar em environments/<env>/values.yaml (ex.: 10.0.2.87)." -}}
+{{- end -}}
+{{- if not .Values.uniplusApiPortal.redis.host -}}
+{{- fail "uniplusApiPortal.redis.host é obrigatório quando enabled=true." -}}
+{{- end -}}
+{{- if not .Values.uniplusApiPortal.storage.endpoint -}}
+{{- fail "uniplusApiPortal.storage.endpoint é obrigatório quando enabled=true (MinIO endpoint)." -}}
+{{- end -}}
+{{- if and .Values.uniplusApiPortal.oidc.enabled (not .Values.uniplusApiPortal.oidc.issuerUri) -}}
+{{- fail "uniplusApiPortal.oidc.issuerUri é obrigatório quando oidc.enabled=true." -}}
+{{- end -}}
+{{- if and .Values.uniplusApiPortal.kafka.enabled (not .Values.uniplusApiPortal.kafka.bootstrapServers) -}}
+{{- fail "uniplusApiPortal.kafka.bootstrapServers é obrigatório quando kafka.enabled=true." -}}
+{{- end -}}
+{{- if not .Values.uniplusApiPortal.externalSecrets.enabled -}}
+{{- fail "uniplusApiPortal.enabled=true requer externalSecrets.enabled=true. Deployment depende dos Secrets sintetizados pelo ESO (Postgres password, Redis, MinIO, Kafka, OIDC)." -}}
+{{- end -}}
+{{- $cs := .Values.uniplusApiPortal.database.connectionStringName -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "uniplusApiPortal.fullname" . }}
+  labels:
+    {{- include "uniplusApiPortal.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.uniplusApiPortal.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      {{- include "uniplusApiPortal.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "uniplusApiPortal.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "uniplusApiPortal.serviceAccountName" . }}
+      {{- with .Values.uniplusApiPortal.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.uniplusApiPortal.podSecurityContext | nindent 8 }}
+      containers:
+        - name: api
+          image: "{{ .Values.uniplusApiPortal.image.registry }}/{{ .Values.uniplusApiPortal.image.repository }}:{{ .Values.uniplusApiPortal.image.tag }}"
+          imagePullPolicy: {{ .Values.uniplusApiPortal.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.uniplusApiPortal.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            # === ASP.NET Core base ===
+            - name: ASPNETCORE_ENVIRONMENT
+              value: {{ .Values.uniplusApiPortal.aspnet.environment | quote }}
+            - name: ASPNETCORE_URLS
+              value: {{ .Values.uniplusApiPortal.aspnet.urls | quote }}
+            # === Postgres (ConnectionStrings__<Name>Db via .NET binding) ===
+            # Composição via env: host/port/database em values, password
+            # injetado via secretKeyRef. .NET aceita connection string completa
+            # numa única env — montamos no formato Npgsql.
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiPortal.postgresSecretName" . }}
+                  key: POSTGRES_PASSWORD
+            - name: ConnectionStrings__{{ $cs }}
+              value: "Host={{ .Values.uniplusApiPortal.database.host }};Port={{ .Values.uniplusApiPortal.database.port }};Database={{ .Values.uniplusApiPortal.database.name }};Username={{ .Values.uniplusApiPortal.database.username }};Password=$(POSTGRES_PASSWORD)"
+            # === Redis (Connection string formato StackExchange.Redis) ===
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiPortal.redisSecretName" . }}
+                  key: REDIS_PASSWORD
+            - name: Redis__ConnectionString
+              value: "{{ .Values.uniplusApiPortal.redis.host }}:{{ .Values.uniplusApiPortal.redis.port }},user={{ .Values.uniplusApiPortal.redis.username }},password=$(REDIS_PASSWORD)"
+            {{- if .Values.uniplusApiPortal.kafka.enabled }}
+            # === Kafka (SASL_SSL + SCRAM via .NET nested binding) ===
+            # Confluent.Kafka client lê estas env como AdminClientConfig/
+            # ProducerConfig.SecurityProtocol/SaslMechanism/SaslUsername/etc
+            # quando bind via IConfiguration.GetSection("Kafka").
+            - name: Kafka__BootstrapServers
+              value: {{ .Values.uniplusApiPortal.kafka.bootstrapServers | quote }}
+            - name: Kafka__SecurityProtocol
+              value: {{ .Values.uniplusApiPortal.kafka.securityProtocol | quote }}
+            - name: Kafka__SaslMechanism
+              value: {{ .Values.uniplusApiPortal.kafka.saslMechanism | quote }}
+            - name: Kafka__SaslUsername
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiPortal.kafkaSecretName" . }}
+                  key: KAFKA_USERNAME
+            - name: Kafka__SaslPassword
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiPortal.kafkaSecretName" . }}
+                  key: KAFKA_PASSWORD
+            - name: Kafka__SslCaLocation
+              value: {{ .Values.uniplusApiPortal.kafka.caCertPath | quote }}
+            {{- end }}
+            # === MinIO (Storage:* binding) ===
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiPortal.minioSecretName" . }}
+                  key: MINIO_ACCESS_KEY
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiPortal.minioSecretName" . }}
+                  key: MINIO_SECRET_KEY
+            - name: Storage__Endpoint
+              value: {{ .Values.uniplusApiPortal.storage.endpoint | quote }}
+            - name: Storage__AccessKey
+              value: "$(MINIO_ACCESS_KEY)"
+            - name: Storage__SecretKey
+              value: "$(MINIO_SECRET_KEY)"
+            - name: Storage__BucketName
+              value: {{ .Values.uniplusApiPortal.storage.bucketName | quote }}
+            {{- if .Values.uniplusApiPortal.oidc.enabled }}
+            # === OIDC (Auth:* binding — bearer validation) ===
+            - name: Auth__Authority
+              value: {{ .Values.uniplusApiPortal.oidc.issuerUri | quote }}
+            - name: Auth__Audience
+              value: {{ .Values.uniplusApiPortal.oidc.audience | quote }}
+            {{- end }}
+            {{- with .Values.uniplusApiPortal.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.uniplusApiPortal.kafka.enabled }}
+          volumeMounts:
+            # CA cert PEM do broker Kafka self-signed.
+            - name: kafka-ca
+              mountPath: /etc/uniplus-kafka/ca.crt
+              subPath: ca.crt
+              readOnly: true
+          {{- end }}
+          startupProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            failureThreshold: {{ .Values.uniplusApiPortal.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.uniplusApiPortal.startupProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            periodSeconds: {{ .Values.uniplusApiPortal.livenessProbe.periodSeconds }}
+          # Readiness usa /health (agregado com checks externos: Postgres,
+          # Redis, etc.). Pod sai de Ready quando dependência está down —
+          # comportamento desejado pra service mesh remover do load balancer.
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: {{ .Values.uniplusApiPortal.readinessProbe.periodSeconds }}
+          resources:
+            {{- toYaml .Values.uniplusApiPortal.resources | nindent 12 }}
+      {{- if .Values.uniplusApiPortal.kafka.enabled }}
+      volumes:
+        - name: kafka-ca
+          secret:
+            secretName: {{ include "uniplusApiPortal.kafkaSecretName" . }}
+            items:
+              - key: ca.crt
+                path: ca.crt
+      {{- end }}
+{{- end }}

--- a/apps/uniplus-api-portal/templates/externalsecret.yaml
+++ b/apps/uniplus-api-portal/templates/externalsecret.yaml
@@ -1,0 +1,130 @@
+{{- if and .Values.uniplusApiPortal.enabled .Values.uniplusApiPortal.externalSecrets.enabled -}}
+{{- $top := . -}}
+{{- $es := .Values.uniplusApiPortal.externalSecrets -}}
+# ESO 1: Postgres app password (DB dedicada — ex.: uniplus_portal/role portal).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiPortal.postgresSecretName" . }}
+  labels:
+    {{- include "uniplusApiPortal.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiPortal.postgresSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: {{ $es.postgresApp.vaultPath }}
+        property: {{ $es.postgresApp.passwordKey }}
+---
+# ESO 2: Redis default user password.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiPortal.redisSecretName" . }}
+  labels:
+    {{- include "uniplusApiPortal.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiPortal.redisSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: REDIS_PASSWORD
+      remoteRef:
+        key: {{ $es.redisDefault.vaultPath }}
+        property: {{ $es.redisDefault.passwordKey }}
+---
+# ESO 3: MinIO root credentials (compartilhado em standalone).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiPortal.minioSecretName" . }}
+  labels:
+    {{- include "uniplusApiPortal.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiPortal.minioSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: MINIO_ACCESS_KEY
+      remoteRef:
+        key: {{ $es.minioRoot.vaultPath }}
+        property: {{ $es.minioRoot.usernameKey }}
+    - secretKey: MINIO_SECRET_KEY
+      remoteRef:
+        key: {{ $es.minioRoot.vaultPath }}
+        property: {{ $es.minioRoot.passwordKey }}
+{{- if .Values.uniplusApiPortal.kafka.enabled }}
+---
+# ESO 4: Kafka SCRAM admin credentials + CA cert.
+# Em standalone usa SCRAM admin compartilhado (ADR-009 — em hml/prod migrar
+# para SCRAM users dedicados por app).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiPortal.kafkaSecretName" . }}
+  labels:
+    {{- include "uniplusApiPortal.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiPortal.kafkaSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: KAFKA_USERNAME
+      remoteRef:
+        key: {{ $es.kafkaAdmin.vaultPath }}
+        property: {{ $es.kafkaAdmin.usernameKey }}
+    - secretKey: KAFKA_PASSWORD
+      remoteRef:
+        key: {{ $es.kafkaAdmin.vaultPath }}
+        property: {{ $es.kafkaAdmin.passwordKey }}
+    - secretKey: ca.crt
+      remoteRef:
+        key: {{ $es.kafkaAdmin.vaultPath }}
+        property: {{ $es.kafkaAdmin.caCertKey }}
+{{- end }}
+{{- if .Values.uniplusApiPortal.oidc.enabled }}
+---
+# ESO 5: OIDC client_secret reservado para machine-to-machine (m2m)
+# FUTURO. Resource server bearer-only NÃO consome este Secret em runtime
+# — não há env var nem envFrom no Deployment referenciando-o. ESO antecipa
+# o cenário em que a API se autentica como service account contra outras
+# APIs (client_credentials grant). Mantido para parity com kafka-ui/apicurio-registry.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiPortal.oidcSecretName" . }}
+  labels:
+    {{- include "uniplusApiPortal.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiPortal.oidcSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: {{ $es.oidcClient.vaultPath }}
+        property: {{ $es.oidcClient.clientSecretKey }}
+{{- end }}
+{{- end }}

--- a/apps/uniplus-api-portal/templates/ingressroute.yaml
+++ b/apps/uniplus-api-portal/templates/ingressroute.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.uniplusApiPortal.enabled .Values.uniplusApiPortal.ingress.enabled -}}
+{{- if not .Values.uniplusApiPortal.ingress.host -}}
+{{- fail "uniplusApiPortal.ingress.host é obrigatório quando ingress.enabled=true (ex.: api-portal.standalone.portaluni.com.br)." -}}
+{{- end -}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "uniplusApiPortal.fullname" . }}
+  labels:
+    {{- include "uniplusApiPortal.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.uniplusApiPortal.ingress.entryPoint }}
+  routes:
+    - match: Host(`{{ .Values.uniplusApiPortal.ingress.host }}`)
+      kind: Rule
+      services:
+        - name: {{ include "uniplusApiPortal.fullname" . }}
+          port: 8080
+  {{- if .Values.uniplusApiPortal.ingress.tls.enabled }}
+  tls:
+    secretName: {{ .Values.uniplusApiPortal.ingress.tls.secretName | default (printf "%s-tls" (include "uniplusApiPortal.fullname" .)) }}
+  {{- end }}
+{{- end }}

--- a/apps/uniplus-api-portal/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-portal/templates/networkpolicy.yaml
@@ -1,0 +1,85 @@
+{{- if and .Values.uniplusApiPortal.enabled .Values.uniplusApiPortal.networkPolicy.enabled -}}
+{{- if not .Values.uniplusApiPortal.networkPolicy.dataHostCIDR -}}
+{{- fail "uniplusApiPortal.networkPolicy.dataHostCIDR é obrigatório (egress para Postgres + Redis + Kafka + MinIO no data-host)." -}}
+{{- end -}}
+{{- if and .Values.uniplusApiPortal.oidc.enabled (not .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (issuer público resolvido via Traefik no IP do k8s-host)." -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "uniplusApiPortal.fullname" . }}
+  labels:
+    {{- include "uniplusApiPortal.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "uniplusApiPortal.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiPortal.networkPolicy.traefikNamespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- if and .Values.uniplusApiPortal.metrics.enabled .Values.uniplusApiPortal.serviceMonitor.enabled }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiPortal.networkPolicy.monitoringNamespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- end }}
+  egress:
+    # DNS (CoreDNS).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Data-host (Postgres 5432 + Redis 6379 + Kafka 9092 + MinIO 9000).
+    # Single rule by CIDR + multi-port (todos compartilham mesmo /24 em standalone).
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.uniplusApiPortal.networkPolicy.dataHostCIDR }}
+      ports:
+        - protocol: TCP
+          port: 5432  # Postgres
+        - protocol: TCP
+          port: 6379  # Redis
+        - protocol: TCP
+          port: 9000  # MinIO API S3
+        {{- if .Values.uniplusApiPortal.kafka.enabled }}
+        - protocol: TCP
+          port: 9092  # Kafka SASL_SSL
+        {{- end }}
+    # Keycloak in-cluster (fallback se issuerUri usar Service DNS).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiPortal.networkPolicy.keycloakNamespace }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: keycloak-replica
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uniplusApiPortal.networkPolicy.keycloakPort }}
+    {{- if .Values.uniplusApiPortal.oidc.enabled }}
+    # OIDC issuer público — JWT validation chama jwks endpoint (HTTPS).
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uniplusApiPortal.networkPolicy.oidcIssuerPort }}
+    {{- end }}
+{{- end }}

--- a/apps/uniplus-api-portal/templates/service.yaml
+++ b/apps/uniplus-api-portal/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.uniplusApiPortal.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "uniplusApiPortal.fullname" . }}
+  labels:
+    {{- include "uniplusApiPortal.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "uniplusApiPortal.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/apps/uniplus-api-portal/templates/serviceaccount.yaml
+++ b/apps/uniplus-api-portal/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.uniplusApiPortal.enabled .Values.uniplusApiPortal.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "uniplusApiPortal.serviceAccountName" . }}
+  labels:
+    {{- include "uniplusApiPortal.labels" . | nindent 4 }}
+{{- end }}

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -1,22 +1,162 @@
-# Default values para uniplus-api-portal
-# TODO: implementar conforme estrutura do uniplus-web
-
-replicas: 2
-
-image:
-  registry: ghcr.io
-  repository: unifesspa-edu-br/uniplus-api-portal
-  pullPolicy: IfNotPresent
-  tag: ""
-
-resources:
-  requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 500m
-    memory: 256Mi
+# Defaults do chart apps/uniplus-api-portal/.
+# Cada environment (environments/<env>/values.yaml) sobrescreve apenas o
+# necessário. Por padrão DESABILITADO — só ambientes onde a imagem GHCR
+# estiver publicada e os pré-requisitos atendidos (DB, Vault paths, OIDC
+# client) ligam via `uniplusApiPortal.enabled: true`.
 
 commonLabels:
   app.kubernetes.io/part-of: uniplus
   app.kubernetes.io/component: api
+
+uniplusApiPortal:
+  enabled: false
+
+  image:
+    registry: ghcr.io
+    repository: unifesspa-edu-br/uniplus-api-portal
+    # Sincronizar com tag publicada em GHCR.
+    tag: "v0.1.1"
+    pullPolicy: IfNotPresent
+
+  imagePullSecrets: []
+
+  # API stateless. Em standalone 1 réplica para reduzir uso de recursos.
+  replicas: 1
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+
+  serviceAccount:
+    create: true
+    name: ""
+
+  aspnet:
+    environment: Production
+    urls: "http://+:8080"
+
+  # === Backend Postgres (DB dedicada por app) ===
+  database:
+    host: ""                    # ex.: 10.0.2.87
+    port: 5432
+    name: uniplus_portal
+    username: portal
+    # Nome em ConnectionStrings__<Name>Db (.NET config binding).
+    connectionStringName: PortalDb
+
+  # === Backend Redis (default user) ===
+  redis:
+    host: ""                    # ex.: 10.0.2.87
+    port: 6379
+    username: default
+
+  # === Backend Kafka (SASL_SSL + SCRAM-SHA-512, ADR-009) ===
+  # Pode ser desligado em primeiro deploy se SCRAM users per-app ainda não
+  # foram provisionados. Em standalone usa SCRAM admin compartilhado.
+  kafka:
+    enabled: true
+    bootstrapServers: ""        # ex.: 10.0.2.87:9092
+    securityProtocol: SASL_SSL
+    saslMechanism: SCRAM-SHA-512
+    # CA cert PEM mountado de Secret kafka-admin (key ca_cert).
+    caCertPath: /etc/uniplus-kafka/ca.crt
+
+  # === Backend MinIO S3 ===
+  storage:
+    endpoint: ""                # ex.: 10.0.2.87:9000
+    bucketName: uniplus-storage
+
+  # === OIDC (Auth bearer) ===
+  oidc:
+    enabled: true
+    issuerUri: ""               # ex.: https://standalone.portaluni.com.br/auth/realms/uniplus
+    audience: uniplus
+
+  # === ExternalSecrets (Vault → K8s Secret) ===
+  externalSecrets:
+    enabled: true
+    refreshInterval: "1h"
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: vault-default
+
+    postgresApp:
+      vaultPath: secret/standalone/postgres/portal
+      passwordKey: password
+
+    redisDefault:
+      vaultPath: secret/standalone/redis/default
+      passwordKey: password
+
+    kafkaAdmin:
+      vaultPath: secret/standalone/kafka/admin
+      usernameKey: username
+      passwordKey: password
+      caCertKey: ca_cert
+
+    minioRoot:
+      vaultPath: secret/standalone/minio/root
+      usernameKey: username
+      passwordKey: password
+
+    oidcClient:
+      vaultPath: secret/standalone/keycloak/clients/uniplus-api-portal
+      clientSecretKey: client_secret
+
+  # === Exposição externa via Traefik IngressRoute ===
+  ingress:
+    enabled: false
+    entryPoint: websecure
+    host: ""                    # ex.: api-portal.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: ""
+      certManager:
+        enabled: false
+        clusterIssuer: ""       # ex.: letsencrypt-prod
+
+  # === NetworkPolicy ===
+  networkPolicy:
+    enabled: true
+    traefikNamespace: traefik
+    monitoringNamespace: observability-prometheus
+    dataHostCIDR: ""            # ex.: 10.0.2.0/24
+    keycloakService: keycloak-replica-uniplus-standalone
+    keycloakNamespace: uniplus
+    keycloakPort: 8080
+    oidcIssuerCIDR: ""          # ex.: 164.152.53.29/32
+    oidcIssuerPort: 443
+
+  metrics:
+    enabled: false
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+
+  # /health/live: dependency-free (sempre 200 enquanto processo respira).
+  # /health: agregado readiness — falha sob transient outage de deps.
+  startupProbe:
+    failureThreshold: 60
+    periodSeconds: 5
+  livenessProbe:
+    periodSeconds: 10
+  readinessProbe:
+    periodSeconds: 5
+
+  # Container roda como `appuser` (UID 999, Debian useradd default).
+  podSecurityContext:
+    fsGroup: 999
+  containerSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false
+
+  extraEnv: []

--- a/apps/uniplus-api-selecao/Chart.yaml
+++ b/apps/uniplus-api-selecao/Chart.yaml
@@ -1,19 +1,33 @@
 apiVersion: v2
 name: uniplus-api-selecao
-description: API .NET 10 do módulo Seleção — editais e classificação
+description: |
+  API .NET 10 do módulo Selecao Uni+ — conteúdo institucional e perfis.
+  Backend ASP.NET Core minimal API + Wolverine (CQRS/messaging) + Serilog.
+  OpenAPI 3.1 em /openapi/portal.json. Health: /health (readiness),
+  /health/live (liveness).
 type: application
+
 version: 0.1.0
-appVersion: "1.0.0"
-keywords:
-  - uniplus
-  - api
-  - unifesspa
+
+# Sincronizar com tag publicada em ghcr.io/unifesspa-edu-br/uniplus-api-selecao.
+appVersion: "0.1.1"
+
 home: https://github.com/unifesspa-edu-br/uniplus-infra
 sources:
   - https://github.com/unifesspa-edu-br/uniplus-infra
+  - https://github.com/unifesspa-edu-br/uniplus-api
+
 maintainers:
   - name: CTIC UNIFESSPA
     email: jeferson.ferreira@unifesspa.edu.br
+
+keywords:
+  - uniplus
+  - api
+  - portal
+  - dotnet
+  - unifesspa
+
 annotations:
   category: api
   licenses: MIT

--- a/apps/uniplus-api-selecao/README.md
+++ b/apps/uniplus-api-selecao/README.md
@@ -1,6 +1,6 @@
 # uniplus-api-selecao
 
-API .NET 10 do módulo Seleção — editais e classificação
+API .NET 10 do módulo Selecao — conteúdo institucional e perfis
 
 > ⚠️ **Status:** placeholder inicial. Implementação dos templates pendente.
 

--- a/apps/uniplus-api-selecao/templates/_helpers.tpl
+++ b/apps/uniplus-api-selecao/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/* Fullname com truncate DNS-1123. */}}
+{{- define "uniplusApiSelecao.fullname" -}}
+{{- if .Values.uniplusApiSelecao.fullnameOverride -}}
+{{- .Values.uniplusApiSelecao.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.uniplusApiSelecao.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "uniplusApiSelecao.selectorLabels" -}}
+app.kubernetes.io/name: {{ default .Chart.Name .Values.uniplusApiSelecao.nameOverride }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "uniplusApiSelecao.labels" -}}
+{{ include "uniplusApiSelecao.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end -}}
+{{- end -}}
+
+{{- define "uniplusApiSelecao.serviceAccountName" -}}
+{{- if .Values.uniplusApiSelecao.serviceAccount.create -}}
+{{- default (printf "%s-sa" (include "uniplusApiSelecao.fullname" .)) .Values.uniplusApiSelecao.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.uniplusApiSelecao.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Nomes dos Secrets sintetizados pelo ESO. */}}
+{{- define "uniplusApiSelecao.postgresSecretName" -}}
+{{ include "uniplusApiSelecao.fullname" . }}-postgres
+{{- end -}}
+
+{{- define "uniplusApiSelecao.redisSecretName" -}}
+{{ include "uniplusApiSelecao.fullname" . }}-redis
+{{- end -}}
+
+{{- define "uniplusApiSelecao.kafkaSecretName" -}}
+{{ include "uniplusApiSelecao.fullname" . }}-kafka
+{{- end -}}
+
+{{- define "uniplusApiSelecao.minioSecretName" -}}
+{{ include "uniplusApiSelecao.fullname" . }}-minio
+{{- end -}}
+
+{{- define "uniplusApiSelecao.oidcSecretName" -}}
+{{ include "uniplusApiSelecao.fullname" . }}-oidc-client
+{{- end -}}

--- a/apps/uniplus-api-selecao/templates/certificate.yaml
+++ b/apps/uniplus-api-selecao/templates/certificate.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.uniplusApiSelecao.enabled .Values.uniplusApiSelecao.ingress.enabled .Values.uniplusApiSelecao.ingress.tls.enabled .Values.uniplusApiSelecao.ingress.tls.certManager.enabled -}}
+{{- if not .Values.uniplusApiSelecao.ingress.tls.certManager.clusterIssuer -}}
+{{- fail "uniplusApiSelecao.ingress.tls.certManager.clusterIssuer é obrigatório quando certManager.enabled=true (ex.: letsencrypt-prod)." -}}
+{{- end -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "uniplusApiSelecao.fullname" . }}
+  labels:
+    {{- include "uniplusApiSelecao.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.uniplusApiSelecao.ingress.tls.secretName | default (printf "%s-tls" (include "uniplusApiSelecao.fullname" .)) }}
+  commonName: {{ .Values.uniplusApiSelecao.ingress.host }}
+  dnsNames:
+    - {{ .Values.uniplusApiSelecao.ingress.host }}
+  issuerRef:
+    name: {{ .Values.uniplusApiSelecao.ingress.tls.certManager.clusterIssuer }}
+    kind: ClusterIssuer
+{{- end }}

--- a/apps/uniplus-api-selecao/templates/deployment.yaml
+++ b/apps/uniplus-api-selecao/templates/deployment.yaml
@@ -1,0 +1,175 @@
+{{- if .Values.uniplusApiSelecao.enabled -}}
+{{- if not .Values.uniplusApiSelecao.database.host -}}
+{{- fail "uniplusApiSelecao.database.host é obrigatório quando enabled=true. Configurar em environments/<env>/values.yaml (ex.: 10.0.2.87)." -}}
+{{- end -}}
+{{- if not .Values.uniplusApiSelecao.redis.host -}}
+{{- fail "uniplusApiSelecao.redis.host é obrigatório quando enabled=true." -}}
+{{- end -}}
+{{- if not .Values.uniplusApiSelecao.storage.endpoint -}}
+{{- fail "uniplusApiSelecao.storage.endpoint é obrigatório quando enabled=true (MinIO endpoint)." -}}
+{{- end -}}
+{{- if and .Values.uniplusApiSelecao.oidc.enabled (not .Values.uniplusApiSelecao.oidc.issuerUri) -}}
+{{- fail "uniplusApiSelecao.oidc.issuerUri é obrigatório quando oidc.enabled=true." -}}
+{{- end -}}
+{{- if and .Values.uniplusApiSelecao.kafka.enabled (not .Values.uniplusApiSelecao.kafka.bootstrapServers) -}}
+{{- fail "uniplusApiSelecao.kafka.bootstrapServers é obrigatório quando kafka.enabled=true." -}}
+{{- end -}}
+{{- if not .Values.uniplusApiSelecao.externalSecrets.enabled -}}
+{{- fail "uniplusApiSelecao.enabled=true requer externalSecrets.enabled=true. Deployment depende dos Secrets sintetizados pelo ESO (Postgres password, Redis, MinIO, Kafka, OIDC)." -}}
+{{- end -}}
+{{- $cs := .Values.uniplusApiSelecao.database.connectionStringName -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "uniplusApiSelecao.fullname" . }}
+  labels:
+    {{- include "uniplusApiSelecao.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.uniplusApiSelecao.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      {{- include "uniplusApiSelecao.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "uniplusApiSelecao.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "uniplusApiSelecao.serviceAccountName" . }}
+      {{- with .Values.uniplusApiSelecao.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.uniplusApiSelecao.podSecurityContext | nindent 8 }}
+      containers:
+        - name: api
+          image: "{{ .Values.uniplusApiSelecao.image.registry }}/{{ .Values.uniplusApiSelecao.image.repository }}:{{ .Values.uniplusApiSelecao.image.tag }}"
+          imagePullPolicy: {{ .Values.uniplusApiSelecao.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.uniplusApiSelecao.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            # === ASP.NET Core base ===
+            - name: ASPNETCORE_ENVIRONMENT
+              value: {{ .Values.uniplusApiSelecao.aspnet.environment | quote }}
+            - name: ASPNETCORE_URLS
+              value: {{ .Values.uniplusApiSelecao.aspnet.urls | quote }}
+            # === Postgres (ConnectionStrings__<Name>Db via .NET binding) ===
+            # Composição via env: host/port/database em values, password
+            # injetado via secretKeyRef. .NET aceita connection string completa
+            # numa única env — montamos no formato Npgsql.
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiSelecao.postgresSecretName" . }}
+                  key: POSTGRES_PASSWORD
+            - name: ConnectionStrings__{{ $cs }}
+              value: "Host={{ .Values.uniplusApiSelecao.database.host }};Port={{ .Values.uniplusApiSelecao.database.port }};Database={{ .Values.uniplusApiSelecao.database.name }};Username={{ .Values.uniplusApiSelecao.database.username }};Password=$(POSTGRES_PASSWORD)"
+            # === Redis (Connection string formato StackExchange.Redis) ===
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiSelecao.redisSecretName" . }}
+                  key: REDIS_PASSWORD
+            - name: Redis__ConnectionString
+              value: "{{ .Values.uniplusApiSelecao.redis.host }}:{{ .Values.uniplusApiSelecao.redis.port }},user={{ .Values.uniplusApiSelecao.redis.username }},password=$(REDIS_PASSWORD)"
+            {{- if .Values.uniplusApiSelecao.kafka.enabled }}
+            # === Kafka (SASL_SSL + SCRAM via .NET nested binding) ===
+            # Confluent.Kafka client lê estas env como AdminClientConfig/
+            # ProducerConfig.SecurityProtocol/SaslMechanism/SaslUsername/etc
+            # quando bind via IConfiguration.GetSection("Kafka").
+            - name: Kafka__BootstrapServers
+              value: {{ .Values.uniplusApiSelecao.kafka.bootstrapServers | quote }}
+            - name: Kafka__SecurityProtocol
+              value: {{ .Values.uniplusApiSelecao.kafka.securityProtocol | quote }}
+            - name: Kafka__SaslMechanism
+              value: {{ .Values.uniplusApiSelecao.kafka.saslMechanism | quote }}
+            - name: Kafka__SaslUsername
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiSelecao.kafkaSecretName" . }}
+                  key: KAFKA_USERNAME
+            - name: Kafka__SaslPassword
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiSelecao.kafkaSecretName" . }}
+                  key: KAFKA_PASSWORD
+            - name: Kafka__SslCaLocation
+              value: {{ .Values.uniplusApiSelecao.kafka.caCertPath | quote }}
+            {{- end }}
+            # === MinIO (Storage:* binding) ===
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiSelecao.minioSecretName" . }}
+                  key: MINIO_ACCESS_KEY
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiSelecao.minioSecretName" . }}
+                  key: MINIO_SECRET_KEY
+            - name: Storage__Endpoint
+              value: {{ .Values.uniplusApiSelecao.storage.endpoint | quote }}
+            - name: Storage__AccessKey
+              value: "$(MINIO_ACCESS_KEY)"
+            - name: Storage__SecretKey
+              value: "$(MINIO_SECRET_KEY)"
+            - name: Storage__BucketName
+              value: {{ .Values.uniplusApiSelecao.storage.bucketName | quote }}
+            {{- if .Values.uniplusApiSelecao.oidc.enabled }}
+            # === OIDC (Auth:* binding — bearer validation) ===
+            - name: Auth__Authority
+              value: {{ .Values.uniplusApiSelecao.oidc.issuerUri | quote }}
+            - name: Auth__Audience
+              value: {{ .Values.uniplusApiSelecao.oidc.audience | quote }}
+            {{- end }}
+            {{- with .Values.uniplusApiSelecao.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.uniplusApiSelecao.kafka.enabled }}
+          volumeMounts:
+            # CA cert PEM do broker Kafka self-signed.
+            - name: kafka-ca
+              mountPath: /etc/uniplus-kafka/ca.crt
+              subPath: ca.crt
+              readOnly: true
+          {{- end }}
+          startupProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            failureThreshold: {{ .Values.uniplusApiSelecao.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.uniplusApiSelecao.startupProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            periodSeconds: {{ .Values.uniplusApiSelecao.livenessProbe.periodSeconds }}
+          # Readiness usa /health (agregado com checks externos: Postgres,
+          # Redis, etc.). Pod sai de Ready quando dependência está down —
+          # comportamento desejado pra service mesh remover do load balancer.
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: {{ .Values.uniplusApiSelecao.readinessProbe.periodSeconds }}
+          resources:
+            {{- toYaml .Values.uniplusApiSelecao.resources | nindent 12 }}
+      {{- if .Values.uniplusApiSelecao.kafka.enabled }}
+      volumes:
+        - name: kafka-ca
+          secret:
+            secretName: {{ include "uniplusApiSelecao.kafkaSecretName" . }}
+            items:
+              - key: ca.crt
+                path: ca.crt
+      {{- end }}
+{{- end }}

--- a/apps/uniplus-api-selecao/templates/externalsecret.yaml
+++ b/apps/uniplus-api-selecao/templates/externalsecret.yaml
@@ -1,0 +1,130 @@
+{{- if and .Values.uniplusApiSelecao.enabled .Values.uniplusApiSelecao.externalSecrets.enabled -}}
+{{- $top := . -}}
+{{- $es := .Values.uniplusApiSelecao.externalSecrets -}}
+# ESO 1: Postgres app password (DB dedicada — ex.: uniplus_selecao/role portal).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiSelecao.postgresSecretName" . }}
+  labels:
+    {{- include "uniplusApiSelecao.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiSelecao.postgresSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: {{ $es.postgresApp.vaultPath }}
+        property: {{ $es.postgresApp.passwordKey }}
+---
+# ESO 2: Redis default user password.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiSelecao.redisSecretName" . }}
+  labels:
+    {{- include "uniplusApiSelecao.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiSelecao.redisSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: REDIS_PASSWORD
+      remoteRef:
+        key: {{ $es.redisDefault.vaultPath }}
+        property: {{ $es.redisDefault.passwordKey }}
+---
+# ESO 3: MinIO root credentials (compartilhado em standalone).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiSelecao.minioSecretName" . }}
+  labels:
+    {{- include "uniplusApiSelecao.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiSelecao.minioSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: MINIO_ACCESS_KEY
+      remoteRef:
+        key: {{ $es.minioRoot.vaultPath }}
+        property: {{ $es.minioRoot.usernameKey }}
+    - secretKey: MINIO_SECRET_KEY
+      remoteRef:
+        key: {{ $es.minioRoot.vaultPath }}
+        property: {{ $es.minioRoot.passwordKey }}
+{{- if .Values.uniplusApiSelecao.kafka.enabled }}
+---
+# ESO 4: Kafka SCRAM admin credentials + CA cert.
+# Em standalone usa SCRAM admin compartilhado (ADR-009 — em hml/prod migrar
+# para SCRAM users dedicados por app).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiSelecao.kafkaSecretName" . }}
+  labels:
+    {{- include "uniplusApiSelecao.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiSelecao.kafkaSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: KAFKA_USERNAME
+      remoteRef:
+        key: {{ $es.kafkaAdmin.vaultPath }}
+        property: {{ $es.kafkaAdmin.usernameKey }}
+    - secretKey: KAFKA_PASSWORD
+      remoteRef:
+        key: {{ $es.kafkaAdmin.vaultPath }}
+        property: {{ $es.kafkaAdmin.passwordKey }}
+    - secretKey: ca.crt
+      remoteRef:
+        key: {{ $es.kafkaAdmin.vaultPath }}
+        property: {{ $es.kafkaAdmin.caCertKey }}
+{{- end }}
+{{- if .Values.uniplusApiSelecao.oidc.enabled }}
+---
+# ESO 5: OIDC client_secret reservado para machine-to-machine (m2m)
+# FUTURO. Resource server bearer-only NÃO consome este Secret em runtime
+# — não há env var nem envFrom no Deployment referenciando-o. ESO antecipa
+# o cenário em que a API se autentica como service account contra outras
+# APIs (client_credentials grant). Mantido para parity com kafka-ui/apicurio-registry.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplusApiSelecao.oidcSecretName" . }}
+  labels:
+    {{- include "uniplusApiSelecao.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplusApiSelecao.oidcSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: {{ $es.oidcClient.vaultPath }}
+        property: {{ $es.oidcClient.clientSecretKey }}
+{{- end }}
+{{- end }}

--- a/apps/uniplus-api-selecao/templates/ingressroute.yaml
+++ b/apps/uniplus-api-selecao/templates/ingressroute.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.uniplusApiSelecao.enabled .Values.uniplusApiSelecao.ingress.enabled -}}
+{{- if not .Values.uniplusApiSelecao.ingress.host -}}
+{{- fail "uniplusApiSelecao.ingress.host é obrigatório quando ingress.enabled=true (ex.: api-portal.standalone.portaluni.com.br)." -}}
+{{- end -}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "uniplusApiSelecao.fullname" . }}
+  labels:
+    {{- include "uniplusApiSelecao.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.uniplusApiSelecao.ingress.entryPoint }}
+  routes:
+    - match: Host(`{{ .Values.uniplusApiSelecao.ingress.host }}`)
+      kind: Rule
+      services:
+        - name: {{ include "uniplusApiSelecao.fullname" . }}
+          port: 8080
+  {{- if .Values.uniplusApiSelecao.ingress.tls.enabled }}
+  tls:
+    secretName: {{ .Values.uniplusApiSelecao.ingress.tls.secretName | default (printf "%s-tls" (include "uniplusApiSelecao.fullname" .)) }}
+  {{- end }}
+{{- end }}

--- a/apps/uniplus-api-selecao/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-selecao/templates/networkpolicy.yaml
@@ -1,0 +1,85 @@
+{{- if and .Values.uniplusApiSelecao.enabled .Values.uniplusApiSelecao.networkPolicy.enabled -}}
+{{- if not .Values.uniplusApiSelecao.networkPolicy.dataHostCIDR -}}
+{{- fail "uniplusApiSelecao.networkPolicy.dataHostCIDR é obrigatório (egress para Postgres + Redis + Kafka + MinIO no data-host)." -}}
+{{- end -}}
+{{- if and .Values.uniplusApiSelecao.oidc.enabled (not .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (issuer público resolvido via Traefik no IP do k8s-host)." -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "uniplusApiSelecao.fullname" . }}
+  labels:
+    {{- include "uniplusApiSelecao.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "uniplusApiSelecao.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiSelecao.networkPolicy.traefikNamespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- if and .Values.uniplusApiSelecao.metrics.enabled .Values.uniplusApiSelecao.serviceMonitor.enabled }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiSelecao.networkPolicy.monitoringNamespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- end }}
+  egress:
+    # DNS (CoreDNS).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Data-host (Postgres 5432 + Redis 6379 + Kafka 9092 + MinIO 9000).
+    # Single rule by CIDR + multi-port (todos compartilham mesmo /24 em standalone).
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.uniplusApiSelecao.networkPolicy.dataHostCIDR }}
+      ports:
+        - protocol: TCP
+          port: 5432  # Postgres
+        - protocol: TCP
+          port: 6379  # Redis
+        - protocol: TCP
+          port: 9000  # MinIO API S3
+        {{- if .Values.uniplusApiSelecao.kafka.enabled }}
+        - protocol: TCP
+          port: 9092  # Kafka SASL_SSL
+        {{- end }}
+    # Keycloak in-cluster (fallback se issuerUri usar Service DNS).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiSelecao.networkPolicy.keycloakNamespace }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: keycloak-replica
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uniplusApiSelecao.networkPolicy.keycloakPort }}
+    {{- if .Values.uniplusApiSelecao.oidc.enabled }}
+    # OIDC issuer público — JWT validation chama jwks endpoint (HTTPS).
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uniplusApiSelecao.networkPolicy.oidcIssuerPort }}
+    {{- end }}
+{{- end }}

--- a/apps/uniplus-api-selecao/templates/service.yaml
+++ b/apps/uniplus-api-selecao/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.uniplusApiSelecao.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "uniplusApiSelecao.fullname" . }}
+  labels:
+    {{- include "uniplusApiSelecao.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "uniplusApiSelecao.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/apps/uniplus-api-selecao/templates/serviceaccount.yaml
+++ b/apps/uniplus-api-selecao/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.uniplusApiSelecao.enabled .Values.uniplusApiSelecao.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "uniplusApiSelecao.serviceAccountName" . }}
+  labels:
+    {{- include "uniplusApiSelecao.labels" . | nindent 4 }}
+{{- end }}

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -1,22 +1,162 @@
-# Default values para uniplus-api-selecao
-# TODO: implementar conforme estrutura do uniplus-web
-
-replicas: 2
-
-image:
-  registry: ghcr.io
-  repository: unifesspa-edu-br/uniplus-api-selecao
-  pullPolicy: IfNotPresent
-  tag: ""
-
-resources:
-  requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 500m
-    memory: 256Mi
+# Defaults do chart apps/uniplus-api-selecao/.
+# Cada environment (environments/<env>/values.yaml) sobrescreve apenas o
+# necessário. Por padrão DESABILITADO — só ambientes onde a imagem GHCR
+# estiver publicada e os pré-requisitos atendidos (DB, Vault paths, OIDC
+# client) ligam via `uniplusApiSelecao.enabled: true`.
 
 commonLabels:
   app.kubernetes.io/part-of: uniplus
   app.kubernetes.io/component: api
+
+uniplusApiSelecao:
+  enabled: false
+
+  image:
+    registry: ghcr.io
+    repository: unifesspa-edu-br/uniplus-api-selecao
+    # Sincronizar com tag publicada em GHCR.
+    tag: "v0.1.1"
+    pullPolicy: IfNotPresent
+
+  imagePullSecrets: []
+
+  # API stateless. Em standalone 1 réplica para reduzir uso de recursos.
+  replicas: 1
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+
+  serviceAccount:
+    create: true
+    name: ""
+
+  aspnet:
+    environment: Production
+    urls: "http://+:8080"
+
+  # === Backend Postgres (DB dedicada por app) ===
+  database:
+    host: ""                    # ex.: 10.0.2.87
+    port: 5432
+    name: uniplus_selecao
+    username: selecao
+    # Nome em ConnectionStrings__<Name>Db (.NET config binding).
+    connectionStringName: SelecaoDb
+
+  # === Backend Redis (default user) ===
+  redis:
+    host: ""                    # ex.: 10.0.2.87
+    port: 6379
+    username: default
+
+  # === Backend Kafka (SASL_SSL + SCRAM-SHA-512, ADR-009) ===
+  # Pode ser desligado em primeiro deploy se SCRAM users per-app ainda não
+  # foram provisionados. Em standalone usa SCRAM admin compartilhado.
+  kafka:
+    enabled: true
+    bootstrapServers: ""        # ex.: 10.0.2.87:9092
+    securityProtocol: SASL_SSL
+    saslMechanism: SCRAM-SHA-512
+    # CA cert PEM mountado de Secret kafka-admin (key ca_cert).
+    caCertPath: /etc/uniplus-kafka/ca.crt
+
+  # === Backend MinIO S3 ===
+  storage:
+    endpoint: ""                # ex.: 10.0.2.87:9000
+    bucketName: uniplus-storage
+
+  # === OIDC (Auth bearer) ===
+  oidc:
+    enabled: true
+    issuerUri: ""               # ex.: https://standalone.portaluni.com.br/auth/realms/uniplus
+    audience: uniplus
+
+  # === ExternalSecrets (Vault → K8s Secret) ===
+  externalSecrets:
+    enabled: true
+    refreshInterval: "1h"
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: vault-default
+
+    postgresApp:
+      vaultPath: secret/standalone/postgres/selecao
+      passwordKey: password
+
+    redisDefault:
+      vaultPath: secret/standalone/redis/default
+      passwordKey: password
+
+    kafkaAdmin:
+      vaultPath: secret/standalone/kafka/admin
+      usernameKey: username
+      passwordKey: password
+      caCertKey: ca_cert
+
+    minioRoot:
+      vaultPath: secret/standalone/minio/root
+      usernameKey: username
+      passwordKey: password
+
+    oidcClient:
+      vaultPath: secret/standalone/keycloak/clients/uniplus-api-selecao
+      clientSecretKey: client_secret
+
+  # === Exposição externa via Traefik IngressRoute ===
+  ingress:
+    enabled: false
+    entryPoint: websecure
+    host: ""                    # ex.: api-portal.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: ""
+      certManager:
+        enabled: false
+        clusterIssuer: ""       # ex.: letsencrypt-prod
+
+  # === NetworkPolicy ===
+  networkPolicy:
+    enabled: true
+    traefikNamespace: traefik
+    monitoringNamespace: observability-prometheus
+    dataHostCIDR: ""            # ex.: 10.0.2.0/24
+    keycloakService: keycloak-replica-uniplus-standalone
+    keycloakNamespace: uniplus
+    keycloakPort: 8080
+    oidcIssuerCIDR: ""          # ex.: 164.152.53.29/32
+    oidcIssuerPort: 443
+
+  metrics:
+    enabled: false
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+
+  # /health/live: dependency-free (sempre 200 enquanto processo respira).
+  # /health: agregado readiness — falha sob transient outage de deps.
+  startupProbe:
+    failureThreshold: 60
+    periodSeconds: 5
+  livenessProbe:
+    periodSeconds: 10
+  readinessProbe:
+    periodSeconds: 5
+
+  # Container roda como `appuser` (UID 999, Debian useradd default).
+  podSecurityContext:
+    fsGroup: 999
+  containerSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false
+
+  extraEnv: []

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -610,6 +610,105 @@ minioConsoleProxy:
         clusterIssuer: letsencrypt-prod
 
 # ----------------------------------------------------------------------------
+# Apps Uni+ API (portal, seleção, ingresso) — backends .NET 10 ASP.NET Core
+# publicados em ghcr.io/unifesspa-edu-br/uniplus-api-{portal,selecao,ingresso}.
+# Resource servers (bearer-only) que validam JWT contra realm uniplus,
+# audience=uniplus. Conectam Postgres (DB dedicado), Redis, Kafka SASL_SSL,
+# MinIO S3.
+# ----------------------------------------------------------------------------
+uniplusApiPortal:
+  enabled: true
+  database:
+    host: 10.0.2.87
+  redis:
+    host: 10.0.2.87
+  kafka:
+    # Desligado no primeiro deploy até validar que Wolverine/Confluent.Kafka
+    # do `uniplus-api` faz binding nativo de Kafka__SecurityProtocol/SaslMechanism/
+    # SaslUsername/SaslPassword/SslCaLocation via IConfiguration.GetSection("Kafka").
+    # Se o binding não existir, conexão SASL_SSL falha em runtime sem aparecer
+    # em helm lint. Re-habilitar após confirmação no código (issue follow-up).
+    # Code-reviewer P1 round 1.
+    enabled: false
+    bootstrapServers: 10.0.2.87:9092
+  storage:
+    endpoint: 10.0.2.87:9000
+  oidc:
+    issuerUri: https://standalone.portaluni.com.br/auth/realms/uniplus
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    host: api-portal.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: uniplus-api-portal-tls
+      certManager:
+        enabled: true
+        clusterIssuer: letsencrypt-prod
+  networkPolicy:
+    enabled: true
+    dataHostCIDR: 10.0.2.0/24
+    oidcIssuerCIDR: 164.152.53.29/32
+
+uniplusApiSelecao:
+  enabled: true
+  database:
+    host: 10.0.2.87
+  redis:
+    host: 10.0.2.87
+  kafka:
+    # Ver comentário em uniplusApiPortal.kafka — desligado até validar binding.
+    enabled: false
+    bootstrapServers: 10.0.2.87:9092
+  storage:
+    endpoint: 10.0.2.87:9000
+  oidc:
+    issuerUri: https://standalone.portaluni.com.br/auth/realms/uniplus
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    host: api-selecao.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: uniplus-api-selecao-tls
+      certManager:
+        enabled: true
+        clusterIssuer: letsencrypt-prod
+  networkPolicy:
+    enabled: true
+    dataHostCIDR: 10.0.2.0/24
+    oidcIssuerCIDR: 164.152.53.29/32
+
+uniplusApiIngresso:
+  enabled: true
+  database:
+    host: 10.0.2.87
+  redis:
+    host: 10.0.2.87
+  kafka:
+    # Ver comentário em uniplusApiPortal.kafka — desligado até validar binding.
+    enabled: false
+    bootstrapServers: 10.0.2.87:9092
+  storage:
+    endpoint: 10.0.2.87:9000
+  oidc:
+    issuerUri: https://standalone.portaluni.com.br/auth/realms/uniplus
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    host: api-ingresso.standalone.portaluni.com.br
+    tls:
+      enabled: true
+      secretName: uniplus-api-ingresso-tls
+      certManager:
+        enabled: true
+        clusterIssuer: letsencrypt-prod
+  networkPolicy:
+    enabled: true
+    dataHostCIDR: 10.0.2.0/24
+    oidcIssuerCIDR: 164.152.53.29/32
+
+# ----------------------------------------------------------------------------
 # Componentes stateful no data-host (Postgres, Kafka, MinIO, Redis) rodam
 # FORA do K8s, gerenciados por systemd em /var/lib/uniplus/* (ADR-002 +
 # ADR-005). Endpoints chegam às apps via External Secrets sintetizados a


### PR DESCRIPTION
## Resumo

Destrava deploy das 3 APIs .NET 10 publicadas hoje em GHCR (\`v0.1.1\`). Antes deste PR os charts \`apps/uniplus-api-*/\` eram só placeholders sem templates — ApplicationSet sincronizava sem criar pods.

## Pré-requisitos provisionados (sem PR — operacional)

- ✅ 3 DBs Postgres: \`uniplus_{portal,selecao,ingresso}\` (custódia em Vault \`secret/standalone/postgres/{portal,selecao,ingresso}\`)
- ✅ 3 OIDC clients confidential no realm \`uniplus\` (custódia \`secret/standalone/keycloak/clients/uniplus-api-{portal,selecao,ingresso}\`)
- ✅ Audience mapper \`uniplus\` adicionado ao \`apicurio-registry\` — JWT emitido por ele agora tem \`aud: [\"uniplus\", \"account\"]\`

## Decisões

### Kafka temporariamente OFF (\`kafka.enabled: false\`)

Wolverine/Confluent.Kafka client do uniplus-api ainda não foi validado para fazer binding nativo de \`Kafka__SecurityProtocol\`/\`SaslMechanism\`/etc via .NET IConfiguration. Re-habilitar após confirmação no código do uniplus-api (caso contrário, conexão SASL_SSL falha em runtime). Code-reviewer P1.

### OIDC client_secret reservado para m2m futuro

APIs são bearer-only (validam JWT, não emitem). ESO sintetiza o Secret mas Deployment NÃO consome. Mantido para parity com kafka-ui/apicurio-registry e prep para client_credentials grant entre APIs futuro.

### Connection strings via \`\$(VAR)\` expansion

Postgres: \`Host=...;Database=...;Username=...;Password=\$(POSTGRES_PASSWORD)\`. Ordem das envs no array garante expansão correta.

## Pre-PR review (subagent code-reviewer)

- 0 P0
- 3 P1: 1 corrigido (kafka enabled=false), 1 corrigido (comentário OIDC), 1 deferido (selectorLabels colision-safe via Release.Name distinto no AppSet)
- 2 P2 deferidos (values.schema.json follow-up, readOnlyRootFilesystem hardening)

## Validações

- helm lint enabled=false e enabled=true (full overlay) nos 3 charts ✓
- helm template renderiza 7 recursos com Kafka OFF (Service, SA, Deployment, 4 ESOs, IngressRoute, Certificate, NetworkPolicy) ✓
- yamllint clean ✓
- Connection string expansion order validada (POSTGRES_PASSWORD antes de ConnectionStrings__*) ✓

## Test plan pós-merge

- [ ] ApplicationSet sync: 3 apps Synced/Healthy com pods 1/1 Ready
- [ ] DNS OCI: 3 CNAMEs \`api-{portal,selecao,ingresso}.standalone.portaluni.com.br\`
- [ ] cert-manager emite cert LE prod nos 3
- [ ] Smoke E2E: token via apicurio-registry (audience=uniplus) → \`GET /health\` autenticado retorna 200 nas 3 APIs

## Follow-up issues

- Ativar Kafka SASL após confirmar binding no uniplus-api
- values.schema.json (paridade com apicurio-registry)
- SCRAM users dedicados Kafka per-app (HML/prod, ADR-009)
- IAM users MinIO + buckets isolados per-app (HML/prod)
- readOnlyRootFilesystem hardening