### PR TITLE
feat(charts): bump APIs Uni+ para v0.2.0 (Epic uniplus-api#347)

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.1.1"
+    tag: "v0.2.0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.1.1"
+    tag: "v0.2.0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.1.1"
+    tag: "v0.2.0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
## Resumo

Sub-issue #164 da Epic standalone #40. Bumpa as 3 charts Helm das APIs Uni+ de `v0.1.1` para `v0.2.0`, puxando para o cluster standalone toda a Epic [uniplus-api#347](https://github.com/unifesspa-edu-br/uniplus-api/issues/347) (encerrada em 2026-05-09 com 5 sub-issues mergeadas).

Tag `v0.2.0` criada em \`uniplus-api/main\` HEAD (commit \`13dc977\`) — workflow \`publish-images.yml\` aciona em push de tag \`v*.*.*\` e publica 3 imagens em GHCR:

- `ghcr.io/unifesspa-edu-br/uniplus-api-portal:v0.2.0`
- `ghcr.io/unifesspa-edu-br/uniplus-api-selecao:v0.2.0`
- `ghcr.io/unifesspa-edu-br/uniplus-api-ingresso:v0.2.0`

## Diff

3 linhas — só o campo `tag` em cada `values.yaml`:

```diff
-    tag: "v0.1.1"
+    tag: "v0.2.0"
```

Aplicado em `apps/uniplus-api-portal/`, `apps/uniplus-api-selecao/`, `apps/uniplus-api-ingresso/`.

## O que vem na v0.2.0 (Epic uniplus-api#347)

| sub-issue | tema |
|---|---|
| #342 (PR uniplus-api#349) | DI MinIO + IStorageService — fecha gap latente que travava upload de documentos |
| #343 (PR uniplus-api#351) | Wolverine Kafka SASL_SSL+SCRAM via KafkaSettings (com 2 fixes Codex P2) |
| #344 (PR uniplus-api#352) | Migrations EF Core + Wolverine schema no startup via IHostedService filtrável |
| #345 (PR uniplus-api#356) | Health checks PG/Redis/MinIO/Kafka + DI Redis (IConnectionMultiplexer + ICacheService) |
| #346 (PR uniplus-api#357) | Endpoints smoke `/api/_smoke` + `KeycloakRolesClaimsTransformation` |

Bônus arquiteturais entregues fora do escopo das issues originais:

- `KeycloakRolesClaimsTransformation` — destrava `RequireRole(...)` nativo do .NET para qualquer policy futura
- `ApiFactoryBase.InfraHealthCheckNamesToRemoveForTests` — pattern de filtragem para test factories HTTP-only
- DI Redis (`IConnectionMultiplexer` + `ICacheService` registration) — gap latente análogo ao IMinioClient pré-#342

## Critérios de aceite

- [x] Tag `v0.2.0` criada em `uniplus-api/main` apontando para HEAD pós-Epic
- [ ] 3 imagens publicadas em GHCR com a nova tag (verificação após CI publish)
- [x] 3 charts em `apps/uniplus-api-*/values.yaml` atualizados para `v0.2.0`
- [x] `helm lint` limpo nos 3 charts
- [ ] ArgoCD reconcilia limpo após merge (verificar pós-merge)
- [ ] `kubectl rollout status` retorna `successfully rolled out` para os 3 (pós-deploy)
- [ ] `/health/ready` retorna agregado com OIDC + PG verdes (pós-deploy)

## Validação manual pós-merge

```bash
# Imagens disponíveis em GHCR
gh api /orgs/unifesspa-edu-br/packages/container/uniplus-api-portal/versions \
  --jq '.[] | select(.metadata.container.tags | contains(["v0.2.0"])) | .name'

# ArgoCD reconcilia
argocd app sync uniplus-api-portal uniplus-api-selecao uniplus-api-ingresso

# Rollout status
kubectl rollout status deploy/uniplus-api-portal -n uniplus
kubectl rollout status deploy/uniplus-api-selecao -n uniplus
kubectl rollout status deploy/uniplus-api-ingresso -n uniplus

# Health ready
kubectl exec deploy/uniplus-api-portal -n uniplus -- curl -s http://localhost:8080/health/ready
```

## Rollback

`git revert` do PR. ArgoCD reconcilia para `v0.1.1` (desfaz a Epic). Não há mudanças de schema/deploy estrutural — só a tag muda.

## Próximas issues

- #165 — habilitar `kafka.enabled: true` em `environments/standalone/values.yaml` (depende deste merge para que os pods tenham o helper SASL)
- #166 — smoke E2E manual no cluster
- #167 — aterrissar uniplus-web (paralelo, depende de uniplus-web#217)

## Referências

- Epic Uni+ standalone uniplus-infra#40
- Epic uniplus-api#347 (encerrada)
- ADR-0050 uniplus-api: lockstep release com GHCR
- Tag: https://github.com/unifesspa-edu-br/uniplus-api/releases/tag/v0.2.0

Refs #40
Refs uniplus-api#347
Closes #164