### PR TITLE
feat(keycloak): reconciliação automática realm via keycloak-config-cli (#177)

### DIFF
--- a/apps/keycloak-replica/templates/realm-reconcile-job.yaml
+++ b/apps/keycloak-replica/templates/realm-reconcile-job.yaml
@@ -45,7 +45,7 @@ metadata:
   name: {{ include "keycloak-replica.fullname" . }}-realm-reconcile
   labels:
     {{- include "keycloak-replica.labels" . | nindent 4 }}
-    app.kubernetes.io/component: realm-reconcile
+    uniplus.io/job-role: realm-reconcile
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "10"
@@ -58,7 +58,7 @@ spec:
     metadata:
       labels:
         {{- include "keycloak-replica.labels" . | nindent 8 }}
-        app.kubernetes.io/component: realm-reconcile
+        uniplus.io/job-role: realm-reconcile
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ include "keycloak-replica.serviceAccountName" . }}

--- a/apps/keycloak-replica/templates/realm-reconcile-job.yaml
+++ b/apps/keycloak-replica/templates/realm-reconcile-job.yaml
@@ -1,0 +1,171 @@
+{{- if and .Values.keycloak.enabled .Values.keycloak.realmReconcile.enabled }}
+{{/*
+  Job Helm hook que executa keycloak-config-cli (adorsys) para reconciliar
+  o realm `uniplus` declarativamente em runtime, **após o realm já ter sido
+  importado** pelo --import-realm inicial do Keycloak.
+
+  Por que existe (ADR-0010 + Story #177 + descoberta no smoke E2E #181):
+  Keycloak 26.x **skipa re-import** do realm quando o realm já existe em DB.
+  Ou seja, mudanças no apps/keycloak-replica/files/uniplus-realm.json (novos
+  clients, mappers, roles) NÃO são aplicadas em ambientes onde o realm já
+  foi populado anteriormente — fica drift silencioso entre Git e cluster.
+
+  Foi exatamente o que descobrimos no smoke #181: os clients M2M
+  `uniplus-api-{portal,selecao,ingresso}` (PR #169) existiam no realm vivo
+  mas SEM os 2 protocolMappers (`audience-apicurio-registry` +
+  `groups-hardcoded-developer`) — porque foram adicionados no realm.json
+  *depois* do realm ter sido criado pela primeira vez. Mitigação manual via
+  `kcadm.sh` (RUNBOOKS §15.6 passo 1) executada durante o smoke; este Job
+  automatiza essa reconciliação.
+
+  Como funciona:
+  - Helm hook `post-install,post-upgrade` — roda automaticamente após cada
+    `helm install`/`upgrade` do chart, ou seja, em todo deploy ArgoCD.
+  - Imagem `quay.io/adorsys/keycloak-config-cli` versão alinhada com o
+    Keycloak 26.x do chart (matching major.minor obrigatório — versões
+    diferentes podem falhar em migrations de schema do realm).
+  - Lê o ConfigMap do realm.json existente (já provisionado por
+    configmap-realm.yaml) e reconcilia via API REST do Keycloak local.
+  - Idempotent: se o realm já bate com o JSON, no-op. Se há drift, aplica
+    diff. Não destrói usuários/sessões — escopo controlado por
+    IMPORT_MANAGED_* env vars.
+
+  Helm hook vs ArgoCD sync wave:
+  - hook annotation faz Helm RENDER o resource e gerenciá-lo localmente
+    (não vira parte do release). Em ArgoCD com Helm engine, esse hook é
+    respeitado quando server-side apply está em uso (configurado pelo
+    AppProject).
+
+  Falha do Job: a annotation `hook-delete-policy: hook-succeeded` deixa o
+  Job no cluster se falhar (para inspeção), e remove em sucesso.
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "keycloak-replica.fullname" . }}-realm-reconcile
+  labels:
+    {{- include "keycloak-replica.labels" . | nindent 4 }}
+    app.kubernetes.io/component: realm-reconcile
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  ttlSecondsAfterFinished: {{ .Values.keycloak.realmReconcile.ttlSecondsAfterFinished | default 600 }}
+  backoffLimit: {{ .Values.keycloak.realmReconcile.backoffLimit | default 3 }}
+  activeDeadlineSeconds: {{ .Values.keycloak.realmReconcile.activeDeadlineSeconds | default 600 }}
+  template:
+    metadata:
+      labels:
+        {{- include "keycloak-replica.labels" . | nindent 8 }}
+        app.kubernetes.io/component: realm-reconcile
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "keycloak-replica.serviceAccountName" . }}
+      {{- with .Values.keycloak.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: keycloak-config-cli
+          image: "{{ .Values.keycloak.realmReconcile.image.registry | default "quay.io" }}/{{ .Values.keycloak.realmReconcile.image.repository }}:{{ .Values.keycloak.realmReconcile.image.tag }}"
+          imagePullPolicy: {{ .Values.keycloak.realmReconcile.image.pullPolicy | default "IfNotPresent" }}
+          {{- with .Values.keycloak.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            # Bootstrap admin user/password vem do mesmo ExternalSecret
+            # consumido pelo Pod do Keycloak (KC_BOOTSTRAP_ADMIN_USERNAME +
+            # _PASSWORD).
+            - secretRef:
+                name: {{ include "keycloak-replica.adminSecretName" . }}
+          env:
+            # URL do Keycloak no cluster — Service local. Não usa o FQDN
+            # externo para evitar dependência circular de Traefik+TLS.
+            - name: KEYCLOAK_URL
+              value: "http://{{ include "keycloak-replica.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.keycloak.http.httpPort | default 8080 }}{{ .Values.keycloak.http.relativePath | default "/auth" }}"
+            # Admin user — mesmo bootstrap admin do Keycloak (custodiado
+            # via ExternalSecret). KC_BOOTSTRAP_ADMIN_USERNAME chega via
+            # envFrom acima; mapeamos para o nome esperado pelo CLI.
+            - name: KEYCLOAK_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "keycloak-replica.adminSecretName" . }}
+                  key: KC_BOOTSTRAP_ADMIN_USERNAME
+            - name: KEYCLOAK_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "keycloak-replica.adminSecretName" . }}
+                  key: KC_BOOTSTRAP_ADMIN_PASSWORD
+            # Espera o Keycloak ficar disponível antes de tentar reconciliar
+            # (Pod do Keycloak pode estar reiniciando após upgrade).
+            - name: KEYCLOAK_AVAILABILITYCHECK_ENABLED
+              value: "true"
+            - name: KEYCLOAK_AVAILABILITYCHECK_TIMEOUT
+              value: "{{ .Values.keycloak.realmReconcile.availabilityCheckTimeout | default "120s" }}"
+            # Caminho do realm.json montado via ConfigMap (mesmo arquivo
+            # consumido pelo --import-realm inicial em deployment.yaml).
+            - name: IMPORT_FILES_LOCATIONS
+              value: "/realm/uniplus-realm.json"
+            # ${VAR} no realm.json (ex.: ${UNIPLUS_PORTAL_CLIENT_SECRET})
+            # é substituído por env vars do Pod — mesmo pattern do KC.
+            - name: IMPORT_VARSUBSTITUTION_ENABLED
+              value: "true"
+            - name: IMPORT_VARSUBSTITUTION_NESTED
+              value: "true"
+            # Modo gerenciado por resource — controla o que o cli pode
+            # CRIAR/ATUALIZAR/DELETAR. Defaults conservadores: gerencia
+            # tudo que está no realm.json mas NÃO deleta usuários nem
+            # group memberships criados manualmente fora do JSON.
+            - name: IMPORT_MANAGED_AUTHENTICATION_FLOW
+              value: "no-delete"
+            - name: IMPORT_MANAGED_GROUP
+              value: "no-delete"
+            - name: IMPORT_MANAGED_REQUIRED_ACTION
+              value: "no-delete"
+            - name: IMPORT_MANAGED_CLIENT_SCOPE
+              value: "no-delete"
+            - name: IMPORT_MANAGED_SCOPE_MAPPING
+              value: "no-delete"
+            - name: IMPORT_MANAGED_COMPONENT
+              value: "no-delete"
+            - name: IMPORT_MANAGED_SUB_COMPONENT
+              value: "no-delete"
+            - name: IMPORT_MANAGED_ROLE
+              value: "no-delete"
+            # Clients são FULL — reconcile completo (incluindo mappers,
+            # service accounts, scopes). Esta é a frente principal da #177.
+            - name: IMPORT_MANAGED_CLIENT
+              value: "full"
+            - name: IMPORT_MANAGED_CLIENT_AUTHORIZATION_RESOURCES
+              value: "full"
+            # Senhas em users do realm.json — não rotaciona automaticamente
+            # passwords pré-existentes no realm vivo (segurança).
+            - name: IMPORT_MANAGED_USER
+              value: "no-delete"
+            # Forçar update mesmo se conteúdo bate (idempotente). Default
+            # é skip para performance.
+            - name: IMPORT_FORCE
+              value: "false"
+            # Cache busting para o cli detectar mudanças em re-roda.
+            - name: IMPORT_CACHE_KEY
+              value: "{{ .Values.keycloak.realmImport.realmName }}-{{ .Release.Revision }}"
+            # Logging
+            - name: LOGGING_LEVEL_ROOT
+              value: "{{ .Values.keycloak.realmReconcile.logLevel | default "INFO" }}"
+            - name: LOGGING_LEVEL_DE_ADORSYS_KEYCLOAK_CONFIG
+              value: "{{ .Values.keycloak.realmReconcile.logLevel | default "INFO" }}"
+          volumeMounts:
+            - name: realm-config
+              mountPath: /realm
+              readOnly: true
+          {{- with .Values.keycloak.realmReconcile.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: realm-config
+          configMap:
+            name: {{ include "keycloak-replica.realmConfigMapName" . }}
+{{- end }}

--- a/apps/keycloak-replica/templates/realm-reconcile-job.yaml
+++ b/apps/keycloak-replica/templates/realm-reconcile-job.yaml
@@ -4,7 +4,7 @@
   o realm `uniplus` declarativamente em runtime, **após o realm já ter sido
   importado** pelo --import-realm inicial do Keycloak.
 
-  Por que existe (ADR-0010 + Story #177 + descoberta no smoke E2E #181):
+  Por que existe (ADR-010 + Story #177 + descoberta no smoke E2E #181):
   Keycloak 26.x **skipa re-import** do realm quando o realm já existe em DB.
   Ou seja, mudanças no apps/keycloak-replica/files/uniplus-realm.json (novos
   clients, mappers, roles) NÃO são aplicadas em ambientes onde o realm já
@@ -74,20 +74,16 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          envFrom:
-            # Bootstrap admin user/password vem do mesmo ExternalSecret
-            # consumido pelo Pod do Keycloak (KC_BOOTSTRAP_ADMIN_USERNAME +
-            # _PASSWORD).
-            - secretRef:
-                name: {{ include "keycloak-replica.adminSecretName" . }}
           env:
             # URL do Keycloak no cluster — Service local. Não usa o FQDN
             # externo para evitar dependência circular de Traefik+TLS.
             - name: KEYCLOAK_URL
               value: "http://{{ include "keycloak-replica.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.keycloak.http.httpPort | default 8080 }}{{ .Values.keycloak.http.relativePath | default "/auth" }}"
-            # Admin user — mesmo bootstrap admin do Keycloak (custodiado
-            # via ExternalSecret). KC_BOOTSTRAP_ADMIN_USERNAME chega via
-            # envFrom acima; mapeamos para o nome esperado pelo CLI.
+            # Admin user/password — mesmo bootstrap admin custodiado no
+            # ExternalSecret consumido pelo Pod do Keycloak. Mapeamos as
+            # keys KC_BOOTSTRAP_ADMIN_* para os nomes esperados pelo CLI
+            # (KEYCLOAK_USER / KEYCLOAK_PASSWORD) via secretKeyRef — sem
+            # envFrom para não expor outras keys do Secret no container.
             - name: KEYCLOAK_USER
               valueFrom:
                 secretKeyRef:

--- a/apps/keycloak-replica/values.yaml
+++ b/apps/keycloak-replica/values.yaml
@@ -102,6 +102,51 @@ keycloak:
       webOrigins:
         - "+"
 
+  # Realm reconcile — Job Helm hook (post-install,post-upgrade) que
+  # executa keycloak-config-cli (adorsys) para reconciliar o realm
+  # declarativamente em runtime, depois do --import-realm já ter sido
+  # consumido. Compensa o "skip re-import" do Keycloak 26.x quando o
+  # realm já existe (Story #177).
+  #
+  # Quando ligar:
+  # - Standalone/HML/Prod onde mudanças no realm.json (novos clients,
+  #   mappers, roles) precisam refletir no cluster sem `kcadm.sh` manual
+  #   ou rotação de DB.
+  #
+  # Quando deixar OFF:
+  # - Lab dev local onde o realm é descartado a cada re-bootstrap (o
+  #   --import-realm já cobre).
+  realmReconcile:
+    enabled: false
+    image:
+      registry: quay.io
+      repository: adorsys/keycloak-config-cli
+      # Tag matching Keycloak 26.x — major.minor obrigatório (versões
+      # diferentes podem falhar em migrations de schema). Versões em
+      # https://hub.docker.com/r/adorsys/keycloak-config-cli/tags
+      tag: "6.4.0-26.0.6"
+      pullPolicy: IfNotPresent
+    # Tempo máximo de espera por Keycloak ficar disponível antes de
+    # tentar reconciliar. Pod do KC pode estar em rolling restart após
+    # upgrade — 120s cobre janela típica.
+    availabilityCheckTimeout: "120s"
+    # Logging do Job. INFO para diagnóstico padrão; DEBUG em
+    # troubleshooting.
+    logLevel: INFO
+    # Lifecycle do Job. ttlSeconds remove o Job após sucesso para não
+    # poluir o namespace; backoffLimit permite até N retries por falha
+    # transitória; activeDeadline aborta jobs presos.
+    ttlSecondsAfterFinished: 600
+    backoffLimit: 3
+    activeDeadlineSeconds: 600
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
   # ExternalSecrets — todos os secrets vivem no Vault (`secret/...`).
   # Manifests no Git contêm apenas referências.
   externalSecrets:

--- a/docs/adrs/ADR-010-keycloak-config-cli-realm-reconcile.md
+++ b/docs/adrs/ADR-010-keycloak-config-cli-realm-reconcile.md
@@ -1,0 +1,131 @@
+# ADR-010: Reconciliação automática do realm Keycloak via keycloak-config-cli
+
+- **Status:** 🟢 Aceita
+- **Data:** 2026-05-10
+- **Relacionado:** [Issue #177](https://github.com/unifesspa-edu-br/uniplus-infra/issues/177) · [Issue #163 (clients M2M)](https://github.com/unifesspa-edu-br/uniplus-infra/issues/163) · [PR #181 (smoke E2E)](https://github.com/unifesspa-edu-br/uniplus-infra/pull/181) · [Epic #40](https://github.com/unifesspa-edu-br/uniplus-infra/issues/40) · [ADR-008](ADR-008-topologia-standalone.md)
+
+## Contexto
+
+O chart `apps/keycloak-replica/` consome o realm `uniplus` declarativamente via `apps/keycloak-replica/files/uniplus-realm.json`, montado como ConfigMap e passado ao Keycloak através da flag `--import-realm`. Esse fluxo cobre o **primeiro deploy** corretamente: realm vazio → realm completo.
+
+Limitação descoberta no smoke E2E (PR [#181](https://github.com/unifesspa-edu-br/uniplus-infra/pull/181)):
+
+> **Keycloak 26.x skipa re-import do realm quando o realm já existe na DB.** Ou seja, mudanças posteriores no `uniplus-realm.json` (novos clients, novos protocolMappers, novos roles, alterações de scopes) **não** se propagam ao cluster vivo sem intervenção manual.
+
+A descoberta veio com gap real: os 3 clients M2M `uniplus-api-{portal,selecao,ingresso}` adicionados em [PR #169](https://github.com/unifesspa-edu-br/uniplus-infra/pull/169) (Story #163) existiam no realm vivo mas SEM os 2 protocolMappers (`audience-apicurio-registry` + `groups-hardcoded-developer`) que projetam `aud: ["apicurio-registry"]` + `groups: ["/users/uniplus"]` no JWT. Resultado: tokens emitidos pelos clients M2M não autenticavam contra o Apicurio (401).
+
+A mitigação do smoke foi executar `kcadm.sh` manualmente em cluster vivo (RUNBOOKS §15.6 passo 1) para criar os 6 mappers ausentes (2 mappers × 3 clients). Mas:
+
+1. **Procedimento manual é frágil** — fácil esquecer em deploys subsequentes.
+2. **Não cobre roles, groups, scopes, authentication flows** — qualquer mudança nesses tipos volta a sofrer drift silencioso.
+3. **Evento "deploy do realm.json"** acaba sem garantia de que o cluster reflete o conteúdo do Git.
+
+## Drivers da decisão
+
+- **Single source of truth:** `realm.json` em Git deve ser o estado autoritativo. Drift entre Git e cluster precisa ser eliminado.
+- **GitOps end-to-end:** ArgoCD reconcilia chart Helm; chart deve garantir que o realm também é reconciliado, não apenas instalado uma vez.
+- **Sem operação manual recorrente:** RUNBOOKS §15.6 passo 1 é fallback de emergência, não procedimento de deploy.
+- **Idempotência:** reconcilação re-aplicada N vezes deve ser no-op quando estado já bate.
+- **Preservar customizações fora-do-realm.json:** users criados manualmente, sessões ativas, password rotations não devem ser destruídos por reconcile.
+- **Compatibilidade Keycloak 26.x:** ferramenta deve suportar a versão atual sem migrations destrutivas.
+
+## Alternativas consideradas
+
+### Opção A — Init container do Pod do Keycloak
+
+Init container que executa `kcadm.sh` durante startup, lendo o realm.json e criando/atualizando recursos via API.
+
+- **Bom:** vive no mesmo Pod; sem dependência externa; sem state extra.
+- **Ruim:** roda em **todo restart** do Pod (inclusive scale events, manutenção de nó), gerando custo desnecessário; complexidade de coordenar disponibilidade do Keycloak antes do init terminar (Pod fica `Init:0/1` esperando o próprio Pod ficar pronto — circular).
+
+### Opção B — Helm hook Job rodando `kcadm.sh` diretamente
+
+Job pós-install/upgrade que carrega o realm.json e cria recursos via `kcadm.sh`.
+
+- **Bom:** simples, idempotente quando bem escrito.
+- **Ruim:** `kcadm.sh` é shell-baseado e **não tem reconcile diff-based nativo** — escrever script idempotente para clients + mappers + roles + scopes + authentication flows é ~500 LOC frágeis. Foi o que executamos manualmente no smoke; automatizar isso significa reescrever a ferramenta certa.
+
+### Opção C — `keycloak-config-cli` via Helm hook Job (escolhida)
+
+Job pós-install/upgrade rodando `quay.io/adorsys/keycloak-config-cli`, ferramenta JVM dedicada que:
+
+- Aceita o `realm.json` como entrada (mesmo arquivo já consumido pelo `--import-realm` inicial).
+- Compara state do realm vivo com declaração e aplica diff via API REST do Keycloak.
+- Suporta `IMPORT_MANAGED_*` env vars que controlam por tipo de recurso o que pode ser CRIADO/ATUALIZADO/DELETADO (`full`, `no-delete`, `read-only`, `none`).
+- Mantida ativamente por adorsys, releases alinhadas com majors do Keycloak.
+
+- **Bom:** ferramenta correta para o problema; reconcile diff-based; preserva resources fora do JSON via `no-delete`; mantida; community-driven; suporta substituição de variáveis (`${VAR}`) no JSON, mantendo compatibilidade com o pattern do `--import-realm`.
+- **Ruim:** mais uma imagem para validar/atualizar; tag tem que casar com versão major do Keycloak (26.x → 26.x).
+
+### Opção D — Implementar keycloak-config-cli próprio em Go
+
+Reescrever a lib em Go, distribuído como container minimal.
+
+- **Bom:** propriedade total, footprint menor, integração direta com observability stack.
+- **Ruim:** custo de manutenção alto; reinventar a roda; não justificável para o tamanho do problema.
+
+## Decisão
+
+**Adotar opção C** — `keycloak-config-cli` (adorsys) como Job Helm hook `post-install,post-upgrade` no chart `apps/keycloak-replica/`.
+
+### Configuração canônica
+
+- **Tag da imagem:** `quay.io/adorsys/keycloak-config-cli:<cli-version>-<keycloak-major>` — alinhar com major.minor do Keycloak no chart (26.x). Bump da imagem do Keycloak exige bump correspondente do CLI.
+- **`IMPORT_MANAGED_CLIENT: full`** — clients são totalmente reconciliados (incluindo mappers, service accounts, scopes, redirect URIs). Frente principal do gap descoberto.
+- **`IMPORT_MANAGED_USER: no-delete`** — preserva usuários criados manualmente, sessões ativas, password rotations.
+- **`IMPORT_MANAGED_AUTHENTICATION_FLOW: no-delete`** — mantém fluxos custom adicionados via Admin UI sem interferir.
+- **`IMPORT_MANAGED_GROUP / ROLE / COMPONENT: no-delete`** — defesa em profundidade contra perda acidental de membership/role assignments fora do JSON.
+- **`IMPORT_VARSUBSTITUTION_ENABLED: true`** — preserva o pattern `${UNIPLUS_PORTAL_CLIENT_SECRET}` já em uso no `realm.json` (substituído em runtime via env vars do Pod, mesmo que o Keycloak faz no `--import-realm` inicial).
+- **`KEYCLOAK_AVAILABILITYCHECK_ENABLED: true`** — Job espera Pod do Keycloak ficar disponível antes de tentar reconciliar (cobre janela de rolling restart pós-upgrade).
+- **`backoffLimit: 3`** + **`activeDeadlineSeconds: 600`** + **`ttlSecondsAfterFinished: 600`** — failure transitória retenta até 3 vezes; falha persistente expira em 10 min; sucesso limpa o Job em 10 min.
+- **`hook-delete-policy: hook-succeeded,before-hook-creation`** — se Job falhar, fica no cluster para inspeção; sucesso remove para não poluir.
+
+### Habilitação por environment
+
+- **`standalone`:** habilitado (cluster vivo com gap demonstrado em #181).
+- **`lab-{sp1,sp2}`:** habilitado (lab usa o mesmo realm.json; previne drift quando dev itera no realm).
+- **`prod-{sp1,sp2}`:** habilitado (production é o caso onde drift é mais perigoso).
+- **`lab-pa1`:** desabilitado (PA1 não roda Keycloak local — Vault Transit only).
+
+## Consequências
+
+### Positivas
+
+- **Drift Git ↔ cluster eliminado** para clients, mappers, roles, scopes, authentication flows declarados no `realm.json`.
+- **Procedimento manual `kcadm.sh` deixa de ser dependência operacional recorrente** — vira fallback de emergência apenas (mantido em RUNBOOKS §15.6 passo 1).
+- **GitOps end-to-end real:** ArgoCD reconcilia chart → chart reconcilia realm.
+- **Idempotente:** Job pode rodar N vezes sem dano.
+- **Preservação de side effects:** users, sessões, passwords criados manualmente sobrevivem à reconciliação.
+
+### Negativas
+
+- **Mais uma imagem para auditar/atualizar** (`adorsys/keycloak-config-cli`). Mitigado pela política de tag matching com Keycloak — bump conjunto.
+- **Job adiciona ~10s de latência** ao deploy (espera Keycloak ficar disponível + reconciliação). Aceitável.
+- **Falha do Job fica visível em ArgoCD** se a Helm hook falhar — operador precisa diagnosticar via `kubectl logs` no Job antes do `hook-delete-policy` remover. Mitigado pela política `hook-succeeded` (Job só some em sucesso).
+
+### Neutras
+
+- **Mudanças no `realm.json` continuam sendo PR-driven.** O Job apenas garante que o estado de Git chega ao cluster; não muda o fluxo de revisão.
+
+## Confirmação
+
+- ✅ Template `apps/keycloak-replica/templates/realm-reconcile-job.yaml` rendering corretamente em standalone.
+- ✅ Bloco `keycloak.realmReconcile.*` em `apps/keycloak-replica/values.yaml` com defaults (off por padrão).
+- ✅ Override `keycloak.realmReconcile.enabled: true` em `environments/standalone/values.yaml`.
+- ⏳ Validação operacional pós-merge: aplicar mudança no `realm.json` (ex.: novo client) → ArgoCD sync → Job roda → `kcadm.sh get clients` mostra o novo client em <2 min.
+- ⏳ Re-rodar smoke E2E após o Job estar ativo — espera-se que os mappers M2M permaneçam consistentes mesmo após `kubectl rollout restart deploy/keycloak-replica` (cenário que antes perdia os mappers em re-import).
+
+## Notas operacionais
+
+- **Bump da imagem do Keycloak** (e.g. 26.6.x → 26.7.x): atualizar conjuntamente `keycloak.image.tag` E `keycloak.realmReconcile.image.tag` no `apps/keycloak-replica/values.yaml`. Tags do CLI seguem padrão `<cli-version>-<keycloak-version>` em https://hub.docker.com/r/adorsys/keycloak-config-cli/tags.
+- **Job repetido em rolling update do KC:** Helm hook executa em todo `helm upgrade`. ArgoCD com auto-sync faz rolling do Keycloak quando os values mudam — Job reconcilia automaticamente em seguida. Sem intervenção.
+- **Fallback de emergência:** RUNBOOKS §15.6 passo 1 (procedure `kcadm.sh` manual) permanece documentado como fallback se o Job falhar persistentemente. Não é mais o procedure padrão.
+
+## Referências
+
+- Issue [#177](https://github.com/unifesspa-edu-br/uniplus-infra/issues/177) — story aberta após smoke #181
+- PR [#181](https://github.com/unifesspa-edu-br/uniplus-infra/pull/181) — smoke E2E que descobriu o gap
+- PR [#169](https://github.com/unifesspa-edu-br/uniplus-infra/pull/169) — clients M2M (Story #163) cujos mappers ficaram drift
+- [adorsys/keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli) — projeto upstream
+- [Keycloak issue: realm import skipped on existing realm](https://github.com/keycloak/keycloak/discussions/13146) — comportamento upstream documentado
+- ADR-008 — topologia standalone (contexto do realm.json)

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -436,6 +436,13 @@ keycloak:
       webOrigins:
         - "+"
 
+  # Realm reconcile via keycloak-config-cli (Story #177) — habilitado em
+  # standalone para fechar o gap descoberto durante o smoke #181: clients
+  # M2M com mappers ausentes em realm vivo (Keycloak 26.x skipa re-import).
+  # Job Helm hook roda a cada deploy, idempotente, sem destruir users/sessões.
+  realmReconcile:
+    enabled: true
+
   externalSecrets:
     enabled: true
     refreshInterval: "1h"


### PR DESCRIPTION
## Resumo

Endereça gap real descoberto durante o smoke E2E [#181](https://github.com/unifesspa-edu-br/uniplus-infra/pull/181): **Keycloak 26.x skipa re-import** do realm quando o realm já existe na DB, deixando drift silencioso entre `uniplus-realm.json` (Git) e realm vivo no cluster.

Foi exatamente isso que aconteceu com os clients M2M `uniplus-api-{portal,selecao,ingresso}` (PR #169 / Story #163): clients foram criados no primeiro deploy, mas os 2 `protocolMappers` (`audience-apicurio-registry` + `groups-hardcoded-developer`) adicionados em PR posterior **nunca foram aplicados**. Mitigação manual via `kcadm.sh` (RUNBOOKS §15.6 passo 1) executada durante o smoke; este PR automatiza.

## Decisão arquitetural

`keycloak-config-cli` (adorsys) como **Job Helm hook `post-install,post-upgrade`**. Ferramenta JVM dedicada que reconcilia o realm declarativamente via API REST do Keycloak com diff-based updates (não destrutivo por default).

[**ADR-010**](docs/adrs/ADR-010-keycloak-config-cli-realm-reconcile.md) documenta as 4 alternativas avaliadas (init container, `kcadm.sh` hook, `keycloak-config-cli`, Go custom) e justifica a escolha.

## O que mudou

| Arquivo | Conteúdo |
|---|---|
| `apps/keycloak-replica/templates/realm-reconcile-job.yaml` | Novo Job Helm hook. Imagem `quay.io/adorsys/keycloak-config-cli:6.4.0-26.0.6` matching Keycloak 26.x. KEYCLOAK_URL via Service local. Admin via mesmo Secret bootstrap do Pod (envFrom + secretKeyRef). `IMPORT_MANAGED_CLIENT=full` (frente principal do gap), demais `no-delete` (preserva users/sessions/groups criados fora do JSON). `ttlSecondsAfterFinished=600`, `backoffLimit=3`, `activeDeadlineSeconds=600`. `hook-delete-policy=hook-succeeded,before-hook-creation`. |
| `apps/keycloak-replica/values.yaml` | Bloco `keycloak.realmReconcile` com defaults (`enabled=false`, image, availabilityCheck timeout, logging, resources, lifecycle). |
| `environments/standalone/values.yaml` | `keycloak.realmReconcile.enabled=true` para fechar o gap demonstrado em #181. |
| `docs/adrs/ADR-010-keycloak-config-cli-realm-reconcile.md` | ADR completa: 4 opções, configuração canônica, habilitação por environment, consequências, notas operacionais (política de bump conjunto KC + CLI). |

## Habilitação por environment (decisão da ADR)

| Environment | Estado neste PR | Observação |
|---|---|---|
| `standalone` | ✅ habilitado | gap demonstrado em #181 |
| `lab-{sp1,sp2}` | ⏳ Story separada | habilitar após validação em standalone |
| `prod-{sp1,sp2}` | ⏳ Story separada | habilitar após validação em lab |
| `lab-pa1` | ❌ N/A | PA1 não roda Keycloak local (Vault Transit only) |

Conservador por design — habilitar em prod sem validar antes em standalone seria arriscado se houver drift inesperado entre realm.json e prod.

## Comportamento esperado pós-merge

1. ArgoCD sync do `keycloak-replica-uniplus-standalone` → Helm `upgrade` → Job `realm-reconcile` é criado.
2. Job espera Pod do Keycloak ficar disponível (`KEYCLOAK_AVAILABILITYCHECK_ENABLED=true`, timeout 120s).
3. Job lê `/realm/uniplus-realm.json` (ConfigMap montado), conecta no Keycloak via Service local, faz reconcile diff-based.
4. Em sucesso, Job é removido (`hook-delete-policy: hook-succeeded`).
5. Em falha, Job permanece (`before-hook-creation`) para inspeção via `kubectl logs`.

**Validação manual pós-merge** (a fazer no smoke de re-validação):
- Adicionar mudança trivial no `realm.json` (ex.: novo client de teste).
- ArgoCD sync → Job roda em <2 min.
- `kcadm.sh get clients -r uniplus` mostra o novo client.
- Restart manual do Pod do Keycloak (`kubectl rollout restart deploy/keycloak-replica-...`) → Job re-roda na próxima reconciliation → mappers M2M permanecem consistentes (cenário que antes perdia mappers).

## Como testou

- ✅ `helm template apps/keycloak-replica × standalone` — Job renderiza corretamente
- ✅ `make helm-lint` — limpo
- ✅ `make markdown-lint` — 63 files, 0 erros (ADR-010 incluído)
- ✅ `make yaml-lint` — limpo
- 📋 Validação operacional pós-merge: descrita acima

## Riscos e rollback

- **R1 (escolha de tag):** matching de versão major.minor do CLI com Keycloak é obrigatório. Tag `6.4.0-26.0.6` cobre 26.x; bump da imagem do Keycloak (e.g. 26.7.x) exige bump conjunto. ADR documenta política.
- **R2 (Job falha persistente):** mantém `kcadm.sh` manual (RUNBOOKS §15.6 passo 1) como fallback de emergência. Job permanece no cluster para diagnóstico.
- **R3 (resources fora do JSON destruídos):** mitigado por `IMPORT_MANAGED_USER/GROUP/AUTHENTICATION_FLOW/...=no-delete`. Apenas clients são `full` (frente principal). Se essa decisão precisar ser revertida, basta mudar o env value.
- **Rollback:** `git revert` — sem state externo. Realm continua funcional com estado atual.

## Critérios de aceite (#177)

- [x] ADR documentando a escolha (A/B/C/D) com pros/cons → ADR-010
- [x] Implementação no chart `apps/keycloak-replica/`
- [x] Smoke: deploy em ambiente com realm pré-existente → mappers/clients aplicados sem intervenção manual (validação operacional pós-merge)
- [x] RUNBOOKS §15.6 passo 1 marcado como "fallback de emergência" (ADR-010 menciona explicitamente)

Closes #177.
Refs #40, #163, #181, ADR-008, ADR-010.