### PR TITLE
fix(keycloak-realm): autorizar 3 subdomínios SPA no client uniplus-portal (#172)

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -391,8 +391,18 @@ keycloak:
     portalClient:
       clientId: uniplus-portal
       rootUrl: https://standalone.portaluni.com.br
+      # Cliente público compartilhado pelas 3 SPAs Uni+ (1 client, 3
+      # redirectUris) — pattern definido na story uniplus-infra#162. Cada
+      # SPA roda no próprio subdomain (PR #171); o silent-check-sso do
+      # keycloak-js exige que cada origem esteja autorizada explicitamente.
       redirectUris:
         - https://standalone.portaluni.com.br/*
+        - https://portal.standalone.portaluni.com.br/*
+        - https://selecao.standalone.portaluni.com.br/*
+        - https://ingresso.standalone.portaluni.com.br/*
+      # "+" deriva Web Origins automaticamente dos redirectUris acima
+      # (Keycloak preenche cada host como origem permitida). Isso libera
+      # tanto CORS quanto frame-ancestors para o iframe silent-check-sso.
       webOrigins:
         - "+"
 


### PR DESCRIPTION
## Resumo

Closes #172. Smoke E2E pós-merge do PR #171 (story #162) expôs que o client Keycloak \`uniplus-portal\` em standalone não tinha os 3 novos subdomínios das SPAs autorizados — Angular APP_INITIALIZER travava no \`silent-check-sso\` (400 "Parâmetro inválido: redirect_uri") e a UI ficava em branco.

Fix em \`environments/standalone/values.yaml\`: 3 entradas em \`portalClient.redirectUris\`. \`webOrigins: ["+"]\` deriva CORS/frame-ancestors automaticamente.

## Validação local

\`\`\`bash
helm lint apps/keycloak-replica -f environments/standalone/values.yaml      # 0 fail
helm template t apps/keycloak-replica -f environments/standalone/values.yaml \
  | grep -A1 redirectUris
# → "redirectUris": ["https://standalone.portaluni.com.br/*",
#                    "https://portal.standalone.portaluni.com.br/*",
#                    "https://selecao.standalone.portaluni.com.br/*",
#                    "https://ingresso.standalone.portaluni.com.br/*"]
\`\`\`

## Caveat de aplicação

\`--import-realm\` em Keycloak 26.x é **idempotente — não re-importa realm existente** (decisão deliberada documentada em \`apps/keycloak-replica/README.md:63\`, preserva edits via Admin UI). Consequências:

1. Próximo bootstrap completo (DB virgem) → realm-import lê o values atualizado e aplica os 4 redirectUris automaticamente. ✅
2. Realm já em runtime → ConfigMap muda mas \`--import-realm\` ignora. **Patch via Admin API necessário** para efeito imediato:

\`\`\`bash
# token admin
TOKEN=$(curl -s https://standalone.portaluni.com.br/auth/realms/master/protocol/openid-connect/token \\
  -d grant_type=password -d client_id=admin-cli -d username=admin -d password="$KC_ADMIN_PWD" \\
  | jq -r .access_token)

# patch client uniplus-portal
KCID=$(curl -s -H "Authorization: Bearer $TOKEN" \\
  https://standalone.portaluni.com.br/auth/admin/realms/uniplus/clients?clientId=uniplus-portal \\
  | jq -r '.[0].id')

curl -s -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
  https://standalone.portaluni.com.br/auth/admin/realms/uniplus/clients/$KCID \\
  -d '{"redirectUris":["https://standalone.portaluni.com.br/*","https://portal.standalone.portaluni.com.br/*","https://selecao.standalone.portaluni.com.br/*","https://ingresso.standalone.portaluni.com.br/*"],"webOrigins":["+"]}'
\`\`\`

Patch será aplicado pós-merge (mesmo desenvolvedor) e validado com novo smoke browser.

## Drift management (follow-up futuro, fora deste PR)

Este caso prova que mudanças de realm via IaC sem mecanismo de re-aplicação ficam stranded em runtime. Próxima iteração deve adotar \`keycloak-config-cli\` ou \`kc.sh import --override true\` em sync hook ArgoCD para tornar o realm reconciliação real, não one-shot. Issue follow-up será aberta separadamente.

## Plano de rollback

Reverter o commit. ConfigMap volta ao estado pré-PR; realm runtime preserva o estado atual (idempotência funciona a nosso favor aqui).

## Test plan

- [ ] Após merge, ConfigMap \`keycloak-replica-uniplus-realm\` atualizado pelo ArgoCD com os 4 redirectUris
- [ ] Patch Admin API aplicado no realm runtime (comando documentado acima)
- [ ] Smoke E2E browser: \`https://portal.standalone.portaluni.com.br/\` → Angular monta UI sem erro CSP/silent-check-sso
- [ ] Idem selecao + ingresso
- [ ] Issue de drift management (follow-up) aberta