### PR TITLE
feat(uniplus-web): chart Helm — 3 deployments por subdomain (#162)

### DIFF
--- a/apps/uniplus-web/Chart.yaml
+++ b/apps/uniplus-web/Chart.yaml
@@ -7,11 +7,12 @@ description: |
 
 type: application
 
-# Versão do chart
-version: 0.1.0
+# Versão do chart — bumped quando templates mudam (uniplus-infra#162).
+version: 0.2.0
 
-# Versão da aplicação Uni+ Web (atualizar conforme releases)
-appVersion: "1.0.0"
+# Versão da aplicação Uni+ Web (release inicial GHCR — uniplus-web#216).
+# Tag override por app em values.yaml (apps.<name>.tag).
+appVersion: "v0.1.0"
 
 keywords:
   - uniplus

--- a/apps/uniplus-web/templates/_helpers.tpl
+++ b/apps/uniplus-web/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/*
+  Fullname-base do release. Cada app web (portal/seleção/ingresso) é um
+  Deployment separado com sufixo do app: `<release>-<chart>-<app>`.
+
+  Truncate aplicado em camadas para garantir DNS-1123 (≤63 chars) tanto no
+  fullname-base quanto no nome final concatenado com o app.
+*/}}
+{{- define "uniplusWeb.fullname" -}}
+{{- if .Values.uniplusWeb.fullnameOverride -}}
+{{- .Values.uniplusWeb.fullnameOverride | trunc 53 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.uniplusWeb.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 53 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  Per-app fullname: `<fullname>-<app>`.
+
+  Recebe um dict com `ctx` (root context) e `app` (nome do app — portal/
+  selecao/ingresso). Trunca a 63 chars para não exceder limite DNS-1123.
+*/}}
+{{- define "uniplusWeb.appFullname" -}}
+{{- printf "%s-%s" (include "uniplusWeb.fullname" .ctx) .app | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+  Selector labels comuns a todo o chart, mais o sufixo `app.kubernetes.io/
+  component-instance` que distingue os 3 deployments dentro do release.
+*/}}
+{{- define "uniplusWeb.selectorLabels" -}}
+{{- $name := default .ctx.Chart.Name .ctx.Values.uniplusWeb.nameOverride -}}
+app.kubernetes.io/name: {{ $name }}
+app.kubernetes.io/instance: {{ .ctx.Release.Name }}
+app.kubernetes.io/component-instance: {{ .app }}
+{{- end -}}
+
+{{- define "uniplusWeb.labels" -}}
+{{ include "uniplusWeb.selectorLabels" . }}
+app.kubernetes.io/version: {{ .ctx.Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .ctx.Chart.Name .ctx.Chart.Version | replace "+" "_" }}
+{{- with .ctx.Values.uniplusWeb.commonLabels }}
+{{ toYaml . }}
+{{- end -}}
+{{- end -}}
+
+{{- define "uniplusWeb.serviceAccountName" -}}
+{{- if .ctx.Values.uniplusWeb.serviceAccount.create -}}
+{{- default (printf "%s-sa" (include "uniplusWeb.appFullname" .)) .ctx.Values.uniplusWeb.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .ctx.Values.uniplusWeb.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  Image fully-qualified: registry/repository/<image>:<tag>.
+  Resolve tag com fallback `apps.<name>.tag` → `image.tag` → `Chart.AppVersion`.
+*/}}
+{{- define "uniplusWeb.image" -}}
+{{- $img := .appCfg.image -}}
+{{- $tag := .appCfg.tag | default .ctx.Values.uniplusWeb.image.tag | default .ctx.Chart.AppVersion -}}
+{{- printf "%s/%s/%s:%s" .ctx.Values.uniplusWeb.image.registry .ctx.Values.uniplusWeb.image.repository $img $tag -}}
+{{- end -}}
+
+{{/*
+  ConfigMap nome (runtime-config.json) per-app.
+*/}}
+{{- define "uniplusWeb.runtimeConfigMapName" -}}
+{{ include "uniplusWeb.appFullname" . }}-runtime-config
+{{- end -}}

