### PR TITLE
fix(uniplus-apis): Cors__AllowedOrigins obrigatório em Production

### DIFF
--- a/apps/uniplus-api-ingresso/templates/deployment.yaml
+++ b/apps/uniplus-api-ingresso/templates/deployment.yaml
@@ -131,6 +131,11 @@ spec:
             - name: Auth__Audience
               value: {{ .Values.uniplusApiIngresso.oidc.audience | quote }}
             {{- end }}
+            
+            {{- range $i, $origin := .Values.uniplusApiIngresso.cors.allowedOrigins }}
+            - name: Cors__AllowedOrigins__{{ $i }}
+              value: {{ $origin | quote }}
+            {{- end }}
             {{- with .Values.uniplusApiIngresso.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -76,6 +76,14 @@ uniplusApiIngresso:
     issuerUri: ""               # ex.: https://standalone.portaluni.com.br/auth/realms/uniplus
     audience: uniplus
 
+  # === CORS (obrigatório fora de Development) ===
+  # APIs validam no startup que Cors:AllowedOrigins esteja preenchido em
+  # ASPNETCORE_ENVIRONMENT=Production. Lista de origins (frontend SPA, ex.:
+  # https://portal.standalone.portaluni.com.br). Renderiza como env vars
+  # Cors__AllowedOrigins__0=..., __1=..., etc (.NET nested config binding).
+  cors:
+    allowedOrigins: []          # ex.: ["https://portal.standalone.portaluni.com.br"]
+
   # === ExternalSecrets (Vault → K8s Secret) ===
   externalSecrets:
     enabled: true

--- a/apps/uniplus-api-portal/templates/deployment.yaml
+++ b/apps/uniplus-api-portal/templates/deployment.yaml
@@ -131,6 +131,11 @@ spec:
             - name: Auth__Audience
               value: {{ .Values.uniplusApiPortal.oidc.audience | quote }}
             {{- end }}
+            
+            {{- range $i, $origin := .Values.uniplusApiPortal.cors.allowedOrigins }}
+            - name: Cors__AllowedOrigins__{{ $i }}
+              value: {{ $origin | quote }}
+            {{- end }}
             {{- with .Values.uniplusApiPortal.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -76,6 +76,14 @@ uniplusApiPortal:
     issuerUri: ""               # ex.: https://standalone.portaluni.com.br/auth/realms/uniplus
     audience: uniplus
 
+  # === CORS (obrigatório fora de Development) ===
+  # APIs validam no startup que Cors:AllowedOrigins esteja preenchido em
+  # ASPNETCORE_ENVIRONMENT=Production. Lista de origins (frontend SPA, ex.:
+  # https://portal.standalone.portaluni.com.br). Renderiza como env vars
+  # Cors__AllowedOrigins__0=..., __1=..., etc (.NET nested config binding).
+  cors:
+    allowedOrigins: []          # ex.: ["https://portal.standalone.portaluni.com.br"]
+
   # === ExternalSecrets (Vault → K8s Secret) ===
   externalSecrets:
     enabled: true

--- a/apps/uniplus-api-selecao/templates/deployment.yaml
+++ b/apps/uniplus-api-selecao/templates/deployment.yaml
@@ -131,6 +131,11 @@ spec:
             - name: Auth__Audience
               value: {{ .Values.uniplusApiSelecao.oidc.audience | quote }}
             {{- end }}
+            
+            {{- range $i, $origin := .Values.uniplusApiSelecao.cors.allowedOrigins }}
+            - name: Cors__AllowedOrigins__{{ $i }}
+              value: {{ $origin | quote }}
+            {{- end }}
             {{- with .Values.uniplusApiSelecao.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -76,6 +76,14 @@ uniplusApiSelecao:
     issuerUri: ""               # ex.: https://standalone.portaluni.com.br/auth/realms/uniplus
     audience: uniplus
 
+  # === CORS (obrigatório fora de Development) ===
+  # APIs validam no startup que Cors:AllowedOrigins esteja preenchido em
+  # ASPNETCORE_ENVIRONMENT=Production. Lista de origins (frontend SPA, ex.:
+  # https://portal.standalone.portaluni.com.br). Renderiza como env vars
+  # Cors__AllowedOrigins__0=..., __1=..., etc (.NET nested config binding).
+  cors:
+    allowedOrigins: []          # ex.: ["https://portal.standalone.portaluni.com.br"]
+
   # === ExternalSecrets (Vault → K8s Secret) ===
   externalSecrets:
     enabled: true

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -635,6 +635,14 @@ uniplusApiPortal:
     endpoint: 10.0.2.87:9000
   oidc:
     issuerUri: https://standalone.portaluni.com.br/auth/realms/uniplus
+  cors:
+    # APIs validam Cors:AllowedOrigins não-vazio em ASPNETCORE_ENVIRONMENT=Production
+    # (StartupValidator do .NET); pod CrashLoopBackOff sem isso.
+    # Frontend Uni+ Portal SPA ainda não deployado (uniplus-web#217 OPEN);
+    # placeholder pré-configurado para o domínio futuro.
+    allowedOrigins:
+      - https://standalone.portaluni.com.br
+      - https://portal.standalone.portaluni.com.br
   ingress:
     enabled: true
     entryPoint: websecure
@@ -664,6 +672,11 @@ uniplusApiSelecao:
     endpoint: 10.0.2.87:9000
   oidc:
     issuerUri: https://standalone.portaluni.com.br/auth/realms/uniplus
+  cors:
+    allowedOrigins:
+      - https://standalone.portaluni.com.br
+      - https://portal.standalone.portaluni.com.br
+      - https://selecao.standalone.portaluni.com.br
   ingress:
     enabled: true
     entryPoint: websecure
@@ -693,6 +706,11 @@ uniplusApiIngresso:
     endpoint: 10.0.2.87:9000
   oidc:
     issuerUri: https://standalone.portaluni.com.br/auth/realms/uniplus
+  cors:
+    allowedOrigins:
+      - https://standalone.portaluni.com.br
+      - https://portal.standalone.portaluni.com.br
+      - https://ingresso.standalone.portaluni.com.br
   ingress:
     enabled: true
     entryPoint: websecure


### PR DESCRIPTION
## Hotfix do PR #160

Smoke pós-merge: as 3 APIs entram em CrashLoopBackOff porque exigem `Cors:AllowedOrigins` em Production.

```
Microsoft.Extensions.Options.OptionsValidationException:
  CORS AllowedOrigins must be configured outside Development.
```

StartupValidator do .NET valida no boot. Não documentado no appsettings.json (vem da camada Infrastructure.Core.Cors do uniplus-api).

## Fix

- `cors.allowedOrigins: []` em values.yaml (default empty)
- Render `Cors__AllowedOrigins__N` no deployment.yaml (range nas origins)
- standalone: domínios futuros do frontend Uni+ pré-configurados

## Lição

Mais um caso de bug runtime que helm lint não pega — smoke fresh deploy é etapa irredutível.

## Test plan

- [x] helm lint OK
- [x] helm template renderiza Cors__AllowedOrigins__0/__1/__2
- [ ] Pós-merge: 3 pods Ready
- [ ] Smoke E2E /health autenticado
