### PR TITLE
feat(standalone): habilita kafka.enabled=true (Epic uniplus-api#347)

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -623,13 +623,14 @@ uniplusApiPortal:
   redis:
     host: 10.0.2.87
   kafka:
-    # Desligado no primeiro deploy até validar que Wolverine/Confluent.Kafka
-    # do `uniplus-api` faz binding nativo de Kafka__SecurityProtocol/SaslMechanism/
-    # SaslUsername/SaslPassword/SslCaLocation via IConfiguration.GetSection("Kafka").
-    # Se o binding não existir, conexão SASL_SSL falha em runtime sem aparecer
-    # em helm lint. Re-habilitar após confirmação no código (issue follow-up).
-    # Code-reviewer P1 round 1.
-    enabled: false
+    # Habilitado em 2026-05-09 (#165) — bind nativo Kafka:SecurityProtocol/
+    # SaslMechanism/SaslUsername/SaslPassword/SslCaLocation entregue por
+    # uniplus-api#343 (PR #351) e KafkaHealthCheck refatorado para usar
+    # IOptions<KafkaSettings> em uniplus-api#345 (PR #356), publicados em
+    # GHCR como v0.2.0 e puxados pela Epic uniplus-infra#164 (PR #168).
+    # Pré-requisito Vault: secret/standalone/kafka/admin com keys
+    # `username`, `password`, `ca_cert` (ESO refresha o Secret kafka-admin).
+    enabled: true
     bootstrapServers: 10.0.2.87:9092
   storage:
     endpoint: 10.0.2.87:9000
@@ -665,8 +666,8 @@ uniplusApiSelecao:
   redis:
     host: 10.0.2.87
   kafka:
-    # Ver comentário em uniplusApiPortal.kafka — desligado até validar binding.
-    enabled: false
+    # Ver comentário em uniplusApiPortal.kafka — habilitado em #165.
+    enabled: true
     bootstrapServers: 10.0.2.87:9092
   storage:
     endpoint: 10.0.2.87:9000
@@ -699,8 +700,8 @@ uniplusApiIngresso:
   redis:
     host: 10.0.2.87
   kafka:
-    # Ver comentário em uniplusApiPortal.kafka — desligado até validar binding.
-    enabled: false
+    # Ver comentário em uniplusApiPortal.kafka — habilitado em #165.
+    enabled: true
     bootstrapServers: 10.0.2.87:9092
   storage:
     endpoint: 10.0.2.87:9000


### PR DESCRIPTION
## Resumo

Sub-issue #165 da Epic standalone #40. As 3 APIs Uni+ no cluster standalone estavam com `kafka.enabled: false` desde o deploy inicial (PR #160), aguardando o binding nativo de `Kafka:SecurityProtocol`/`SaslMechanism`/`SaslUsername`/`SaslPassword`/`SslCaLocation` no `uniplus-api`. Esse binding foi entregue na Epic uniplus-api#347 e está disponível em runtime após o bump v0.2.0 (PR #168).

## Diff

12 linhas em `environments/standalone/values.yaml` (3 blocos `kafka.enabled` + comentários atualizados):

```diff
   kafka:
-    # Desligado no primeiro deploy até validar que Wolverine/Confluent.Kafka
-    # do `uniplus-api` faz binding nativo de Kafka__SecurityProtocol/...
-    enabled: false
+    # Habilitado em 2026-05-09 (#165) — bind nativo entregue por
+    # uniplus-api#343 (PR #351) + KafkaHealthCheck #356, GHCR v0.2.0 (#168).
+    enabled: true
```

Aplicado em `uniplusApiPortal`, `uniplusApiSelecao`, `uniplusApiIngresso`.

## O que destrava

Após ArgoCD reconciliar, cada Deployment passa a emitir env vars completos:

```bash
- name: Kafka__BootstrapServers      # value: 10.0.2.87:9092
- name: Kafka__SecurityProtocol      # value: SASL_SSL
- name: Kafka__SaslMechanism         # value: SCRAM-SHA-512
- name: Kafka__SaslUsername          # secretKeyRef: kafka-admin/KAFKA_USERNAME
- name: Kafka__SaslPassword          # secretKeyRef: kafka-admin/KAFKA_PASSWORD
- name: Kafka__SslCaLocation         # value: /etc/uniplus-kafka/ca.crt
```

E mounta `ca.crt` de `kafka-admin` Secret (volume mount `/etc/uniplus-kafka/ca.crt`).

`KafkaSettings` + `KafkaSecurity.Apply` no app fazem o resto: `Wolverine.UseKafka(...).ConfigureClient(...)` aplica o SecurityProtocol/SaslMechanism/etc. no `ClientConfig`. `KafkaHealthCheck` (refatorado em uniplus-api#345/PR #356) recebe `IOptions<KafkaSettings>` e usa o mesmo helper para health check em standalone — para de reportar Unhealthy permanente.

## Pré-requisito Vault (operacional)

ESO (`templates/externalsecret.yaml`) lê 3 keys de `secret/standalone/kafka/admin`:

| Key Vault | Mapeia para Secret K8s |
|---|---|
| `username` | `KAFKA_USERNAME` |
| `password` | `KAFKA_PASSWORD` |
| `ca_cert`  | `ca.crt` |

Verificar pré-merge:

```bash
vault kv get secret/standalone/kafka/admin
# Esperado: campos `username`, `password`, `ca_cert` populados.
```

Se algum estiver ausente, ESO falha em sincronizar → Deployment fica `CreateContainerConfigError` ou pods crash com env var ausente. Operador deve popular antes do merge.

## Validação local

```bash
helm lint apps/uniplus-api-portal apps/uniplus-api-selecao apps/uniplus-api-ingresso  # clean

# render confirma envs Kafka SASL_SSL nos 3 charts
helm template apps/uniplus-api-portal -f apps/uniplus-api-portal/values.yaml -f environments/standalone/values.yaml | grep Kafka__
```

Render limpo (3 charts) — vars Kafka aparecem só com `kafka.enabled: true`.

## Critérios de aceite (issue #165)

- [x] 3 blocos `kafka.enabled: true` em `environments/standalone/values.yaml`
- [x] Comentário inline atualizado citando uniplus-api#343 / PR #351
- [ ] ArgoCD reconcilia limpo (verificar pós-merge)
- [ ] `kubectl exec deploy/uniplus-api-portal -- curl -s http://localhost:8080/health/ready | jq '.entries.kafka.status'` retorna `Healthy` (pós-deploy)
- [ ] Pelo menos 1 publish via `/api/_smoke/messaging/publish` chega ao broker — log com `EventId 4001` (validado em #166)

## Validação manual pós-merge

```bash
# Verificar binding aplicado
kubectl exec deploy/uniplus-api-portal -n uniplus -- env | grep '^Kafka'

# ESO sincronizou Secret kafka-admin?
kubectl get secret kafka-admin -n uniplus -o jsonpath='{.data}' | jq 'keys'
# Esperado: ["KAFKA_PASSWORD","KAFKA_USERNAME","ca.crt"]

# Health check Kafka
kubectl exec deploy/uniplus-api-portal -n uniplus -- \
  curl -s http://localhost:8080/health/ready | jq '.entries.kafka'

# Smoke E2E (admin token — ver #166)
TOKEN="<admin token>"
kubectl exec deploy/uniplus-api-portal -n uniplus -- \
  curl -s -X POST -H "Authorization: Bearer $TOKEN" \
  http://localhost:8080/api/_smoke/messaging/publish | jq

# Confirmar log do consumer
kubectl logs deploy/uniplus-api-portal -n uniplus | grep '"EventId":4001'
```

## Rollback

`git revert` do PR. ArgoCD reconcilia para `enabled: false`. Pods reiniciam sem env vars Kafka — Wolverine fica com queue PG-only, mas processo sobe normalmente.

## Referências

- Epic Uni+ standalone uniplus-infra#40
- ADR-009 uniplus-infra (Kafka SASL_SSL+SCRAM)
- uniplus-api PR #351 (#343): KafkaSettings + helpers
- uniplus-api PR #356 (#345): KafkaHealthCheck refatorado para `IOptions<KafkaSettings>`
- uniplus-api v0.2.0 release tag
- uniplus-infra PR #168 (#164): bump charts para v0.2.0

Refs #40
Refs uniplus-api#347
Closes #165