--- a/apps/uniplus-web/templates/certificate.yaml
+++ b/apps/uniplus-web/templates/certificate.yaml
@@ -3,7 +3,10 @@
 {{- fail "uniplusWeb.ingress.tls.certManager.clusterIssuer é obrigatório quando certManager.enabled=true (ex.: letsencrypt-prod)." -}}
 {{- end -}}
 {{- range $app, $cfg := .Values.uniplusWeb.apps -}}
-{{- if $cfg.enabled }}
+{{- if $cfg.enabled -}}
+{{- if not $cfg.host -}}
+{{- fail (printf "uniplusWeb.apps.%s.host é obrigatório quando ingress.tls.certManager.enabled=true (ex.: %s.standalone.portaluni.com.br). Certificate cert-manager exige dnsNames válido." $app $app) -}}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/apps/uniplus-web/templates/certificate.yaml
+++ b/apps/uniplus-web/templates/certificate.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.uniplusWeb.enabled .Values.uniplusWeb.ingress.enabled .Values.uniplusWeb.ingress.tls.enabled .Values.uniplusWeb.ingress.tls.certManager.enabled -}}
+{{- if not .Values.uniplusWeb.ingress.tls.certManager.clusterIssuer -}}
+{{- fail "uniplusWeb.ingress.tls.certManager.clusterIssuer é obrigatório quando certManager.enabled=true (ex.: letsencrypt-prod)." -}}
+{{- end -}}
+{{- range $app, $cfg := .Values.uniplusWeb.apps -}}
+{{- if $cfg.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app) }}
+  labels:
+    {{- include "uniplusWeb.labels" (dict "ctx" $ "app" $app) | nindent 4 }}
+spec:
+  secretName: {{ printf "%s-tls" (include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app)) }}
+  commonName: {{ $cfg.host }}
+  dnsNames:
+    - {{ $cfg.host }}
+  issuerRef:
+    name: {{ $.Values.uniplusWeb.ingress.tls.certManager.clusterIssuer }}
+    kind: ClusterIssuer
+{{- end }}
+{{- end }}
+{{- end }}

--- a/apps/uniplus-web/templates/configmap-runtime.yaml
+++ b/apps/uniplus-web/templates/configmap-runtime.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.uniplusWeb.enabled -}}
+{{- range $app, $cfg := .Values.uniplusWeb.apps -}}
+{{- if $cfg.enabled -}}
+{{- if not $cfg.runtimeConfig.apiUrl -}}
+{{- fail (printf "uniplusWeb.apps.%s.runtimeConfig.apiUrl é obrigatório (URL pública da API correspondente, ex.: https://api-%s.standalone.portaluni.com.br). Sem URL real, runtime-config.json contém placeholder e o app aborta o bootstrap (ADR-0021 assertNaoEhPlaceholder)." $app $app) -}}
+{{- end -}}
+{{- if not $cfg.runtimeConfig.keycloak.url -}}
+{{- fail (printf "uniplusWeb.apps.%s.runtimeConfig.keycloak.url é obrigatório (URL do realm Keycloak, ex.: https://standalone.portaluni.com.br/auth)." $app) -}}
+{{- end -}}
+{{- if not $cfg.runtimeConfig.keycloak.realm -}}
+{{- fail (printf "uniplusWeb.apps.%s.runtimeConfig.keycloak.realm é obrigatório (ex.: uniplus)." $app) -}}
+{{- end -}}
+{{- if not $cfg.runtimeConfig.keycloak.clientId -}}
+{{- fail (printf "uniplusWeb.apps.%s.runtimeConfig.keycloak.clientId é obrigatório (ex.: uniplus-portal)." $app) -}}
+{{- end }}
+---
+# ConfigMap montado sobre /usr/share/nginx/html/assets/runtime-config.json
+# (substitui o placeholder embutido na imagem). Schema é a interface
+# AppConfig em libs/shared-data/lib/config/app-config.model.ts do
+# uniplus-web (ADR-0021). nginx serve com Cache-Control: no-store, então
+# bumps de ConfigMap chegam imediatamente ao browser sem rolling restart
+# do pod (mas restart não dói — `data.runtime-config.json` muda hash do
+# objeto, ConfigMap reload é automático via subPath no volume).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "uniplusWeb.runtimeConfigMapName" (dict "ctx" $ "app" $app) }}
+  labels:
+    {{- include "uniplusWeb.labels" (dict "ctx" $ "app" $app) | nindent 4 }}
+data:
+  runtime-config.json: |
+    {
+      "apiUrl": {{ $cfg.runtimeConfig.apiUrl | quote }},
+      "keycloak": {
+        "url": {{ $cfg.runtimeConfig.keycloak.url | quote }},
+        "realm": {{ $cfg.runtimeConfig.keycloak.realm | quote }},
+        "clientId": {{ $cfg.runtimeConfig.keycloak.clientId | quote }}
+      }
+    }
+{{- end }}
+{{- end }}
+{{- end }}

