### PR TITLE
feat(keycloak): adiciona 3 OIDC clients confidenciais para APIs Uni+ (M2M Apicurio)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ### Adicionado
 
+- Keycloak realm `uniplus` ganha 3 confidential clients para fluxo M2M `client_credentials` — `uniplus-api-portal`, `uniplus-api-selecao`, `uniplus-api-ingresso`. Cada um com `serviceAccountsEnabled=true`, audience mapper para `apicurio-registry` e hardcoded-claim mapper que projeta `groups: ["/users/uniplus"]` (Apicurio mapeia → role `sr-developer`). Destrava `uniplus-api#358` (integração Apicurio Schema Registry). RUNBOOKS §15.6 documenta procedure de recuperação do `client_secret` pós-import. Issue #163.
 - Estrutura inicial do repositório uniplus-infra
 - Documentação institucional (README, CONTRIBUTING, SECURITY, LICENSE)
 - Documentação técnica (ARCHITECTURE, VALIDATION-PLAN, SETUP, RUNBOOKS)

--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -140,6 +140,165 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "uniplus-api-portal",
+      "name": "Uni+ API Portal — Service Account (M2M)",
+      "description": "Cliente OIDC confidencial da API Portal Uni+ para fluxo client_credentials (M2M). Usado pela API para obter access_token e chamar a Apicurio Registry REST API (Confluent SR). Não tem fluxo interativo: standardFlowEnabled=false, directAccessGrantsEnabled=false. client_secret gerado pelo Keycloak no import inicial; operador recupera via kcadm.sh e custodia em secret/standalone/keycloak/clients/uniplus-api-portal (RUNBOOKS §15.6). access_token tem aud=apicurio-registry e groups=[/users/uniplus] (via mappers abaixo) — Apicurio mapeia /users/uniplus → role sr-developer (apps/apicurio-registry/values.yaml).",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "frontchannelLogout": false,
+      "redirectUris": [],
+      "webOrigins": [],
+      "attributes": {
+        "access.token.lifespan": "300"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "protocolMappers": [
+        {
+          "name": "audience-apicurio-registry",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "apicurio-registry",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "groups-hardcoded-developer",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "groups",
+            "claim.value": "[\"/users/uniplus\"]",
+            "jsonType.label": "JSON",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "access.tokenResponse.claim": "false"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "uniplus-api-selecao",
+      "name": "Uni+ API Seleção — Service Account (M2M)",
+      "description": "Cliente OIDC confidencial da API Seleção Uni+ para fluxo client_credentials (M2M). Usado pela API para obter access_token e chamar a Apicurio Registry REST API (Confluent SR). Não tem fluxo interativo: standardFlowEnabled=false, directAccessGrantsEnabled=false. client_secret gerado pelo Keycloak no import inicial; operador recupera via kcadm.sh e custodia em secret/standalone/keycloak/clients/uniplus-api-selecao (RUNBOOKS §15.6). access_token tem aud=apicurio-registry e groups=[/users/uniplus] (via mappers abaixo) — Apicurio mapeia /users/uniplus → role sr-developer (apps/apicurio-registry/values.yaml).",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "frontchannelLogout": false,
+      "redirectUris": [],
+      "webOrigins": [],
+      "attributes": {
+        "access.token.lifespan": "300"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "protocolMappers": [
+        {
+          "name": "audience-apicurio-registry",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "apicurio-registry",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "groups-hardcoded-developer",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "groups",
+            "claim.value": "[\"/users/uniplus\"]",
+            "jsonType.label": "JSON",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "access.tokenResponse.claim": "false"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "uniplus-api-ingresso",
+      "name": "Uni+ API Ingresso — Service Account (M2M)",
+      "description": "Cliente OIDC confidencial da API Ingresso Uni+ para fluxo client_credentials (M2M). Usado pela API para obter access_token e chamar a Apicurio Registry REST API (Confluent SR). Não tem fluxo interativo: standardFlowEnabled=false, directAccessGrantsEnabled=false. client_secret gerado pelo Keycloak no import inicial; operador recupera via kcadm.sh e custodia em secret/standalone/keycloak/clients/uniplus-api-ingresso (RUNBOOKS §15.6). access_token tem aud=apicurio-registry e groups=[/users/uniplus] (via mappers abaixo) — Apicurio mapeia /users/uniplus → role sr-developer (apps/apicurio-registry/values.yaml).",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "frontchannelLogout": false,
+      "redirectUris": [],
+      "webOrigins": [],
+      "attributes": {
+        "access.token.lifespan": "300"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "protocolMappers": [
+        {
+          "name": "audience-apicurio-registry",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "apicurio-registry",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "groups-hardcoded-developer",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "groups",
+            "claim.value": "[\"/users/uniplus\"]",
+            "jsonType.label": "JSON",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "access.tokenResponse.claim": "false"
+          }
+        }
+      ]
     }
   ],
   "groups": [

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2994,10 +2994,12 @@ Saída esperada para cada cliente:
 **Passo 4 — Validar acesso à Apicurio com o token.**
 
 ```bash
-# Recarrega o client_secret de uniplus-api-portal explicitamente.
-# Sem isso, $CSECRET pode estar vindo da última iteração do Passo 3
-# (uniplus-api-ingresso), causando 401 falso e mascarando problemas
-# reais de auth na Apicurio.
+# Re-declara ISSUER e recarrega client_secret de uniplus-api-portal.
+# Sem isso, operador rodando este passo em shell novo (não na sequência
+# do Passo 3) hit URL malformada ($ISSUER unset) ou 401 falso ($CSECRET
+# vindo da última iteração do loop do Passo 3 — uniplus-api-ingresso),
+# mascarando problemas reais de auth na Apicurio.
+ISSUER="https://standalone.portaluni.com.br/auth/realms/uniplus"
 PORTAL_SECRET=$(VAULT_TOKEN=hvs.xxx vault kv get \
   -field=client_secret secret/standalone/keycloak/clients/uniplus-api-portal)
 

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2994,10 +2994,17 @@ Saída esperada para cada cliente:
 **Passo 4 — Validar acesso à Apicurio com o token.**
 
 ```bash
+# Recarrega o client_secret de uniplus-api-portal explicitamente.
+# Sem isso, $CSECRET pode estar vindo da última iteração do Passo 3
+# (uniplus-api-ingresso), causando 401 falso e mascarando problemas
+# reais de auth na Apicurio.
+PORTAL_SECRET=$(VAULT_TOKEN=hvs.xxx vault kv get \
+  -field=client_secret secret/standalone/keycloak/clients/uniplus-api-portal)
+
 TOKEN=$(curl -s -X POST "$ISSUER/protocol/openid-connect/token" \
   -d "grant_type=client_credentials" \
   -d "client_id=uniplus-api-portal" \
-  -d "client_secret=$CSECRET" | jq -r .access_token)
+  -d "client_secret=$PORTAL_SECRET" | jq -r .access_token)
 
 # Lista artifacts (deve retornar 200 OK e JSON, mesmo que vazio).
 curl -s -H "Authorization: Bearer $TOKEN" \

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2837,6 +2837,181 @@ curl -sk -H "Authorization: Bearer $TOKEN" \
 | `auth.apicur.io` aparece em logs OIDC | `QUARKUS_OIDC_AUTH_SERVER_URL` não setado — caiu no default Keycloak demo Red Hat | Validar `oidc.issuerUri` em `environments/standalone/values.yaml`. Sempre obrigatório — sem isso, Apicurio confia em IdP externo público |
 | Browser warning "Not secure" no `schema-registry.standalone.portaluni.com.br` | Cert LE staging | Promover para `letsencrypt-prod` em `ingress.tls.certManager.clusterIssuer` (já é default no `environments/standalone/values.yaml` — checar override por engano) |
 
+### 15.6 Pré-flight: client_secret das APIs Uni+ (uniplus-api-{portal,selecao,ingresso})
+
+Cada uma das 3 APIs Uni+ (`uniplus-api-portal`, `uniplus-api-selecao`, `uniplus-api-ingresso`) usa **OIDC client_credentials** para obter access_token contra o realm `uniplus` e chamar a Apicurio Registry REST API (`schema-registry.standalone.portaluni.com.br`). O fluxo é puro M2M — sem login interativo, sem redirect, sem PKCE.
+
+3 confidential clients foram declarados em `apps/keycloak-replica/files/uniplus-realm.json` na issue #163:
+
+| clientId | Vault path do client_secret | Consumido por |
+|---|---|---|
+| `uniplus-api-portal` | `secret/standalone/keycloak/clients/uniplus-api-portal` | API Portal (`apps/uniplus-api-portal/templates/externalsecret.yaml` ESO 5) |
+| `uniplus-api-selecao` | `secret/standalone/keycloak/clients/uniplus-api-selecao` | API Seleção (`apps/uniplus-api-selecao/templates/externalsecret.yaml` ESO 5) |
+| `uniplus-api-ingresso` | `secret/standalone/keycloak/clients/uniplus-api-ingresso` | API Ingresso (`apps/uniplus-api-ingresso/templates/externalsecret.yaml` ESO 5) |
+
+Sem `client_secret` em Vault, o ESO 5 fica em `SecretNotFound` e o pod da API trava em `CreateContainerConfigError` quando o Deployment passar a referenciar a env var (uniplus-api#358). Hoje (pré-Apicurio) a env não é montada — o ESO sintetiza o Secret no namespace por defesa em profundidade, mas o Deployment ignora.
+
+Cada client tem dois `protocolMappers` que projetam no access_token: (a) `audience-apicurio-registry` (mapper `oidc-audience-mapper`) — adiciona `apicurio-registry` ao claim `aud`, (b) `groups-hardcoded-developer` (mapper `oidc-hardcoded-claim-mapper`) — projeta `groups: ["/users/uniplus"]` no token. O Apicurio (`apps/apicurio-registry/values.yaml` `roleBasedAuth.developerClaim`) mapeia `/users/uniplus` → role interna `sr-developer`.
+
+```bash
+kc() { sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "$@"; }
+```
+
+**Passo 1 — Garantir os 3 clients no realm.**
+
+**Cluster novo (fresh import):** o realm.json já carrega os 3 clients no `--import-realm` inicial. Skipar para o Passo 2.
+
+**Cluster existente** (realm `uniplus` já importado anteriormente — Keycloak 26.x **skipa** re-import quando o realm existe): adicionar os 3 clients via `kcadm.sh` (mesmo pattern de §15.1 passo 2 e §14.1 passo 2). Idempotente:
+
+```bash
+kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c '
+  set -e
+  /opt/keycloak/bin/kcadm.sh config credentials \
+    --server http://localhost:8080/auth \
+    --realm master \
+    --user "$KC_BOOTSTRAP_ADMIN_USERNAME" \
+    --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" >/dev/null
+
+  for cid in uniplus-api-portal uniplus-api-selecao uniplus-api-ingresso; do
+    if ! /opt/keycloak/bin/kcadm.sh get clients -r uniplus --fields clientId 2>/dev/null \
+         | grep -q "\"clientId\" : \"$cid\""; then
+      /opt/keycloak/bin/kcadm.sh create clients -r uniplus \
+        -s clientId=$cid \
+        -s name="Uni+ API $cid — Service Account (M2M)" \
+        -s enabled=true \
+        -s publicClient=false \
+        -s standardFlowEnabled=false \
+        -s implicitFlowEnabled=false \
+        -s directAccessGrantsEnabled=false \
+        -s serviceAccountsEnabled=true \
+        -s frontchannelLogout=false \
+        -s "redirectUris=[]" \
+        -s "webOrigins=[]" \
+        -s "attributes.\"access.token.lifespan\"=300"
+    fi
+
+    CID=$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus -q clientId=$cid --fields id --format csv --noquotes | tail -1)
+
+    # Mapper 1: audience apicurio-registry
+    if ! /opt/keycloak/bin/kcadm.sh get clients/$CID/protocol-mappers/models -r uniplus 2>/dev/null \
+         | grep -q "\"name\" : \"audience-apicurio-registry\""; then
+      /opt/keycloak/bin/kcadm.sh create clients/$CID/protocol-mappers/models -r uniplus \
+        -s name=audience-apicurio-registry \
+        -s protocol=openid-connect \
+        -s protocolMapper=oidc-audience-mapper \
+        -s "config.\"included.client.audience\"=apicurio-registry" \
+        -s "config.\"id.token.claim\"=false" \
+        -s "config.\"access.token.claim\"=true"
+    fi
+
+    # Mapper 2: groups hardcoded /users/uniplus → role sr-developer no Apicurio
+    if ! /opt/keycloak/bin/kcadm.sh get clients/$CID/protocol-mappers/models -r uniplus 2>/dev/null \
+         | grep -q "\"name\" : \"groups-hardcoded-developer\""; then
+      /opt/keycloak/bin/kcadm.sh create clients/$CID/protocol-mappers/models -r uniplus \
+        -s name=groups-hardcoded-developer \
+        -s protocol=openid-connect \
+        -s protocolMapper=oidc-hardcoded-claim-mapper \
+        -s "config.\"claim.name\"=groups" \
+        -s "config.\"claim.value\"=[\"/users/uniplus\"]" \
+        -s "config.\"jsonType.label\"=JSON" \
+        -s "config.\"id.token.claim\"=true" \
+        -s "config.\"access.token.claim\"=true" \
+        -s "config.\"userinfo.token.claim\"=true" \
+        -s "config.\"access.tokenResponse.claim\"=false"
+    fi
+  done
+'
+```
+
+> **Nota — restart do Pod:** mudar o `realm.json` em Git força um rollout via annotation `checksum/realm` (sha256sum do arquivo) — `helm upgrade` faz a mudança sozinho. Em **cluster existente** o realm já está populado em DB, então o restart **não tem efeito incremental** sobre clients/mappers — por isso o `kcadm.sh` acima é necessário.
+
+**Passo 2 — Recuperar `client_secret` de cada client e custodiar em Vault.**
+
+Mesmo pattern do §14.1 (kafka-ui) e §15.1 passo 3 (apicurio-registry). O endpoint `clients/$CID/client-secret` é o único que retorna o valor efetivo.
+
+```bash
+for cid in uniplus-api-portal uniplus-api-selecao uniplus-api-ingresso; do
+  kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c "
+    set -e
+    /opt/keycloak/bin/kcadm.sh config credentials \
+      --server http://localhost:8080/auth \
+      --realm master \
+      --user \"\$KC_BOOTSTRAP_ADMIN_USERNAME\" \
+      --password \"\$KC_BOOTSTRAP_ADMIN_PASSWORD\" >/dev/null
+
+    CID=\$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus \
+      -q clientId=$cid --fields id --format csv --noquotes | tail -1)
+
+    /opt/keycloak/bin/kcadm.sh get clients/\$CID/client-secret -r uniplus \
+      --fields value --format csv --noquotes | tail -1
+  " > /tmp/$cid-cs
+
+  SECRET=$(cat /tmp/$cid-cs)
+
+  VAULT_TOKEN=hvs.xxx \
+    vault kv put secret/standalone/keycloak/clients/$cid \
+      client_secret="$SECRET"
+
+  shred -u /tmp/$cid-cs
+done
+```
+
+**Passo 3 — Smoke test do fluxo client_credentials.**
+
+Confirma que (a) o token endpoint aceita o `client_secret` recuperado, (b) o JWT retornado tem `aud=apicurio-registry` e `groups=["/users/uniplus"]`, (c) o claim `groups` é tratado como array (resultado do mapper com `jsonType.label=JSON`).
+
+```bash
+ISSUER="https://standalone.portaluni.com.br/auth/realms/uniplus"
+for cid in uniplus-api-portal uniplus-api-selecao uniplus-api-ingresso; do
+  CSECRET=$(VAULT_TOKEN=hvs.xxx vault kv get -field=client_secret secret/standalone/keycloak/clients/$cid)
+  TOKEN=$(curl -s -X POST "$ISSUER/protocol/openid-connect/token" \
+    -d "grant_type=client_credentials" \
+    -d "client_id=$cid" \
+    -d "client_secret=$CSECRET" \
+    | jq -r .access_token)
+
+  echo "=== $cid ==="
+  # Decode payload (parte do meio do JWT, base64url)
+  echo "$TOKEN" | cut -d. -f2 | tr '_-' '/+' \
+    | awk '{ l=length($0)%4; if(l==2)$0=$0"=="; else if(l==3)$0=$0"="; print }' \
+    | base64 -d 2>/dev/null \
+    | jq '{aud, azp, groups, scope, sub}'
+done
+```
+
+Saída esperada para cada cliente:
+
+```json
+{
+  "aud": ["apicurio-registry", "account"],
+  "azp": "uniplus-api-portal",
+  "groups": ["/users/uniplus"],
+  "scope": "profile email",
+  "sub": "<uuid-do-service-account>"
+}
+```
+
+**Passo 4 — Validar acesso à Apicurio com o token.**
+
+```bash
+TOKEN=$(curl -s -X POST "$ISSUER/protocol/openid-connect/token" \
+  -d "grant_type=client_credentials" \
+  -d "client_id=uniplus-api-portal" \
+  -d "client_secret=$CSECRET" | jq -r .access_token)
+
+# Lista artifacts (deve retornar 200 OK e JSON, mesmo que vazio).
+curl -s -H "Authorization: Bearer $TOKEN" \
+  https://schema-registry.standalone.portaluni.com.br/apis/registry/v3/groups/default/artifacts | jq .
+```
+
+| Resposta | Diagnóstico |
+|---|---|
+| `200 OK` + JSON | OK — token válido, audience aceito, role developer suficiente |
+| `401 Unauthorized` | Token inválido ou expirado. Re-rodar Passo 3 (lifespan = 300s) |
+| `403 Forbidden` | Token válido mas role insuficiente. Decode `groups` no JWT — deve conter `/users/uniplus`; se ausente, mapper `groups-hardcoded-developer` não foi criado (re-rodar Passo 1) |
+
+**Rotação do client_secret** segue o pattern de §14.4 (kafka-ui) — `kcadm.sh create clients/$CID/client-secret` regenera, depois `vault kv put` atualiza. ESO sincroniza no próximo refresh (1h padrão), e em seguida o Pod consumidor (Deployment da API) precisa ser rolled-restart para pegar a env var nova.
+
 ---
 
 ## 16. RedisInsight UI (standalone)


### PR DESCRIPTION
## Resumo

Adiciona ao realm `uniplus` 3 confidential clients OIDC para fluxo `client_credentials` (M2M), destravando a integração das APIs Uni+ com a Apicurio Schema Registry.

| clientId | Vault path do `client_secret` | Consumidor (post #358) |
|---|---|---|
| `uniplus-api-portal` | `secret/standalone/keycloak/clients/uniplus-api-portal` | API Portal |
| `uniplus-api-selecao` | `secret/standalone/keycloak/clients/uniplus-api-selecao` | API Seleção |
| `uniplus-api-ingresso` | `secret/standalone/keycloak/clients/uniplus-api-ingresso` | API Ingresso |

Cada client tem 2 protocolMappers que projetam no access_token:

- `audience-apicurio-registry` (`oidc-audience-mapper`) — adiciona `apicurio-registry` ao claim `aud`
- `groups-hardcoded-developer` (`oidc-hardcoded-claim-mapper`) — projeta `groups: ["/users/uniplus"]` no token. O Apicurio (`apps/apicurio-registry/values.yaml` `roleBasedAuth.developerClaim`) mapeia `/users/uniplus` → role interna `sr-developer`, suficiente para CRUD de schemas.

## O que mudou

| Arquivo | Mudança |
|---|---|
| `apps/keycloak-replica/files/uniplus-realm.json` | +3 entradas em `clients[]` (M2M, sem fluxo interativo) |
| `docs/RUNBOOKS.md` | Nova §15.6 — espelha pattern de §14.1 (kafka-ui) e §15.1 (apicurio-registry) |
| `CHANGELOG.md` | Entrada em `[Não lançado] / Adicionado` |

## Por que mudou

Pré-requisito de `uniplus-api#358` (Apicurio integration / Fase 5). As 3 APIs precisam fazer `client_credentials` para obter token e chamar a REST API do Apicurio (auth via Quarkus OIDC, Confluent-compatible mode). Sem isso, `secret/standalone/keycloak/clients/uniplus-api-*` não existe → ESO 5 fica em `SecretNotFound` → pod entra em `CreateContainerConfigError` quando o Deployment passar a referenciar a env var.

Os `ExternalSecret` 5 dos 3 charts API (`apps/uniplus-api-{portal,selecao,ingresso}/templates/externalsecret.yaml`) JÁ apontam para os Vault paths corretos (PR anterior); este PR fecha o lado realm.

## Decisão técnica — `/users/uniplus` vs `sr-developer`

A issue diz "Group mapper que projeta `sr-developer` no claim `groups`". Mas `apps/apicurio-registry/values.yaml` define:

```yaml
roleBasedAuth:
  adminClaim: \"/admins/kafka\"
  developerClaim: \"/users/uniplus\"
```

E o Deployment do apicurio-registry seta `APICURIO_AUTH_ROLES_DEVELOPER=/users/uniplus`. Logo, para o Apicurio reconhecer o SA como `sr-developer`, o JWT precisa conter `groups: [\"/users/uniplus\"]`, não `groups: [\"sr-developer\"]`. Implementação alinha com o estado real do código (issue está literalmente errada no valor exato, semanticamente certa na intenção).

## Como testou

- ✅ \`make yaml-lint\` — limpo
- ✅ \`make helm-lint\` — 16 charts lintados, 0 erros
- ✅ \`make markdown-lint\` — 61 arquivos, 0 erros
- ✅ \`make helm-template\` — todos os charts × envs renderizam (incluindo \`keycloak-replica × standalone\`)
- ✅ \`make schema-validate\` — todos os schemas batem
- ✅ Render do realm.json extraído do ConfigMap → \`python3 -m json.tool\` confirma JSON válido com 6 clients (3 originais + 3 novos), 3 novos com \`serviceAccountsEnabled=true\` e 2 mappers cada
- 📋 Smoke real (post-deploy operacional, fora do PR): documentado em RUNBOOKS §15.6 passos 3-4 — fetch token via \`curl client_credentials\` + decode JWT + validar \`aud=apicurio-registry\` + \`groups=[\"/users/uniplus\"]\` + GET artifacts no Apicurio retorna 200

## Riscos e rollback

- **R1** (mitigado): em cluster existente, Keycloak 26.x **skipa** re-import quando realm `uniplus` já existe — alterar `realm.json` em Git não propaga sozinho. RUNBOOKS §15.6 passo 1 documenta o `kcadm.sh` idempotente para criar os 3 clients + 2 mappers em cluster vivo.
- **R2** (aceito): \`access.token.lifespan: 300\` (5min) — Quarkus OIDC client lib renova automaticamente; aceitável para M2M.
- **R3** (aceito): hardcoded-claim mapper escolhido em vez de membership real do SA em group \`/users/uniplus\`. Trade-off: realm import mais simples, claim independente de eventual mudança em group membership. SAs M2M raramente mudam grupo — aceitável.
- **Rollback**: \`git revert\` + \`helm upgrade\` — operador pode também deletar os 3 clients via UI Admin do Keycloak. Sem dependência cruzada (Apicurio não exige clients específicos pré-criados).

## Documentação atualizada

- ✅ RUNBOOKS §15.6 (Pré-flight: client_secret das APIs Uni+) com 4 passos: criar clients, recuperar secrets, smoke client_credentials, smoke acesso Apicurio
- ✅ CHANGELOG.md (entrada em Adicionado)

## Critérios de aceite (issue #163)

- [x] \`apps/keycloak-replica/files/uniplus-realm.json\` ganha 3 entradas em \`clients[]\`
- [x] Helm template renderiza realm sem erros
- [-] Pós-deploy do realm: \`kcadm.sh\` consegue ler client_secret de cada um — operacional pós-merge (RUNBOOKS §15.6 passo 2 documenta)
- [-] Vault populado em \`secret/standalone/keycloak/clients/uniplus-api-{portal,selecao,ingresso}\` — operacional pós-merge (RUNBOOKS §15.6 passo 2)
- [x] ExternalSecret nos 3 charts API publica \`OIDC_CLIENT_SECRET\` env var — JÁ EXISTE em main (precede esta Story)
- [-] App consegue fazer client_credentials request → token tem \`aud: apicurio-registry\` + \`groups: [\"/users/uniplus\"]\` — validável pós-deploy via RUNBOOKS §15.6 passos 3-4
- [x] RUNBOOKS §15.X documenta procedure (§15.6)

Os bullets \`[-]\` são operações pós-merge no lab/HML, não couberam no PR.

## Não-objetivos (por escopo)

- Vault populate em ambiente real (operacional pós-merge)
- Mudança nos templates dos charts API (ESO 5 já existe)
- Consumo de \`OIDC_CLIENT_SECRET\` no Deployment da API (responsabilidade de \`uniplus-api#358\`)
- Renomear \`developerClaim\` no apicurio para \`sr-developer\` literal (mudança maior, fora do escopo)

Closes #163