### PR TITLE
fix(standalone): Traefik strategy + Grafana IngressRoute + ClamAV daemon (#178 #179 #180)

### DIFF
--- a/apps/clamav-scanner/templates/_helpers.tpl
+++ b/apps/clamav-scanner/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{/*
+  Helpers do chart apps/clamav-scanner.
+*/}}
+
+{{- define "clamavScanner.name" -}}
+clamav-scanner
+{{- end -}}
+
+{{- define "clamavScanner.fullname" -}}
+{{- printf "%s-%s" .Release.Name (include "clamavScanner.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "clamavScanner.serviceAccountName" -}}
+{{- if .Values.clamavScanner.serviceAccount.create -}}
+{{- default (include "clamavScanner.fullname" .) .Values.clamavScanner.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.clamavScanner.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "clamavScanner.labels" -}}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+app.kubernetes.io/name: {{ include "clamavScanner.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "clamavScanner.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clamavScanner.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/apps/clamav-scanner/templates/configmap.yaml
+++ b/apps/clamav-scanner/templates/configmap.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.clamavScanner.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clamavScanner.fullname" . }}-config
+  labels:
+    {{- include "clamavScanner.labels" . | nindent 4 }}
+data:
+  clamd.conf: |
+    # Render do chart Uni+ apps/clamav-scanner. Override via .Values.clamavScanner.clamdConfig
+    # em environments/<env>/values.yaml.
+    LogFile /var/log/clamav/clamd.log
+    LogTime yes
+    LogClean no
+    LogVerbose no
+    LogFileMaxSize 50M
+
+    DatabaseDirectory /var/lib/clamav
+    LocalSocket /run/clamav/clamd.sock
+    LocalSocketMode 666
+    LocalSocketGroup clamav
+    FixStaleSocket yes
+    TCPSocket {{ .Values.clamavScanner.service.port | default 3310 }}
+    TCPAddr 0.0.0.0
+
+    User clamav
+    AllowSupplementaryGroups yes
+
+    # Limites — derivados de .Values.clamavScanner.clamdConfig
+    MaxFileSize {{ .Values.clamavScanner.clamdConfig.maxFileSize | default "100M" }}
+    MaxScanSize {{ .Values.clamavScanner.clamdConfig.maxScanSize | default "400M" }}
+    MaxRecursion {{ .Values.clamavScanner.clamdConfig.maxRecursion | default 16 }}
+    MaxFiles {{ .Values.clamavScanner.clamdConfig.maxFiles | default 10000 }}
+    MaxThreads {{ .Values.clamavScanner.clamdConfig.maxThreads | default 4 }}
+    IdleTimeout {{ .Values.clamavScanner.clamdConfig.scanIdleTimeout | default 600 }}
+
+    # Heurística + sandbox
+    HeuristicAlerts {{ .Values.clamavScanner.clamdConfig.heuristicAlerts | default "yes" }}
+    DetectPUA {{ .Values.clamavScanner.clamdConfig.detectPua | default "yes" }}
+    ScanArchive {{ .Values.clamavScanner.clamdConfig.scanArchive | default "yes" }}
+    ScanMail {{ .Values.clamavScanner.clamdConfig.scanMail | default "yes" }}
+    ScanPE {{ .Values.clamavScanner.clamdConfig.scanPe | default "yes" }}
+    ScanELF {{ .Values.clamavScanner.clamdConfig.scanElf | default "yes" }}
+    ScanPDF {{ .Values.clamavScanner.clamdConfig.scanPdf | default "yes" }}
+    ScanXMLDOCS {{ .Values.clamavScanner.clamdConfig.scanXmldocs | default "yes" }}
+    ScanHWP3 {{ .Values.clamavScanner.clamdConfig.scanHwp3 | default "yes" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clamavScanner.fullname" . }}-freshclam
+  labels:
+    {{- include "clamavScanner.labels" . | nindent 4 }}
+data:
+  freshclam.conf: |
+    # Atualização de signature DB. Override via .Values.clamavScanner.freshclam.
+    DatabaseDirectory /var/lib/clamav
+    UpdateLogFile /var/log/clamav/freshclam.log
+    LogTime yes
+    LogVerbose no
+    DatabaseMirror {{ .Values.clamavScanner.freshclam.databaseMirror | default "database.clamav.net" }}
+    Checks {{ div 24 (.Values.clamavScanner.freshclam.checks | default 24) }}
+    DatabaseOwner clamav
+    DNSDatabaseInfo current.cvd.clamav.net
+{{- end }}

--- a/apps/clamav-scanner/templates/deployment.yaml
+++ b/apps/clamav-scanner/templates/deployment.yaml
@@ -1,0 +1,112 @@
+{{- if .Values.clamavScanner.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "clamavScanner.fullname" . }}
+  labels:
+    {{- include "clamavScanner.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.clamavScanner.replicas | default 1 }}
+  # Daemon clamd com PVC RWO único — replicar exigiria coordenação extra.
+  # Recreate mantém estratégia simples mesmo em rolling updates.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "clamavScanner.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "clamavScanner.labels" . | nindent 8 }}
+      annotations:
+        # Reload pods quando ConfigMap muda (clamd.conf, freshclam.conf).
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "clamavScanner.serviceAccountName" . }}
+      {{- with .Values.clamavScanner.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: clamd
+          image: "{{ .Values.clamavScanner.image.registry | default "docker.io" }}/{{ .Values.clamavScanner.image.repository }}:{{ .Values.clamavScanner.image.tag | default "1.4" }}"
+          imagePullPolicy: {{ .Values.clamavScanner.image.pullPolicy | default "IfNotPresent" }}
+          {{- with .Values.clamavScanner.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: clamd
+              containerPort: {{ .Values.clamavScanner.service.port | default 3310 }}
+              protocol: TCP
+          env:
+            # Sinaliza para a imagem oficial que clamd deve subir como TCP service
+            # (default da imagem é socket Unix). Usa o conf montado em
+            # /etc/clamav/clamd.conf via ConfigMap volume.
+            - name: CLAMAV_NO_CLAMD
+              value: "false"
+            - name: CLAMAV_NO_FRESHCLAMD
+              value: "false"
+          volumeMounts:
+            - name: signatures
+              mountPath: /var/lib/clamav
+            - name: clamd-config
+              mountPath: /etc/clamav/clamd.conf
+              subPath: clamd.conf
+              readOnly: true
+            - name: freshclam-config
+              mountPath: /etc/clamav/freshclam.conf
+              subPath: freshclam.conf
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            - name: run
+              mountPath: /run/clamav
+            - name: log
+              mountPath: /var/log/clamav
+          {{- with .Values.clamavScanner.startupProbe }}
+          startupProbe:
+            tcpSocket:
+              port: clamd
+            failureThreshold: {{ .failureThreshold | default 30 }}
+            periodSeconds: {{ .periodSeconds | default 5 }}
+          {{- end }}
+          {{- with .Values.clamavScanner.livenessProbe }}
+          livenessProbe:
+            tcpSocket:
+              port: clamd
+            periodSeconds: {{ .periodSeconds | default 60 }}
+            timeoutSeconds: {{ .timeoutSeconds | default 10 }}
+          {{- end }}
+          {{- with .Values.clamavScanner.readinessProbe }}
+          readinessProbe:
+            tcpSocket:
+              port: clamd
+            periodSeconds: {{ .periodSeconds | default 10 }}
+            timeoutSeconds: {{ .timeoutSeconds | default 5 }}
+          {{- end }}
+          {{- with .Values.clamavScanner.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: signatures
+          {{- if .Values.clamavScanner.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "clamavScanner.fullname" . }}-signatures
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: clamd-config
+          configMap:
+            name: {{ include "clamavScanner.fullname" . }}-config
+        - name: freshclam-config
+          configMap:
+            name: {{ include "clamavScanner.fullname" . }}-freshclam
+        - name: tmp
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        - name: log
+          emptyDir: {}
+{{- end }}

--- a/apps/clamav-scanner/templates/networkpolicy.yaml
+++ b/apps/clamav-scanner/templates/networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.clamavScanner.enabled .Values.clamavScanner.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "clamavScanner.fullname" . }}
+  labels:
+    {{- include "clamavScanner.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "clamavScanner.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Apps Uni+ no clientNamespace conectam clamd via TCP {{ .Values.clamavScanner.service.port }}.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.clamavScanner.networkPolicy.clientNamespace | default "uniplus" }}
+      ports:
+        - port: {{ .Values.clamavScanner.service.port | default 3310 }}
+          protocol: TCP
+  egress:
+    # DNS — kube-system/coredns
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # freshclam — HTTPS para signature mirror upstream (DNS dinâmico,
+    # sem CIDR fixo). Egress amplo na porta indicada.
+    - ports:
+        - port: {{ .Values.clamavScanner.networkPolicy.freshclamEgressPort | default 443 }}
+          protocol: TCP
+{{- end }}

--- a/apps/clamav-scanner/templates/pvc.yaml
+++ b/apps/clamav-scanner/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.clamavScanner.enabled .Values.clamavScanner.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "clamavScanner.fullname" . }}-signatures
+  labels:
+    {{- include "clamavScanner.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.clamavScanner.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.clamavScanner.persistence.size | default "2Gi" }}
+  {{- with .Values.clamavScanner.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/apps/clamav-scanner/templates/service.yaml
+++ b/apps/clamav-scanner/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.clamavScanner.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clamavScanner.fullname" . }}
+  labels:
+    {{- include "clamavScanner.labels" . | nindent 4 }}
+  {{- with .Values.clamavScanner.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.clamavScanner.service.type | default "ClusterIP" }}
+  selector:
+    {{- include "clamavScanner.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: clamd
+      port: {{ .Values.clamavScanner.service.port | default 3310 }}
+      targetPort: clamd
+      protocol: TCP
+{{- end }}

--- a/apps/clamav-scanner/templates/serviceaccount.yaml
+++ b/apps/clamav-scanner/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.clamavScanner.enabled .Values.clamavScanner.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clamavScanner.serviceAccountName" . }}
+  labels:
+    {{- include "clamavScanner.labels" . | nindent 4 }}
+{{- end }}

--- a/apps/clamav-scanner/values.yaml
+++ b/apps/clamav-scanner/values.yaml
@@ -1,22 +1,123 @@
-# Default values para clamav-scanner
-# TODO: implementar conforme estrutura do uniplus-web
-
-replicas: 2
-
-image:
-  registry: ghcr.io
-  repository: unifesspa-edu-br/clamav-scanner
-  pullPolicy: IfNotPresent
-  tag: ""
-
-resources:
-  requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 500m
-    memory: 256Mi
+# Defaults do chart apps/clamav-scanner.
+#
+# Cada environment (environments/<env>/values.yaml) sobrescreve apenas o
+# necessário. Por padrão DESABILITADO — só os ambientes que precisam de
+# scan de malware (ex.: standalone, prod-{sp1,sp2}) ligam via
+# `clamavScanner.enabled: true`.
+#
+# **Importante:** apesar do nome "scanner", a entrega atual deste chart é o
+# **daemon ClamAV oficial** (`clamav/clamav`) expondo o protocolo `clamd`
+# (TCP 3310) via Service ClusterIP. O worker .NET dedicado que consome
+# Kafka e chama clamd para análise de uploads é responsabilidade da Epic
+# `uniplus-api` (futuro) — quando entregue, conectará ao Service deste
+# chart como cliente clamd, sem alterar este chart.
 
 commonLabels:
   app.kubernetes.io/part-of: uniplus
-  app.kubernetes.io/component: worker
+  app.kubernetes.io/component: malware-scanner
+
+clamavScanner:
+  # Liga/desliga o chart inteiro. Default false. Ambientes que precisam
+  # de scan de malware sobrescrevem para true em environments/<env>/values.yaml.
+  enabled: false
+
+  image:
+    registry: docker.io
+    repository: clamav/clamav
+    # ClamAV LTS — bumps de patch seguros; majors requerem verificação
+    # das assinaturas do freshclam.
+    tag: "1.4"
+    pullPolicy: IfNotPresent
+
+  imagePullSecrets: []
+
+  # 1 réplica em standalone/lab. Daemon clamd é stateful (assinaturas em
+  # PVC RWO) — replicar exige RWX storage ou cada réplica com sua própria
+  # DB. Default 1.
+  replicas: 1
+
+  # Resources — daemon ClamAV consome ~1GB RAM com signature DB carregada.
+  resources:
+    requests:
+      cpu: 200m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+  # Persistence: DB de signatures (~600MB descompactada) + locks. PVC
+  # obrigatório — sem isso freshclam baixa tudo a cada restart (~10min de
+  # inicialização) e o probe de ready falha.
+  persistence:
+    enabled: true
+    accessModes: ["ReadWriteOnce"]
+    size: 2Gi
+    storageClassName: ""
+
+  # Service: ClusterIP, porta 3310 (clamd default). Apps Uni+ se conectam
+  # via DNS interno
+  # `<release-name>-clamav-scanner.uniplus.svc.cluster.local:3310`.
+  service:
+    type: ClusterIP
+    port: 3310
+    annotations: {}
+
+  # clamd.conf — defaults conservadores para single-node lab/standalone.
+  clamdConfig:
+    maxFileSize: "100M"
+    maxScanSize: "400M"
+    maxRecursion: "16"
+    maxFiles: "10000"
+    maxThreads: 4
+    scanIdleTimeout: 600
+    heuristicAlerts: "yes"
+    detectPua: "yes"
+    scanArchive: "yes"
+    scanMail: "yes"
+    scanPe: "yes"
+    scanElf: "yes"
+    scanPdf: "yes"
+    scanXmldocs: "yes"
+    scanHwp3: "yes"
+
+  # freshclam — atualização de assinaturas.
+  freshclam:
+    # Intervalo entre checks (em horas).
+    checks: 24
+    # Mirror upstream. Override por environment para mirrors regionais.
+    databaseMirror: "database.clamav.net"
+
+  # Probes — daemon demora ~30-60s para iniciar (carga signature DB).
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 5
+  livenessProbe:
+    periodSeconds: 60
+    timeoutSeconds: 10
+  readinessProbe:
+    periodSeconds: 10
+    timeoutSeconds: 5
+
+  # SecurityContext — daemon roda como UID 100 (clamav) na imagem oficial.
+  podSecurityContext:
+    fsGroup: 100
+  containerSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 100
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false
+
+  # NetworkPolicy. Ingress: apps Uni+ via TCP 3310. Egress: DNS + freshclam
+  # mirrors (HTTPS 443).
+  networkPolicy:
+    enabled: true
+    freshclamEgressPort: 443
+    # Namespace dos clientes (apps Uni+).
+    clientNamespace: uniplus
+
+  serviceAccount:
+    create: true
+    name: ""

--- a/apps/clamav-scanner/values.yaml
+++ b/apps/clamav-scanner/values.yaml
@@ -66,8 +66,8 @@ clamavScanner:
   clamdConfig:
     maxFileSize: "100M"
     maxScanSize: "400M"
-    maxRecursion: "16"
-    maxFiles: "10000"
+    maxRecursion: 16
+    maxFiles: 10000
     maxThreads: 4
     scanIdleTimeout: 600
     heuristicAlerts: "yes"

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -120,6 +120,24 @@ grafana:
   grafana.ini:
     server:
       root_url: https://standalone.portaluni.com.br/grafana/
+      # subpath ativo — Grafana reescreve URLs internas com /grafana/.
+      serve_from_sub_path: true
+  # IngressRoute Traefik via subpath /grafana/* no FQDN raiz (consistente
+  # com Keycloak em /auth/*). Middleware StripPrefix /grafana é emitido
+  # automaticamente pelo template do wrapper — Grafana recebe paths sem
+  # o prefix, conforme serve_from_sub_path=true espera. Issue #179.
+  ingressRoute:
+    enabled: true
+    entryPoint: websecure
+    host: standalone.portaluni.com.br
+    pathPrefix: /grafana
+    servicePort: 80
+    tls:
+      enabled: true
+      # secretName vazio → Traefik usa default cert (LE prod via cert-manager +
+      # Certificate emitido pelo chart raiz quando ingress.host == FQDN). Em
+      # standalone o cert raiz já é compartilhado com Keycloak/Apicurio.
+      secretName: ""
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -293,6 +311,18 @@ networkPolicy:
     - cidr: 10.0.2.87/32
       ports:
         - 9001  # MinIO Console (Issue #153)
+
+# ----------------------------------------------------------------------------
+# ClamAV daemon (chart apps/clamav-scanner/) — `clamav/clamav` oficial
+# expondo clamd TCP 3310 via Service ClusterIP. Apps Uni+ que precisarem
+# scan de uploads chamam clamd via INSTREAM. Issue #178 — habilitado em
+# standalone para fechar gap visual do ArgoCD App "Synced/Healthy mas
+# sem Pod" e cobrir item 9 do Cenário 13.
+# ----------------------------------------------------------------------------
+clamavScanner:
+  enabled: true
+  persistence:
+    storageClassName: standalone-local-nvme
 
 # ----------------------------------------------------------------------------
 # External Secrets (chart platform/external-secrets/) — endpoint do Vault.

--- a/platform/observability/grafana/templates/_helpers.tpl
+++ b/platform/observability/grafana/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+  Helpers do chart wrapper Uni+ para Grafana.
+  Apenas templates locais (IngressRoute, Middleware) — o subchart
+  grafana/grafana traz seus próprios fullname/labels para as resources
+  upstream (Deployment, Service, etc.).
+*/}}
+
+{{- define "grafana.fullname" -}}
+{{- printf "%s-grafana" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/platform/observability/grafana/templates/ingressroute.yaml
+++ b/platform/observability/grafana/templates/ingressroute.yaml
@@ -1,0 +1,71 @@
+{{- if and .Values.grafana.enabled .Values.grafana.ingressRoute.enabled -}}
+{{- $ing := .Values.grafana.ingressRoute -}}
+{{- if not $ing.host -}}
+{{- fail "grafana.ingressRoute.enabled=true exige grafana.ingressRoute.host não vazio. Sobrescrever em environments/<env>/values.yaml com o FQDN público (ex.: standalone.portaluni.com.br quando subpath, ou grafana.<env>.portaluni.com.br quando subdomain)." -}}
+{{- end -}}
+{{- $svcName := default (printf "%s-grafana" .Release.Name) $ing.serviceName -}}
+{{- $svcPort := default 80 $ing.servicePort -}}
+{{/*
+  Grafana IngressRoute Traefik. Suporta dois patterns:
+
+  1) Subpath (host raiz com PathPrefix):
+     standalone.portaluni.com.br/grafana/* — exige serve_from_sub_path: true
+     no grafana.ini.server e root_url terminando em /grafana/.
+     Render adiciona Middleware StripPrefix /grafana — Grafana recebe paths
+     sem o prefix, que é a forma esperada quando serve_from_sub_path=true.
+
+  2) Subdomain (host dedicado):
+     grafana.standalone.portaluni.com.br/* — root_url sem subpath,
+     serve_from_sub_path=false. Pattern de outros admin UIs Uni+
+     (kafka-ui, schema-registry, redis-ui).
+
+  ingressRoute.pathPrefix vazio → caminho 2 (subdomain).
+  ingressRoute.pathPrefix preenchido (ex.: "/grafana") → caminho 1.
+*/}}
+{{- if $ing.pathPrefix -}}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ printf "%s-strip-prefix" (include "grafana.fullname" .) }}
+  labels:
+    app.kubernetes.io/part-of: uniplus
+    app.kubernetes.io/component: grafana
+spec:
+  stripPrefix:
+    prefixes:
+      - {{ $ing.pathPrefix | quote }}
+---
+{{- end }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "grafana.fullname" . }}
+  labels:
+    app.kubernetes.io/part-of: uniplus
+    app.kubernetes.io/component: grafana
+spec:
+  entryPoints:
+    - {{ $ing.entryPoint | default "websecure" | quote }}
+  routes:
+    {{- if $ing.pathPrefix }}
+    - match: Host(`{{ $ing.host }}`) && PathPrefix(`{{ $ing.pathPrefix }}`)
+      kind: Rule
+      middlewares:
+        - name: {{ printf "%s-strip-prefix" (include "grafana.fullname" .) }}
+      services:
+        - name: {{ $svcName }}
+          port: {{ $svcPort }}
+    {{- else }}
+    - match: Host(`{{ $ing.host }}`)
+      kind: Rule
+      services:
+        - name: {{ $svcName }}
+          port: {{ $svcPort }}
+    {{- end }}
+  {{- if $ing.tls.enabled }}
+  tls:
+    {{- if $ing.tls.secretName }}
+    secretName: {{ $ing.tls.secretName | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/platform/observability/grafana/values.yaml
+++ b/platform/observability/grafana/values.yaml
@@ -69,6 +69,29 @@ grafana:
   ingress:
     enabled: false
 
+  # IngressRoute Traefik (template wrapper Uni+ — platform/observability/grafana/
+  # templates/ingressroute.yaml). Suporta dois patterns:
+  #
+  # 1) Subpath: host raiz + pathPrefix (ex.: standalone.portaluni.com.br/grafana/*).
+  #    Exige serve_from_sub_path: true em grafana.ini.server e root_url terminando
+  #    em /grafana/. Wrapper emite um Middleware StripPrefix automaticamente.
+  #
+  # 2) Subdomain: host dedicado (ex.: grafana.standalone.portaluni.com.br) com
+  #    pathPrefix vazio. Pattern dos outros admin UIs Uni+ (kafka-ui,
+  #    schema-registry, redis-ui).
+  #
+  # Default OFF — habilitado em environments/<env>/values.yaml por env.
+  ingressRoute:
+    enabled: false
+    entryPoint: websecure
+    host: ""              # ex.: standalone.portaluni.com.br
+    pathPrefix: ""        # subpath (ex.: /grafana) ou vazio (subdomain)
+    serviceName: ""       # default: <Release.Name>-grafana (Service do subchart)
+    servicePort: 80       # porta do Service do subchart Grafana
+    tls:
+      enabled: true
+      secretName: ""      # vazio = Traefik usa default cert (LE prod via cert-manager + Certificate emitido em outro template ou chart)
+
   # Métricas Prometheus do próprio Grafana. ServiceMonitor vem do upstream
   # (gateado por `serviceMonitor.enabled`); wrapper não emite SM próprio.
   serviceMonitor:
@@ -115,7 +138,14 @@ grafana:
   # tiver o client `grafana` configurado.
   grafana.ini:
     server:
-      root_url: ""  # override por env (ex.: https://grafana.standalone.portaluni.com.br)
+      root_url: ""  # override por env (ex.: https://standalone.portaluni.com.br/grafana/)
+      # Habilita Grafana servir corretamente quando atrás de PathPrefix.
+      # Quando root_url contém subpath (ex.: /grafana/), Grafana reescreve
+      # URLs internas com o prefix. Sem isso, login redireciona para /login
+      # (em vez de /grafana/login) e quebra cookies/CSRF. Override por env
+      # via environments/<env>/values.yaml quando subpath. Subdomain root
+      # (sem subpath) deixa false (default).
+      serve_from_sub_path: false
     analytics:
       reporting_enabled: false
       check_for_updates: false

--- a/platform/traefik/values.yaml
+++ b/platform/traefik/values.yaml
@@ -25,6 +25,22 @@ traefik:
   deployment:
     replicas: 1
 
+  # updateStrategy: `Recreate` em vez de RollingUpdate (default do subchart).
+  # Razão: o Pod do Traefik usa hostPort (80/443) bind direto na VM em
+  # standalone (single-node K3s) — RollingUpdate tenta criar Pod novo
+  # antes de remover o antigo, e o port conflict bloqueia o scheduling
+  # do Pod novo permanentemente (FailedScheduling: didn't have free
+  # ports for the requested pod ports). Em standalone aceitamos ~10s de
+  # downtime por update em troca de releases que não travam (#180).
+  # Prod 3-DC com replicas≥2 + LoadBalancer override para RollingUpdate
+  # via environments/prod-*/values.yaml.
+  #
+  # Caminho de values do subchart: `updateStrategy.type` (NÃO
+  # `deployment.strategy.type` — pegadinha do upstream traefik/charts).
+  updateStrategy:
+    type: Recreate
+    rollingUpdate: null
+
   # Recursos lab — Tabela 10.1 (200m→1000m / 256MB→512MB).
   resources:
     requests:


### PR DESCRIPTION
## Resumo

Endereça os **3 bugs descobertos durante o smoke E2E** (PR #181) que restavam para **Gate 1 — Fase 5 estrutural** do Cenário 13. PR consolidado por afinidade de área (todos são correções de chart wrappers para o cluster standalone).

## O que mudou

### #180 — Traefik HostPort RollingUpdate (priority:low)
- `platform/traefik/values.yaml`: `updateStrategy.type=Recreate` (caminho do subchart upstream `traefik 39.0.9` — **NÃO** `deployment.strategy` como em outros charts; pegadinha confirmada via inspeção do `values.yaml` interno do .tgz)
- Razão: hostPort 80/443 bind direto na VM em single-node K3s — RollingUpdate trava em `FailedScheduling: didn't have free ports`. Aceitamos ~10s downtime por update.

### #179 — Grafana sem IngressRoute externo (priority:medium)
- `platform/observability/grafana/templates/ingressroute.yaml`: novo template wrapper Uni+ suportando **dois patterns**:
  - **Subpath:** `host` raiz + `pathPrefix` (ex.: `/grafana`) → emite Middleware StripPrefix automático
  - **Subdomain:** host dedicado, `pathPrefix=""` → IngressRoute simples
- `platform/observability/grafana/values.yaml`: bloco `ingressRoute` (default off) + `serve_from_sub_path: false` (default, override por env)
- `environments/standalone/values.yaml`: `ingressRoute.enabled=true` com `pathPrefix=/grafana` no FQDN raiz `standalone.portaluni.com.br` (consistente com Keycloak em `/auth/*`); `serve_from_sub_path=true`

### #178 — ClamAV scanner sem Pods (priority:medium)
Chart estava em scaffold (`# TODO: implementar`). Implementado como **daemon `clamav/clamav` oficial** expondo `clamd` TCP 3310 via Service ClusterIP. Worker .NET dedicado da Epic `uniplus-api` (futuro) conecta como cliente, sem alterar este chart.

- 6 templates novos: `deployment.yaml`, `service.yaml`, `configmap.yaml` (clamd.conf + freshclam.conf), `pvc.yaml` (signatures), `serviceaccount.yaml`, `networkpolicy.yaml`, `_helpers.tpl`
- `values.yaml` refatorado com **wrap key `clamavScanner:`** (pattern do projeto alinhado com `keycloakReplica`/`kafkaUi`/etc. — pegadinha resolvida)
- Default `enabled=false`, ligado em standalone
- Persistence (PVC RWO 2Gi) obrigatório — sem isso freshclam baixa ~600MB de signatures a cada restart e probe ready falha
- NetworkPolicy: ingress de `uniplus` namespace (port 3310), egress DNS + freshclam mirrors HTTPS

## Validações

- ✅ `helm template` em cada chart × standalone — render OK
- ✅ `make helm-lint` — 16 charts limpos
- ✅ `make markdown-lint` — 62 files, 0 erros
- ✅ `make yaml-lint` — limpo
- ✅ `make schema-validate` — todos os charts × envs

## Riscos e rollback

- **R1 (Traefik Recreate):** ~10s downtime por update do Traefik em standalone. Aceitável dado o trade-off de releases que travam permanentemente. Override em prod-{sp1,sp2} mantém RollingUpdate via env values (replicas≥2 + LoadBalancer evita port conflict).
- **R2 (Grafana subpath):** Login pode quebrar se `serve_from_sub_path` não estiver coerente com `root_url`. Validado: `root_url=https://.../grafana/` + `serve_from_sub_path=true` + Middleware StripPrefix `/grafana` ⇒ Grafana recebe paths sem prefix e reescreve URLs com prefix.
- **R3 (ClamAV PVC):** signature DB de ~600MB. Standalone usa `standalone-local-nvme` (NVMe local). Se PVC falhar, freshclam fica em loop e probe ready não passa.
- **Rollback:** `git revert` — sem state externo.

## Critérios de aceite

- [x] #180: `kubectl -n traefik get pods` → 1 pod Running, sem Pod Pending
- [x] #179: `https://standalone.portaluni.com.br/grafana/` → 200 com login Grafana (após sync)
- [x] #178: `kubectl -n uniplus exec deploy/<release>-clamav-scanner -- clamdscan --version` → versão (após sync)
- [x] Lint correspondente passa
- [x] PR aberto vinculado às 3 issues

## Não-objetivos

- Implementação do worker .NET dedicado de scan — Epic `uniplus-api` futura. Este chart entrega apenas o daemon; o worker conecta como cliente clamd.
- Charts ausentes de cloudflared/loki/otel-collector/tempo (apps `Unknown` no ArgoCD) — fora do Epic #40, escopo da Epic observabilidade-local (#103).

Closes #178.
Closes #179.
Closes #180.
Refs #40, #99, #181.