--- a/apps/uniplus-web/templates/deployment.yaml
+++ b/apps/uniplus-web/templates/deployment.yaml
@@ -3,10 +3,13 @@
 {{- if $cfg.enabled -}}
 {{- if not $cfg.image -}}
 {{- fail (printf "uniplusWeb.apps.%s.image é obrigatório (nome da imagem em ghcr.io/unifesspa-edu-br/, ex.: uniplus-portal)." $app) -}}
-{{- end -}}
-{{- if not $cfg.host -}}
-{{- fail (printf "uniplusWeb.apps.%s.host é obrigatório (subdomain do app, ex.: %s.standalone.portaluni.com.br). IngressRoute Traefik exige Host(...) válido." $app $app) -}}
 {{- end }}
+{{/*
+  `host` NÃO é validado aqui — só é consumido por ingressroute.yaml e
+  certificate.yaml, que disparam o `fail` por conta própria quando
+  `ingress.enabled=true` mas o host está vazio. Isso permite deploy
+  interno sem ingress (`ingress.enabled=false`) sem precisar setar host.
+*/}}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/apps/uniplus-web/templates/deployment.yaml
+++ b/apps/uniplus-web/templates/deployment.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.uniplusWeb.enabled -}}
+{{- range $app, $cfg := .Values.uniplusWeb.apps -}}
+{{- if $cfg.enabled -}}
+{{- if not $cfg.image -}}
+{{- fail (printf "uniplusWeb.apps.%s.image é obrigatório (nome da imagem em ghcr.io/unifesspa-edu-br/, ex.: uniplus-portal)." $app) -}}
+{{- end -}}
+{{- if not $cfg.host -}}
+{{- fail (printf "uniplusWeb.apps.%s.host é obrigatório (subdomain do app, ex.: %s.standalone.portaluni.com.br). IngressRoute Traefik exige Host(...) válido." $app $app) -}}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app) }}
+  labels:
+    {{- include "uniplusWeb.labels" (dict "ctx" $ "app" $app) | nindent 4 }}
+spec:
+  replicas: {{ $cfg.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      {{- include "uniplusWeb.selectorLabels" (dict "ctx" $ "app" $app) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "uniplusWeb.labels" (dict "ctx" $ "app" $app) | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "uniplusWeb.serviceAccountName" (dict "ctx" $ "app" $app) }}
+      {{- with $.Values.uniplusWeb.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml $.Values.uniplusWeb.podSecurityContext | nindent 8 }}
+      {{- if $.Values.uniplusWeb.podAntiAffinity.enabled }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "uniplusWeb.selectorLabels" (dict "ctx" $ "app" $app) | nindent 20 }}
+                topologyKey: {{ $.Values.uniplusWeb.podAntiAffinity.topologyKey }}
+      {{- end }}
+      containers:
+        - name: web
+          image: {{ include "uniplusWeb.image" (dict "ctx" $ "appCfg" $cfg) }}
+          imagePullPolicy: {{ $.Values.uniplusWeb.image.pullPolicy }}
+          securityContext:
+            {{- toYaml $.Values.uniplusWeb.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          # Healthcheck estático (`/health.json` retorna {"status":"ok"})
+          # — definido em docker/nginx.conf. Liveness e startup ambos olham
+          # para esse endpoint porque nginx-unprivileged não tem deps externas
+          # (não chama Keycloak/API por conta própria — quem faz é o browser
+          # do usuário). Readiness mira o mesmo endpoint para que ArgoCD veja
+          # pod Ready assim que nginx aceita conexões.
+          startupProbe:
+            httpGet:
+              path: /health.json
+              port: http
+            failureThreshold: {{ $.Values.uniplusWeb.startupProbe.failureThreshold }}
+            periodSeconds: {{ $.Values.uniplusWeb.startupProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /health.json
+              port: http
+            periodSeconds: {{ $.Values.uniplusWeb.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /health.json
+              port: http
+            periodSeconds: {{ $.Values.uniplusWeb.readinessProbe.periodSeconds }}
+          resources:
+            {{- toYaml $cfg.resources | nindent 12 }}
+          # Mount runtime-config.json sobre o placeholder embutido na imagem
+          # (que tem URLs `.invalid` e PLACEHOLDER_*). subPath garante que
+          # apenas esse arquivo é substituído — não masca o resto de /assets
+          # que o build do Angular populou (favicons, fonts, etc.).
+          volumeMounts:
+            - name: runtime-config
+              mountPath: /usr/share/nginx/html/assets/runtime-config.json
+              subPath: runtime-config.json
+              readOnly: true
+      volumes:
+        - name: runtime-config
+          configMap:
+            name: {{ include "uniplusWeb.runtimeConfigMapName" (dict "ctx" $ "app" $app) }}
+            items:
+              - key: runtime-config.json
+                path: runtime-config.json
+{{- end }}
+{{- end }}
+{{- end }}

--- a/apps/uniplus-web/templates/deployment.yaml
+++ b/apps/uniplus-web/templates/deployment.yaml
@@ -28,6 +28,13 @@ spec:
     metadata:
       labels:
         {{- include "uniplusWeb.labels" (dict "ctx" $ "app" $app) | nindent 8 }}
+      annotations:
+        # Checksum do runtimeConfig deste app específico — força rolling
+        # restart quando apiUrl/keycloak.* mudam. subPath mounts não
+        # propagam ConfigMap updates aos pods em execução, então sem este
+        # hash uma alteração em values ficaria invisível até restart manual
+        # (problema apontado por Codex P1 no PR #171).
+        checksum/runtime-config: {{ $cfg.runtimeConfig | toJson | sha256sum }}
     spec:
       serviceAccountName: {{ include "uniplusWeb.serviceAccountName" (dict "ctx" $ "app" $app) }}
       {{- with $.Values.uniplusWeb.imagePullSecrets }}

--- a/apps/uniplus-web/templates/ingressroute.yaml
+++ b/apps/uniplus-web/templates/ingressroute.yaml
@@ -1,6 +1,9 @@
 {{- if and .Values.uniplusWeb.enabled .Values.uniplusWeb.ingress.enabled -}}
 {{- range $app, $cfg := .Values.uniplusWeb.apps -}}
-{{- if $cfg.enabled }}
+{{- if $cfg.enabled -}}
+{{- if not $cfg.host -}}
+{{- fail (printf "uniplusWeb.apps.%s.host é obrigatório quando uniplusWeb.ingress.enabled=true (ex.: %s.standalone.portaluni.com.br). IngressRoute Traefik exige Host(...) válido." $app $app) -}}
+{{- end }}
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute

--- a/apps/uniplus-web/templates/ingressroute.yaml
+++ b/apps/uniplus-web/templates/ingressroute.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.uniplusWeb.enabled .Values.uniplusWeb.ingress.enabled -}}
+{{- range $app, $cfg := .Values.uniplusWeb.apps -}}
+{{- if $cfg.enabled }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app) }}
+  labels:
+    {{- include "uniplusWeb.labels" (dict "ctx" $ "app" $app) | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ $.Values.uniplusWeb.ingress.entryPoint }}
+  routes:
+    - match: Host(`{{ $cfg.host }}`)
+      kind: Rule
+      services:
+        - name: {{ include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app) }}
+          port: 8080
+  {{- if $.Values.uniplusWeb.ingress.tls.enabled }}
+  tls:
+    secretName: {{ printf "%s-tls" (include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app)) }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/apps/uniplus-web/templates/networkpolicy.yaml
+++ b/apps/uniplus-web/templates/networkpolicy.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.uniplusWeb.enabled .Values.uniplusWeb.networkPolicy.enabled -}}
+{{- range $app, $cfg := .Values.uniplusWeb.apps -}}
+{{- if $cfg.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app) }}
+  labels:
+    {{- include "uniplusWeb.labels" (dict "ctx" $ "app" $app) | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "uniplusWeb.selectorLabels" (dict "ctx" $ "app" $app) | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $.Values.uniplusWeb.networkPolicy.traefikNamespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- if $.Values.uniplusWeb.serviceMonitor.enabled }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $.Values.uniplusWeb.networkPolicy.monitoringNamespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    {{- end }}
+  egress:
+    # DNS apenas (CoreDNS) — nginx-unprivileged não chama Keycloak/API
+    # por conta própria. Toda a comunicação com o backend é feita pelo
+    # browser do usuário, não pelo pod. Egress restrito a DNS reduz
+    # superfície de ataque caso a imagem seja comprometida.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}
+{{- end }}
+{{- end }}

--- a/apps/uniplus-web/templates/service.yaml
+++ b/apps/uniplus-web/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.uniplusWeb.enabled -}}
+{{- range $app, $cfg := .Values.uniplusWeb.apps -}}
+{{- if $cfg.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app) }}
+  labels:
+    {{- include "uniplusWeb.labels" (dict "ctx" $ "app" $app) | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "uniplusWeb.selectorLabels" (dict "ctx" $ "app" $app) | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/apps/uniplus-web/templates/serviceaccount.yaml
+++ b/apps/uniplus-web/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.uniplusWeb.enabled -}}
+{{- if .Values.uniplusWeb.serviceAccount.create -}}
+{{- range $app, $cfg := .Values.uniplusWeb.apps -}}
+{{- if $cfg.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "uniplusWeb.serviceAccountName" (dict "ctx" $ "app" $app) }}
+  labels:
+    {{- include "uniplusWeb.labels" (dict "ctx" $ "app" $app) | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/apps/uniplus-web/templates/serviceaccount.yaml
+++ b/apps/uniplus-web/templates/serviceaccount.yaml
@@ -1,5 +1,24 @@
 {{- if .Values.uniplusWeb.enabled -}}
 {{- if .Values.uniplusWeb.serviceAccount.create -}}
+{{- if .Values.uniplusWeb.serviceAccount.name }}
+# Override `serviceAccount.name` setado: 1 ServiceAccount compartilhado
+# pelos N apps (RBAC unificado). Sem este branch, a iteração produziria
+# N manifests duplicados para o mesmo metadata.name (Codex P2 no PR #171).
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.uniplusWeb.serviceAccount.name }}
+  labels:
+    app.kubernetes.io/name: {{ default .Chart.Name .Values.uniplusWeb.nameOverride }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+    {{- with .Values.uniplusWeb.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- else }}
 {{- range $app, $cfg := .Values.uniplusWeb.apps -}}
 {{- if $cfg.enabled }}
 ---
@@ -9,6 +28,7 @@ metadata:
   name: {{ include "uniplusWeb.serviceAccountName" (dict "ctx" $ "app" $app) }}
   labels:
     {{- include "uniplusWeb.labels" (dict "ctx" $ "app" $app) | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/apps/uniplus-web/values.yaml
+++ b/apps/uniplus-web/values.yaml
@@ -1,116 +1,160 @@
-# Default values para uniplus-web
-# Cada ambiente (lab-sp1, lab-sp2, prod-sp1, prod-sp2) define overrides
-# em environments/<ambiente>/values.yaml
+# Defaults para uniplus-web.
+#
+# 1 chart, 3 deployments — portal/seleção/ingresso, cada um com seu
+# subdomain dedicado, ConfigMap de runtime-config.json (ADR-0021 web)
+# e Certificate cert-manager. Pattern simétrico aos charts api-* mas
+# iterando sobre `apps.{portal,selecao,ingresso}`.
+#
+# Cada ambiente sobrescreve em `environments/<env>/values.yaml` o bloco
+# `uniplusWeb` com `host` + `runtimeConfig` por app.
 
-# Configuração comum
-nameOverride: ""
-fullnameOverride: ""
-
-# Imagens (build via GitHub Actions, push para registry)
-image:
-  registry: ghcr.io
-  repository: unifesspa-edu-br
-  pullPolicy: IfNotPresent
-  tag: ""  # se vazio, usa appVersion do Chart
-
-imagePullSecrets: []
-
-# 3 frontends Angular como deployments separados
-apps:
-  portal:
-    enabled: true
-    replicas: 2
-    image: uniplus-web-portal
-    path: /portal
-    isDefault: true  # uniplus.unifesspa.edu.br/ → portal
-    resources:
-      requests:
-        cpu: 100m
-        memory: 128Mi
-      limits:
-        cpu: 500m
-        memory: 256Mi
-
-  selecao:
-    enabled: true
-    replicas: 2
-    image: uniplus-web-selecao
-    path: /selecao
-    resources:
-      requests:
-        cpu: 100m
-        memory: 128Mi
-      limits:
-        cpu: 500m
-        memory: 256Mi
-
-  ingresso:
-    enabled: true
-    replicas: 2
-    image: uniplus-web-ingresso
-    path: /ingresso
-    resources:
-      requests:
-        cpu: 100m
-        memory: 128Mi
-      limits:
-        cpu: 500m
-        memory: 256Mi
-
-# Service config
-service:
-  type: ClusterIP
-  port: 80
-
-# Ingress (Traefik via IngressRoute)
-ingress:
+uniplusWeb:
   enabled: true
-  className: traefik
-  host: uniplus.unifesspa.edu.br  # override em prod
-  tls:
-    enabled: true
-    certResolver: letsencrypt  # cert-manager ou traefik resolver
-    secretName: uniplus-web-tls
 
-# Probes
-probes:
-  liveness:
-    path: /
-    initialDelaySeconds: 10
+  nameOverride: ""
+  fullnameOverride: ""
+
+  # Imagem default (apps.<name>.image override por app).
+  image:
+    registry: ghcr.io
+    repository: unifesspa-edu-br
+    pullPolicy: IfNotPresent
+    # tag default puxa da Chart.AppVersion. Override per-app possível em
+    # apps.<name>.tag.
+    tag: ""
+
+  imagePullSecrets: []
+
+  serviceAccount:
+    create: true
+    name: ""
+
+  # Pod-level securityContext alinhado ao nginxinc/nginx-unprivileged
+  # (UID 101, fsGroup 101). nginx-unprivileged escuta :8080 sem
+  # CAP_NET_BIND_SERVICE.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 101
+    runAsGroup: 101
+    readOnlyRootFilesystem: false  # nginx grava em /var/cache/nginx + tmp
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: RuntimeDefault
+
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 2
+  livenessProbe:
     periodSeconds: 10
-  readiness:
-    path: /
-    initialDelaySeconds: 5
+  readinessProbe:
     periodSeconds: 5
 
-# Pod security
-securityContext:
-  runAsNonRoot: true
-  runAsUser: 101  # nginx
-  fsGroup: 101
-  readOnlyRootFilesystem: true
-  allowPrivilegeEscalation: false
+  # 3 frontends Angular como deployments separados, cada um servindo no
+  # próprio subdomain. Defaults são placeholders — environments/<env>/
+  # values.yaml preenche `host` + `runtimeConfig` reais.
+  apps:
+    portal:
+      enabled: false  # ativar em environments/<env>/values.yaml
+      replicas: 2
+      # Imagem GHCR — atenção ao naming inconsistente entre portal (sem
+      # prefixo `web-`) e os demais (com `web-`). Verificar tags em
+      # https://github.com/unifesspa-edu-br/packages.
+      image: uniplus-portal
+      tag: v0.1.0  # tag publicada em GHCR (override per-app possível)
+      host: ""  # ex.: portal.standalone.portaluni.com.br
+      # Conteúdo escrito em /assets/runtime-config.json via ConfigMap.
+      # Schema é a interface AppConfig em libs/shared-data/lib/config/
+      # app-config.model.ts do uniplus-web (ADR-0021).
+      runtimeConfig:
+        apiUrl: ""  # ex.: https://api-portal.standalone.portaluni.com.br
+        keycloak:
+          url: ""  # ex.: https://standalone.portaluni.com.br/auth
+          realm: uniplus
+          clientId: uniplus-portal
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 250m
+          memory: 128Mi
 
-# Network policies
-networkPolicy:
-  enabled: true
+    selecao:
+      enabled: false  # ativar em environments/<env>/values.yaml
+      replicas: 2
+      image: uniplus-web-selecao
+      tag: v0.1.0
+      host: ""
+      runtimeConfig:
+        apiUrl: ""
+        keycloak:
+          url: ""
+          realm: uniplus
+          clientId: uniplus-portal
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 250m
+          memory: 128Mi
+
+    ingresso:
+      enabled: false  # ativar em environments/<env>/values.yaml
+      replicas: 2
+      image: uniplus-web-ingresso
+      tag: v0.1.0
+      host: ""
+      runtimeConfig:
+        apiUrl: ""
+        keycloak:
+          url: ""
+          realm: uniplus
+          clientId: uniplus-portal
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 250m
+          memory: 128Mi
+
   ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/name: traefik
+    enabled: true
+    entryPoint: websecure
+    tls:
+      enabled: true
+      certManager:
+        enabled: true
+        clusterIssuer: letsencrypt-prod
 
-# Observability (auto-discoverable pelo Prometheus)
-serviceMonitor:
-  enabled: true
-  interval: 30s
+  # NetworkPolicy: ingress só do namespace Traefik; egress só DNS (CoreDNS).
+  # Nginx-unprivileged não chama upstream — todas as requests externas
+  # (Keycloak, API) são feitas pelo browser do usuário, não pelo pod.
+  # Por isso não há regra de egress para Keycloak/API.
+  networkPolicy:
+    enabled: true
+    traefikNamespace: traefik
+    monitoringNamespace: monitoring
 
-# Pod anti-affinity para distribuir réplicas
-podAntiAffinity:
-  enabled: true
-  topologyKey: kubernetes.io/hostname
+  # ServiceMonitor opt-in (Prometheus auto-discovery). nginx-unprivileged
+  # serve métricas em formato Prometheus se enabled — fora de escopo standalone.
+  serviceMonitor:
+    enabled: false
+    interval: 30s
 
-# Labels comuns aplicados a todos os recursos
-commonLabels:
-  app.kubernetes.io/part-of: uniplus
-  app.kubernetes.io/component: frontend
+  podAntiAffinity:
+    enabled: true
+    topologyKey: kubernetes.io/hostname
+
+  commonLabels:
+    app.kubernetes.io/part-of: uniplus
+    app.kubernetes.io/component: frontend

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -728,6 +728,57 @@ uniplusApiIngresso:
     oidcIssuerCIDR: 164.152.53.29/32
 
 # ----------------------------------------------------------------------------
+# Frontends Uni+ (Angular SPAs servidas por nginx-unprivileged). 1 chart,
+# 3 deployments — cada um no próprio subdomain (pattern subdomain, ADR-018
+# infra). runtime-config.json é montado via ConfigMap sobre o placeholder
+# embutido na imagem e contém apiUrl + Keycloak (ADR-0021 web). Chart
+# uniplus-infra#162.
+#
+# Realm Keycloak `uniplus`. clientId `uniplus-portal` é compartilhado pelos
+# 3 SPAs (1 client público com 3 redirectUri configurados) — alinhado ao
+# uniplusApiPortal.oidc.audience.
+# ----------------------------------------------------------------------------
+uniplusWeb:
+  enabled: true
+
+  apps:
+    portal:
+      enabled: true
+      replicas: 1  # standalone single-node — anti-affinity é preferred, então 1 replica não conflita
+      image: uniplus-portal
+      host: portal.standalone.portaluni.com.br
+      runtimeConfig:
+        apiUrl: https://api-portal.standalone.portaluni.com.br
+        keycloak:
+          url: https://standalone.portaluni.com.br/auth
+          realm: uniplus
+          clientId: uniplus-portal
+
+    selecao:
+      enabled: true
+      replicas: 1
+      image: uniplus-web-selecao
+      host: selecao.standalone.portaluni.com.br
+      runtimeConfig:
+        apiUrl: https://api-selecao.standalone.portaluni.com.br
+        keycloak:
+          url: https://standalone.portaluni.com.br/auth
+          realm: uniplus
+          clientId: uniplus-portal
+
+    ingresso:
+      enabled: true
+      replicas: 1
+      image: uniplus-web-ingresso
+      host: ingresso.standalone.portaluni.com.br
+      runtimeConfig:
+        apiUrl: https://api-ingresso.standalone.portaluni.com.br
+        keycloak:
+          url: https://standalone.portaluni.com.br/auth
+          realm: uniplus
+          clientId: uniplus-portal
+
+# ----------------------------------------------------------------------------
 # Componentes stateful no data-host (Postgres, Kafka, MinIO, Redis) rodam
 # FORA do K8s, gerenciados por systemd em /var/lib/uniplus/* (ADR-002 +
 # ADR-005). Endpoints chegam às apps via External Secrets sintetizados a


### PR DESCRIPTION
## Resumo

Closes #162. Chart Helm `apps/uniplus-web/` com 3 Deployments separados (Portal, Seleção, Ingresso), cada um servindo no próprio subdomain (`{portal,selecao,ingresso}.standalone.portaluni.com.br`). Pattern subdomain escolhido sobre subpath porque as imagens v0.1.0 publicadas em GHCR têm `<base href=\"/\">` fixo do build Angular — subpath exigiria rebuild, fora do escopo desta issue.

## Decisões

- **Subdomain por app** — alinha com `<base href=\"/\">` das imagens publicadas. 3 CNAMEs criados via OCI CLI apontando para o IP do single-node standalone.
- **1 chart, N deployments** — iteração sobre `apps.{portal,selecao,ingresso}` em todos os 7 templates. Selectors discriminados via `app.kubernetes.io/component-instance`.
- **runtime-config.json via ConfigMap montado por subPath** — substitui o placeholder embutido na imagem (URLs `.invalid` e `PLACEHOLDER_*`) sem mascarar o resto de `/assets/`. Schema = interface `AppConfig` em `libs/shared-data/lib/config/app-config.model.ts` do uniplus-web (ADR-0021 web).
- **Fail-fast no template** — ConfigMap chama `fail` se `apiUrl`/`keycloak.{url,realm,clientId}` estiverem vazios. Evita deploy com placeholder real.
- **NetworkPolicy egress = DNS only** — nginx-unprivileged não chama Keycloak/API por conta própria; é o browser do usuário. Egress restrito reduz superfície caso a imagem seja comprometida.
- **Realm/client compartilhado** — 3 SPAs usam realm `uniplus` + clientId `uniplus-portal` (1 client público com 3 redirectUris configurados).

## Recursos renderizados (por release)

- 3 × Deployment (replicas=1 standalone, anti-affinity preferred)
- 3 × Service (ClusterIP :8080)
- 3 × ConfigMap (runtime-config.json)
- 3 × ServiceAccount
- 3 × IngressRoute (Traefik, websecure)
- 3 × Certificate (cert-manager, letsencrypt-prod)
- 3 × NetworkPolicy

## Validações locais

- `helm lint apps/uniplus-web/` — 0 chart(s) failed
- `helm template ... -f environments/standalone/values.yaml` — render limpo, 21 recursos, JSON válido em ConfigMap, hosts/secrets/imagens corretos
- `yamllint -c .yamllint.yaml apps/uniplus-web/ environments/standalone/values.yaml` — limpo
- DNS: 3 CNAMEs propagados (164.152.53.29 resolve)

## Plano de rollback

Reverter o commit (apps/uniplus-web/templates/ é tudo novo; values.yaml + Chart.yaml + standalone env voltam ao estado pré-PR). ArgoCD reconcilia removendo os 21 recursos.

## Test plan

- [ ] Após merge, ArgoCD `uniplus-web-uniplus-standalone` sincroniza e deploya 3 pods Ready
- [ ] `curl https://portal.standalone.portaluni.com.br/health.json` → 200 `{\"status\":\"ok\"}`
- [ ] `curl https://portal.standalone.portaluni.com.br/assets/runtime-config.json` → JSON real (não placeholder)
- [ ] Idem para selecao.* e ingresso.*
- [ ] Browser: bootstrap do Angular não aborta (validador `assertNaoEhPlaceholder` passa)
- [ ] Login Keycloak → redirect funcional para os 3 SPAs

Refs #40