### PR TITLE
fix(scripts): Postgres systemd LoadCredential (issue #128)

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1419,6 +1419,10 @@ A migração de `EnvironmentFile=` para `LoadCredential=` (PR fecha #128) muda o
 
 **Pré-requisitos:** acesso root no data-host (`10.0.2.87`); cliente Keycloak parado ou em janela onde reconnect é aceitável (Postgres restart força re-auth de connections existentes).
 
+> ⚠️ **Procedimento assume senha hex-only** (`openssl rand -hex N` — caracteres `[0-9a-f]`). Se a política institucional exigir charset diferente (símbolos, mistura), o `ALTER USER ... WITH PASSWORD '$NEW_PW'` em heredoc unquoted e o `sed -i "s/.../...$NEW_PW/"` ficam vulneráveis a escape (`'`, `/`, `&`, etc.). Para outros charsets, gerar via `openssl rand -base64 N | tr -d '/=+'` e validar manualmente, ou refatorar para passar via `psql -v` com `quote_literal()`.
+>
+> Hex é suficientemente forte (32 bytes hex = 128 bits de entropia) e mantém o procedimento simples — recomendamos manter.
+
 **Passo 1 — Gerar nova senha:**
 
 ```bash
@@ -1472,9 +1476,20 @@ Em Ubuntu 24.04 (systemd 255), o credential file pode ser cifrado e bound ao TPM
 sudo systemd-creds has-tpm2
 # Esperado: yes
 
-# 2) Imprime PCRs disponíveis (defaults: 7 = secure boot, 11 = unified kernel image)
+# 2) Imprime PCRs disponíveis para escolha de bind
 sudo tpm2_pcrread sha256
 ```
+
+**Escolha de PCR para o bind:**
+
+| PCR | Cobertura | Estabilidade em servidor Ubuntu |
+|---|---|---|
+| 0 | BIOS/UEFI code | estável entre boots; muda em firmware update |
+| 4 | Boot loader code | muda em update do GRUB/shim |
+| 7 | Secure Boot policy | em servidor sem Secure Boot habilitado, valor é constante (zeros) — válido para sealing mas não adiciona binding real |
+| 11 | Unified Kernel Image (UKI) | só preenchido com UKI (Ubuntu 24.04 default ainda usa initrd tradicional — PCR 11 fica zero) |
+
+Recomendação para Ubuntu 24.04 server **sem UKI** (default): usar **PCR 0** (binding ao firmware da máquina). Adicionar PCR 7 só se Secure Boot estiver habilitado e enrollment do MOK customizado importar para a equação. PCRs 4 e 11 só fazem sentido com configurações específicas.
 
 **Cifrar o credential com TPM2 binding:**
 
@@ -1483,7 +1498,7 @@ sudo tpm2_pcrread sha256
 # para inspeção; pode-se trocar por --binary se preferir.
 NEW_PW_BLOB=$(sudo systemd-creds encrypt \
     --name=postgres-password \
-    --tpm2-pcrs=7+11 \
+    --tpm2-pcrs=0 \
     /etc/credstore/uniplus-postgres-password -)
 
 # Sobrescrever in-place com o blob cifrado

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1245,14 +1245,14 @@ A função `step_data_setup_postgres` em `scripts/bootstrap-standalone.sh` provi
 1. Diretórios `/var/lib/uniplus/postgres/{data,init}` com ownership `70:70` (uid `postgres` no container `postgres:18-alpine` — Alpine usa uid 70, distinto do uid 999 das imagens Debian-based).
 2. `.bootstrap-creds` (root:root 600) em `/var/lib/uniplus/postgres/.bootstrap-creds` com `super_pw` + `keycloak_pw` (256 bits cada via `openssl rand -hex 32`) — gerado **somente na primeira execução**.
 3. Init SQL **efêmero** `/var/lib/uniplus/postgres/init/00-keycloak.sql` (mode `600`, owner `70:70`) — gerado APENAS quando o cluster ainda não foi inicializado (sem `PG_VERSION` em `data/`). Cria role `keycloak` + database `keycloak` na primeira inicialização. Após `pg_isready` confirmar que o entrypoint executou o script, o arquivo é shredded (`shred -u`) — `keycloak_pw` em cleartext NÃO persiste no filesystem do data-host entre runs (snapshots/backups da LVM `vg-postgres` não capturam cópia extra do secret).
-4. EnvironmentFile `/etc/uniplus-postgres.env` (root:root 600) com `POSTGRES_PASSWORD=<super_pw>` lido do `.bootstrap-creds`. `docker run` recebe a senha via `-e POSTGRES_PASSWORD` (sem `=value`) — evita exposure em `/proc/<pid>/cmdline`.
-5. `systemd` unit `/etc/systemd/system/uniplus-postgres.service` com `Restart=always`, `Type=simple`, container em `--network host` (Postgres listen em `10.0.2.87:5432`).
+4. **Credential file** `/etc/credstore/uniplus-postgres-password` (root:root `400`, dir `700`) contendo `super_pw` em texto puro (sem trailing newline). Issue #128 — substitui o legacy `/etc/uniplus-postgres.env` (EnvironmentFile) pelo pattern `LoadCredential=` do systemd 250+: a senha é bind-mounted pelo systemd em `${CREDENTIALS_DIRECTORY}/postgres-password` (tmpfs do unit, isolada de `/proc/<pid>/environ`) e nunca trafega via env do processo. Em Ubuntu 24.04 LTS (systemd 255), o file pode ser opcionalmente cifrado via `systemd-creds encrypt --name=postgres-password --tpm2-pcrs=...` para binding ao TPM2 do host (ver §9.6).
+5. `systemd` unit `/etc/systemd/system/uniplus-postgres.service` com `Restart=always`, `Type=simple`, `LoadCredential=postgres-password:/etc/credstore/uniplus-postgres-password`, container em `--network host` (Postgres listen em `10.0.2.87:5432`). O `docker run` consome a senha via `POSTGRES_PASSWORD_FILE=/run/secrets/postgres-password` (suportado nativamente pelo entrypoint `postgres:18-alpine`) — bind-mount read-only de `${CREDENTIALS_DIRECTORY}/postgres-password` no container, lido pelo entrypoint **antes** do `gosu` drop para uid 70.
 
 **Idempotência (decisões independentes):**
 
 - `.bootstrap-creds`: se já existe, preserva; se não existe e cluster já inicializado, aborta apontando §9.4; senão, gera novas senhas.
 - Init SQL: regenerado sempre que o cluster ainda não tem `PG_VERSION` (cobre o fluxo §9.4 — restore creds, data dir vazio → SQL recriado a partir do `keycloak_pw` persistido). Cleanup defensivo se leftover persiste após cluster já estar inicializado.
-- EnvironmentFile + systemd unit: sempre re-aplicados (cheap, corrige drift sem afetar state do cluster).
+- Credential file (`/etc/credstore/uniplus-postgres-password`) + systemd unit: sempre re-escritos a partir do `super_pw` em `.bootstrap-creds` — corrige drift sem afetar state do cluster. Legacy `/etc/uniplus-postgres.env` (EnvironmentFile) é shredded via `shred -u` na primeira execução pós-migração.
 - Serviço já ativo: bootstrap não reinicia (evita downtime).
 
 **Verificação imediata pós-bootstrap:**
@@ -1406,6 +1406,104 @@ EOF
 >
 > - **Backup:** `pg_dump --format=custom keycloak` rodado periodicamente via systemd timer no data-host, output enviado para bucket MinIO (`s3://backups/postgres/<timestamp>.dump`).
 > - **Restore:** `pg_restore --clean --if-exists --no-owner --dbname=keycloak <dump>` em data-host com volume LVM intacto.
+
+### 9.6 Rotação de credentials e TPM2 binding (issue #128)
+
+A migração de `EnvironmentFile=` para `LoadCredential=` (PR fecha #128) muda o pattern de secret delivery do Postgres systemd. Este sub-runbook cobre operações Day-2 sobre `/etc/credstore/uniplus-postgres-password`.
+
+**Quando rotacionar:**
+
+- Credential exposta acidentalmente (compartilhada em chat/PR/issue por engano)
+- Custódia transferida (engenheiro DevOps off-boarded)
+- Janela de manutenção planejada com bump conjunto de senhas
+
+**Pré-requisitos:** acesso root no data-host (`10.0.2.87`); cliente Keycloak parado ou em janela onde reconnect é aceitável (Postgres restart força re-auth de connections existentes).
+
+**Passo 1 — Gerar nova senha:**
+
+```bash
+ssh -i ~/.ssh/id_ed25519 ubuntu@10.0.2.87
+NEW_PW=$(openssl rand -hex 32)
+echo "New super_pw (custodiar antes de continuar): $NEW_PW"
+```
+
+**Passo 2 — Atualizar a senha no cluster Postgres em si (`ALTER USER`):**
+
+```bash
+sudo docker exec -i uniplus-postgres psql -U postgres -d postgres <<SQL
+ALTER USER postgres WITH PASSWORD '$NEW_PW';
+SQL
+unset NEW_PW   # <-- só desfazer DEPOIS de também atualizar o credential file
+```
+
+> ⚠️ Se desfazer `NEW_PW` antes do Passo 3, ficamos com cluster aceitando a nova senha mas systemd ainda servindo a antiga via LoadCredential — próximo restart do unit falha em `pg_isready`. Sequência rígida.
+
+**Passo 3 — Atualizar credential file e `.bootstrap-creds`:**
+
+```bash
+# Reescrever o credential file (mode 400 root:root, sem trailing newline)
+printf '%s' "$NEW_PW" | sudo tee /etc/credstore/uniplus-postgres-password >/dev/null
+sudo chmod 400 /etc/credstore/uniplus-postgres-password
+
+# Atualizar .bootstrap-creds para que re-runs do bootstrap reflitam a senha viva
+sudo sed -i "s/^super_pw=.*/super_pw=$NEW_PW/" /var/lib/uniplus/postgres/.bootstrap-creds
+unset NEW_PW
+```
+
+**Passo 4 — Re-iniciar o unit (zero downtime se Keycloak tolera reconnect):**
+
+```bash
+sudo systemctl restart uniplus-postgres
+sudo docker exec uniplus-postgres pg_isready -U postgres   # esperado: accepting connections
+```
+
+**Passo 5 — Validar conectividade end-to-end** (do k8s-host, conforme §9.3).
+
+> O `keycloak_pw` (senha do role `keycloak`, não `postgres`) é independente — fica no Vault em `secret/standalone/postgres/keycloak`. Rotação dele segue procedimento separado (`ALTER USER keycloak` + atualizar Vault + restart Keycloak Pod para re-pull do ExternalSecret).
+
+#### 9.6.1 TPM2 binding (opcional)
+
+Em Ubuntu 24.04 (systemd 255), o credential file pode ser cifrado e bound ao TPM2 do host — descriptografar fora desta máquina específica fica computacionalmente inviável.
+
+**Verificar enrollment:**
+
+```bash
+# 1) TPM2 disponível e systemd-creds vê
+sudo systemd-creds has-tpm2
+# Esperado: yes
+
+# 2) Imprime PCRs disponíveis (defaults: 7 = secure boot, 11 = unified kernel image)
+sudo tpm2_pcrread sha256
+```
+
+**Cifrar o credential com TPM2 binding:**
+
+```bash
+# Read+encrypt+write atomicamente. --pretty emite o blob em base64 multiline
+# para inspeção; pode-se trocar por --binary se preferir.
+NEW_PW_BLOB=$(sudo systemd-creds encrypt \
+    --name=postgres-password \
+    --tpm2-pcrs=7+11 \
+    /etc/credstore/uniplus-postgres-password -)
+
+# Sobrescrever in-place com o blob cifrado
+echo "$NEW_PW_BLOB" | sudo tee /etc/credstore/uniplus-postgres-password >/dev/null
+sudo chmod 400 /etc/credstore/uniplus-postgres-password
+unset NEW_PW_BLOB
+```
+
+Após o encrypt, mudar a syntax na unit:
+
+```ini
+# /etc/systemd/system/uniplus-postgres.service
+LoadCredentialEncrypted=postgres-password:/etc/credstore/uniplus-postgres-password
+```
+
+(O bootstrap não força encrypt automaticamente — decisão deliberada para permitir validação antes de tornar o binding obrigatório.)
+
+`systemctl restart uniplus-postgres` e `pg_isready` para confirmar. Se PCRs mudarem (firmware update, kernel diferente em boot via grub), o decrypt falha; ver `man systemd-creds` para policies de unsealing avulso.
+
+> ⚠️ TPM2 binding **destrói portabilidade** do credential. Se o data-host for re-provisionado ou o TPM resetar, o blob fica inrecuperável. Sempre manter custódia paralela do `super_pw` em texto puro no gestor institucional, separadamente.
 
 ## 10. Keycloak (standalone)
 

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -625,7 +625,12 @@ step_data_configure_iptables() {
 #     primeiro pg_isready OK. Cobre o fluxo §9.4 (restore creds, data dir
 #     vazio → SQL recriado) e elimina cópia persistente do keycloak_pw em
 #     cleartext em $DATA_BASE/postgres/init/ (Codex P2 round 2).
-#   - EnvironmentFile + systemd unit: sempre re-aplicados (cheap, corrige drift).
+#   - Credential file (/etc/credstore/uniplus-postgres-password): sempre
+#     re-escrito a partir de super_pw em .bootstrap-creds. Mode 400 root:root.
+#     Pattern systemd LoadCredential — issue #128.
+#   - Legacy /etc/uniplus-postgres.env (EnvironmentFile): se existe, é
+#     shredded — migração one-way para LoadCredential.
+#   - systemd unit: sempre re-aplicada (cheap, corrige drift).
 #   - Serviço já ativo: não reinicia (evita downtime em re-runs).
 #
 # Pós-condições para o operador (ver runbook §9.2):
@@ -647,7 +652,15 @@ step_data_setup_postgres() {
 
     local creds_file="$DATA_BASE/postgres/.bootstrap-creds"
     local init_sql="$DATA_BASE/postgres/init/00-keycloak.sql"
-    local env_file="/etc/uniplus-postgres.env"
+    # systemd LoadCredential — senha lida sob demanda quando o serviço inicia,
+    # nunca via /proc/<pid>/environ. Issue #128 (Codex P2 round 4 do PR #127):
+    # systemd 250+ recomenda LoadCredential=/EncryptedCredential= em vez de
+    # EnvironmentFile= para secret delivery. Em Ubuntu 24.04 (systemd 255)
+    # com TPM2 disponível, podemos opcionalmente cifrar o conteúdo via
+    # `systemd-creds encrypt --name=postgres-password` (binding ao host).
+    local cred_dir="/etc/credstore"
+    local cred_file="$cred_dir/uniplus-postgres-password"
+    local legacy_env_file="/etc/uniplus-postgres.env"
     local unit_file="/etc/systemd/system/uniplus-postgres.service"
 
     # Diretórios + ownership: ambos pertencem ao uid 70 (postgres no container
@@ -744,12 +757,15 @@ EOF
         log_info "Init SQL pronto em $init_sql (será shredded após pg_isready OK)."
     fi
 
-    # EnvironmentFile: sempre re-aplicado (super_pw lido do creds file). Usar
-    # `docker run -e POSTGRES_PASSWORD` (sem `=value`) evita exposure da senha
-    # em /proc/<pid>/cmdline — docker puxa do env do systemd, populado via
-    # EnvironmentFile.
+    # Credential file (systemd LoadCredential): sempre re-aplicado. super_pw
+    # vem do .bootstrap-creds. Mode 400 root:root — só systemd lê durante o
+    # service start. ExecStart NÃO recebe a senha via env — em vez disso,
+    # systemd bind-mounta o file em ${CREDENTIALS_DIRECTORY}/postgres-password
+    # (tmpfs do unit, isolado de /proc/<pid>/environ), e o docker monta esse
+    # path read-only no container, lido pela imagem postgres:18-alpine via
+    # POSTGRES_PASSWORD_FILE (entrypoint suporta nativamente).
     if $DRY_RUN; then
-        echo "[DRY-RUN] Escreveria $env_file (POSTGRES_PASSWORD lido de $creds_file)"
+        echo "[DRY-RUN] Criaria $cred_dir + escreveria $cred_file (super_pw lido de $creds_file)"
     else
         local super_pw_current
         super_pw_current=$(sudo grep '^super_pw=' "$creds_file" | cut -d= -f2)
@@ -757,18 +773,37 @@ EOF
             log_error "Não consegui ler super_pw de $creds_file. Abortando."
             exit 1
         fi
-        sudo tee "$env_file" >/dev/null <<EOF
-POSTGRES_PASSWORD=$super_pw_current
-POSTGRES_INITDB_ARGS=--encoding=UTF8
-EOF
-        sudo chown root:root "$env_file"
-        sudo chmod 600 "$env_file"
+        sudo mkdir -p "$cred_dir"
+        sudo chown root:root "$cred_dir"
+        sudo chmod 700 "$cred_dir"
+        # Senha sem trailing newline — `printf` em vez de heredoc evita
+        # `\n` que `cat` enxergaria como parte da senha (postgres rejeitaria).
+        printf '%s' "$super_pw_current" | sudo tee "$cred_file" >/dev/null
+        sudo chown root:root "$cred_file"
+        sudo chmod 400 "$cred_file"
     fi
 
-    # systemd unit: sempre re-aplicado. Heredoc single-quoted preserva o
-    # conteúdo literal — paths são hardcoded para alinhar com $DATA_BASE
-    # (/var/lib/uniplus). A unit em si não usa variáveis de shell; o systemd
-    # injeta POSTGRES_PASSWORD via EnvironmentFile no env do docker run.
+    # Migração: se /etc/uniplus-postgres.env (legacy EnvironmentFile) existe,
+    # remover via shred para não deixar cópia da senha em texto plano em path
+    # exposto. Idempotente: se já foi migrado em run anterior, no-op.
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Removeria $legacy_env_file via shred -u (se presente)"
+    elif sudo test -f "$legacy_env_file" 2>/dev/null; then
+        sudo shred -u "$legacy_env_file"
+        log_info "Legacy $legacy_env_file removido (migrado para $cred_file)."
+    fi
+
+    # systemd unit: sempre re-aplicada. Usa LoadCredential= em vez de
+    # EnvironmentFile= — systemd 250+ pattern recomendado (sem expor senha em
+    # /proc/<pid>/environ ou propagação a child processes).
+    #
+    # ExecStart resolve `${CREDENTIALS_DIRECTORY}` ANTES do exec — é uma var
+    # do systemd, não shell. Docker recebe o path real (tipicamente
+    # /run/credentials/uniplus-postgres.service/postgres-password) e bind-monta
+    # como /run/secrets/postgres-password no container. POSTGRES_PASSWORD_FILE
+    # aponta para esse path; entrypoint do postgres:18-alpine roda como root
+    # antes do gosu drop e consegue ler (mode 400 root:root no host preserva
+    # ownership no bind mount → root no container lê OK).
     if $DRY_RUN; then
         echo "[DRY-RUN] Escreveria $unit_file"
     else
@@ -785,13 +820,18 @@ Type=simple
 Restart=always
 RestartSec=10
 TimeoutStartSec=120
-EnvironmentFile=/etc/uniplus-postgres.env
+
+# systemd 250+ secret delivery — issue #128. A senha é lida do file abaixo,
+# bind-mounted em ${CREDENTIALS_DIRECTORY}/postgres-password (tmpfs por unit,
+# isolada de /proc<pid>/environ). Não expor via env do systemd.
+LoadCredential=postgres-password:/etc/credstore/uniplus-postgres-password
 
 ExecStartPre=-/usr/bin/docker rm -f uniplus-postgres
 ExecStart=/usr/bin/docker run --rm --name uniplus-postgres \
   --network host \
-  -e POSTGRES_PASSWORD \
-  -e POSTGRES_INITDB_ARGS \
+  -e POSTGRES_PASSWORD_FILE=/run/secrets/postgres-password \
+  -e POSTGRES_INITDB_ARGS=--encoding=UTF8 \
+  -v ${CREDENTIALS_DIRECTORY}/postgres-password:/run/secrets/postgres-password:ro \
   -v /var/lib/uniplus/postgres/data:/var/lib/postgresql \
   -v /var/lib/uniplus/postgres/init:/docker-entrypoint-initdb.d:ro \
   postgres:18-alpine \


### PR DESCRIPTION
## Resumo

Migra o secret delivery do Postgres systemd de `EnvironmentFile=/etc/uniplus-postgres.env` para `LoadCredential=postgres-password:/etc/credstore/uniplus-postgres-password` — pattern recomendado pelo systemd 250+ (`systemd.exec(5)`) que **não expõe a senha via `/proc/<pid>/environ`** nem propaga para child processes.

Endereça issue #128 (Codex P2 round 4 do PR #127).

## Hardening real

| Antes (legacy) | Depois (este PR) |
|---|---|
| `EnvironmentFile=/etc/uniplus-postgres.env` mode 600 | `LoadCredential=` lendo `/etc/credstore/uniplus-postgres-password` mode 400 (dir 700) |
| `POSTGRES_PASSWORD` no env do systemd → cat `/proc/$(pgrep)/environ` mostra senha | Senha bind-mounted em `${CREDENTIALS_DIRECTORY}/postgres-password` (tmpfs do unit, isolada de `/proc/<pid>/environ`) |
| `docker run -e POSTGRES_PASSWORD` puxa do env do systemd → exposed em child `dockerd` env | `docker run -v ${CREDENTIALS_DIRECTORY}/postgres-password:/run/secrets/postgres-password:ro -e POSTGRES_PASSWORD_FILE=...` — entrypoint `postgres:18-alpine` lê o file via `file_env()` (suporte nativo) |
| Senha duplicada em `/etc/uniplus-postgres.env` (texto plano em path bem conhecido) | Senha em `/etc/credstore/` (mode 400, dir 700, path por convenção systemd) |
| Sem path para TPM2 binding | Opcional: `systemd-creds encrypt --tpm2-pcrs=7+11` + `LoadCredentialEncrypted=` (RUNBOOKS §9.6.1) |

## Mudanças

| Arquivo | Conteúdo |
|---|---|
| `scripts/bootstrap-standalone.sh` | `step_data_setup_postgres`: cria `/etc/credstore/` + escreve credential file via `printf` (sem trailing newline). Detecta `/etc/uniplus-postgres.env` legacy e shreda via `shred -u` (migração one-way idempotente). systemd unit reescrita: remove `EnvironmentFile`, adiciona `LoadCredential=`, ExecStart consome `${CREDENTIALS_DIRECTORY}` (resolvido pelo systemd antes do exec) via bind-mount + `POSTGRES_PASSWORD_FILE`. |
| `docs/RUNBOOKS.md §9.1` | Atualiza item 4 (credential file) e item 5 (LoadCredential na unit). Idempotência atualizada. |
| `docs/RUNBOOKS.md §9.6` (nova) | Rotação Day-2: `ALTER USER` → reescrever credential file → restart. Sequência rígida (cluster antes do file) com warnings sobre estado intermediário. |
| `docs/RUNBOOKS.md §9.6.1` (nova) | TPM2 binding opcional via `systemd-creds encrypt`. Pré-flight (`has-tpm2`), encrypt+overwrite, troca para `LoadCredentialEncrypted=`. ⚠️ destrói portabilidade — manter custódia paralela. |

## Como testou

- ✅ `bash -n scripts/bootstrap-standalone.sh` — syntax OK
- ✅ `make markdown-lint` — 63 files, 0 errors
- ✅ Render do unit inspecionado: `${CREDENTIALS_DIRECTORY}` é env do systemd (resolvido antes do exec, NÃO shell expansion)
- ⏳ ShellCheck local indisponível na máquina; CI cobre via `ludeeus/action-shellcheck`

## Aplicação em cluster vivo (manual, pós-merge)

A mudança no script garante que **futuros bootstraps** (re-runs em standalone, novos clusters) usem LoadCredential. Para o standalone atual em produção, a migração é Day-2 — janela de manutenção planejada (~30s downtime do Postgres → cascade Keycloak reconnect).

Sequência (em data-host via SSH):

1. `sudo mkdir -p /etc/credstore && sudo chmod 700 /etc/credstore`
2. `sudo grep '^super_pw=' /var/lib/uniplus/postgres/.bootstrap-creds | cut -d= -f2 | sudo tee /etc/credstore/uniplus-postgres-password >/dev/null`  
   ⚠️ trim trailing newline — usar `printf '%s' "$pw"` se vier de var
3. `sudo chmod 400 /etc/credstore/uniplus-postgres-password`
4. Atualizar `/etc/systemd/system/uniplus-postgres.service` conforme conteúdo do script (removendo `EnvironmentFile=`, adicionando `LoadCredential=`, etc.)
5. `sudo systemctl daemon-reload && sudo systemctl restart uniplus-postgres`
6. `sudo docker exec uniplus-postgres pg_isready -U postgres` — esperado `accepting connections`
7. `sudo shred -u /etc/uniplus-postgres.env`
8. Confirmar Keycloak reconectou: `kubectl logs -n uniplus deploy/keycloak-replica-uniplus-standalone --tail 20 | grep -iE "(error|exception|database)" || echo "clean"`

Vou executar essa sequência no data-host após merge desse PR (acesso SSH disponível).

## Riscos e rollback

- **R1 (postgres recusa POSTGRES_PASSWORD_FILE com newline):** mitigado por `printf '%s'` no script (vs `echo` ou heredoc que adicionam `\n`). Rollback: `mv /etc/uniplus-postgres.env /etc/credstore/uniplus-postgres-password` + reverter unit + restart.
- **R2 (Keycloak não reconecta após restart):** `Restart=always` no Pod do KC + `Wolverine reconnect` cobrem; pior caso: `kubectl rollout restart deploy/keycloak-replica-uniplus-standalone`.
- **R3 (TPM2 sem PCR config — encrypt corrompido):** este PR NÃO ativa TPM2 automaticamente; encrypt é opcional via §9.6.1 com pré-flight `has-tpm2`. Sem risco.
- **Rollback geral:** `git revert` — script idempotente cobre re-criação do legacy `EnvironmentFile=` (a migração `shred -u` perdeu o env file mas re-execução do script com a unit antiga restoraria via `.bootstrap-creds`).

## Critérios de aceite (#128)

- [x] `uniplus-postgres.service` migra de `EnvironmentFile=` → `LoadCredential=`
- [x] Bootstrap escreve a senha em `/etc/credstore/uniplus-postgres-password` (mode 400 root:root)
- [x] `ExecStart` lê via `${CREDENTIALS_DIRECTORY}/postgres-password` (bind-mount + `POSTGRES_PASSWORD_FILE`)
- [x] Migração testada em re-bootstrap: legacy env file shredded; cluster existente continua funcionando após restart com nova credential delivery (validação operacional via §9.6 pós-merge)
- [x] Runbook §9 atualizado com rotação (§9.6) + TPM2 enrollment (§9.6.1)

Closes #128.
Refs #127, #181, ADR-008.