### PR TITLE
chore(uniplus-web): bump tag v0.1.1 → v0.1.2

### DIFF
--- a/apps/uniplus-web/values.yaml
+++ b/apps/uniplus-web/values.yaml
@@ -68,7 +68,7 @@ uniplusWeb:
       # prefixo `web-`) e os demais (com `web-`). Verificar tags em
       # https://github.com/unifesspa-edu-br/packages.
       image: uniplus-portal
-      tag: v0.1.1  # tag publicada em GHCR (override per-app possível)
+      tag: v0.1.2  # tag publicada em GHCR (override per-app possível)
       host: ""  # ex.: portal.standalone.portaluni.com.br
       # Conteúdo escrito em /assets/runtime-config.json via ConfigMap.
       # Schema é a interface AppConfig em libs/shared-data/lib/config/
@@ -91,7 +91,7 @@ uniplusWeb:
       enabled: false  # ativar em environments/<env>/values.yaml
       replicas: 2
       image: uniplus-web-selecao
-      tag: v0.1.1
+      tag: v0.1.2
       host: ""
       runtimeConfig:
         apiUrl: ""
@@ -111,7 +111,7 @@ uniplusWeb:
       enabled: false  # ativar em environments/<env>/values.yaml
       replicas: 2
       image: uniplus-web-ingresso
-      tag: v0.1.1
+      tag: v0.1.2
       host: ""
       runtimeConfig:
         apiUrl: ""


### PR DESCRIPTION
## Resumo

Bump das 3 imagens uniplus-web em \`apps/uniplus-web/values.yaml\` (portal/selecao/ingresso) de \`v0.1.1\` para \`v0.1.2\`. Imagens v0.1.2 publicadas pelo workflow Publish Images do uniplus-web em [run 25615876855](https://github.com/unifesspa-edu-br/uniplus-web/actions/runs/25615876855), 100% success nos 3 jobs.

## Conteúdo do v0.1.2 (uniplus-web#360 / PR #362)

Hardening do CSP \`style-src\` no nginx das 3 SPAs:

- \`style-src 'self' 'unsafe-inline'\` legacy fallback (browsers CSP2)
- \`style-src-elem 'self'\` CSP3 (bloqueia <style> blocks dinâmicos)
- \`style-src-attr 'unsafe-inline'\` CSP3 (libera atributos style=\"\" para Angular [style.X])

Em browsers CSP3 (Chrome 75+, Firefox 75+, Safari 15.4+) o split CSP3 vence sobre o legacy → hardening efetivo. Em browsers CSP2 → fallback funcional.

## Validação local

\`\`\`bash
helm lint apps/uniplus-web -f environments/standalone/values.yaml         # 0 fail
\`\`\`

## Test plan

- [ ] CI green
- [ ] ArgoCD sincroniza + rolling restart
- [ ] Smoke browser ampliado:
  - portal carrega sem erros CSP
  - selecao /editais (EditaisListPage) — DataTable com [style.width] continua funcionando
  - ingresso carrega sem erros CSP
  - **0 erros CSP em DevTools** em todos os 3