### PR TITLE
chore(uniplus-web): bump tag v0.1.0 → v0.1.1

### DIFF
--- a/apps/uniplus-web/values.yaml
+++ b/apps/uniplus-web/values.yaml
@@ -68,7 +68,7 @@ uniplusWeb:
       # prefixo `web-`) e os demais (com `web-`). Verificar tags em
       # https://github.com/unifesspa-edu-br/packages.
       image: uniplus-portal
-      tag: v0.1.0  # tag publicada em GHCR (override per-app possível)
+      tag: v0.1.1  # tag publicada em GHCR (override per-app possível)
       host: ""  # ex.: portal.standalone.portaluni.com.br
       # Conteúdo escrito em /assets/runtime-config.json via ConfigMap.
       # Schema é a interface AppConfig em libs/shared-data/lib/config/
@@ -91,7 +91,7 @@ uniplusWeb:
       enabled: false  # ativar em environments/<env>/values.yaml
       replicas: 2
       image: uniplus-web-selecao
-      tag: v0.1.0
+      tag: v0.1.1
       host: ""
       runtimeConfig:
         apiUrl: ""
@@ -111,7 +111,7 @@ uniplusWeb:
       enabled: false  # ativar em environments/<env>/values.yaml
       replicas: 2
       image: uniplus-web-ingresso
-      tag: v0.1.0
+      tag: v0.1.1
       host: ""
       runtimeConfig:
         apiUrl: ""


### PR DESCRIPTION
## Resumo

Bump das 3 imagens uniplus-web em \`apps/uniplus-web/values.yaml\` (portal/selecao/ingresso) de \`v0.1.0\` para \`v0.1.1\`. As imagens v0.1.1 foram publicadas pelo workflow Publish Images do uniplus-web em [run 25614583984](https://github.com/unifesspa-edu-br/uniplus-web/actions/runs/25614583984), 100% success nos 3 jobs.

## Conteúdo do v0.1.1 (uniplus-web#358 / PR #359)

Desabilita \`optimization.styles.inlineCritical\` no build de produção das 3 SPAs:

- elimina \`<link rel="stylesheet" media="print" onload="this.media='all'">\` do index.html (violava CSP \`script-src 'self'\`)
- elimina o \`<style>\` block inline gigante extraído pelo Beasties
- mantém minificação de styles e demais otimizações

## Validação local

\`\`\`bash
helm lint apps/uniplus-web -f environments/standalone/values.yaml         # 0 fail
helm template t apps/uniplus-web -f environments/standalone/values.yaml \
  | grep "image:"
# → ghcr.io/unifesspa-edu-br/uniplus-portal:v0.1.1
#   ghcr.io/unifesspa-edu-br/uniplus-web-selecao:v0.1.1
#   ghcr.io/unifesspa-edu-br/uniplus-web-ingresso:v0.1.1
\`\`\`

## Plano de rollback

Reverter o commit. ArgoCD reconcilia rolling-back para v0.1.0.

## Test plan

- [ ] CI green
- [ ] ArgoCD sincroniza e faz rolling restart dos 3 deployments
- [ ] Smoke browser nas 3 SPAs:
  - portal: console limpo, UI carrega (router → /processos)
  - selecao + ingresso: console limpo, redirect para login Keycloak
  - **0 erros CSP em todos os 3** (era o objetivo do v0.1.1)