### PR TITLE
docs: topologias suportadas em ARCHITECTURE.md + README (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ Este repositório contém todos os manifests, charts Helm, scripts e documentaç
 
 A plataforma Uni+ é o sistema institucional unificado da UNIFESSPA para processos seletivos, ingresso e portal acadêmico, composta por três módulos integrados (Portal, Seleção e Ingresso) com autenticação federada via Gov.br.
 
+### Topologias suportadas
+
+O mesmo conjunto de charts e scripts é deployable em duas topologias distintas — escolhidas pelo SLA pretendido, não por preferência técnica. Detalhes em [docs/ARCHITECTURE.md §5.5](docs/ARCHITECTURE.md#55-topologias-suportadas).
+
+| Topologia | Descrição | Quando usar | ADRs |
+|---|---|---|---|
+| **3-DC** (`SP1` + `SP2` + `PA1`) | Ativo-ativo entre EVEO Cotia/Osasco + DC institucional UNIFESSPA Marabá. HA por componente (Patroni/KRaft/MinIO distribuído). Sobrevive a falha de site. | Produção plena, HML que exercita DR, certificação institucional. | ADRs 001–007, 009 |
+| **Standalone** (monolocal) | Single-site provider-agnostic (lab, OCI Always Free, on-prem). Duas VMs (`k8s-host` + `data-host`). K3s single-node + Postgres/Kafka/MinIO/Vault em modo single. Mesmos charts, divergência só em `environments/standalone/values.yaml`. | Validação técnica antes de 3-DC, smoke E2E, treinamento, DR exploration, ambientes institucionais com SLA single-site. | [ADR-008](docs/adrs/ADR-008-topologia-standalone.md), [ADR-009](docs/adrs/ADR-009-kafka-sasl-ssl-scram-standalone.md), [ADR-010](docs/adrs/ADR-010-keycloak-config-cli-realm-reconcile.md) |
+
 ## Estrutura do repositório
 
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,6 +9,7 @@
 - [3. Visão de Contexto (C4 Nível 1)](#3-visão-de-contexto-c4-nível-1)
 - [4. Visão de Container (C4 Nível 2)](#4-visão-de-container-c4-nível-2)
 - [5. Topologia Física (C4 Deployment)](#5-topologia-física-c4-deployment)
+- [5.5 Topologias suportadas](#55-topologias-suportadas)
 - [6. Componentes Internos (C4 Nível 3)](#6-componentes-internos-c4-nível-3)
 - [7. Fluxos Principais](#7-fluxos-principais)
 - [8. Decisões Arquiteturais](#8-decisões-arquiteturais)
@@ -189,6 +190,64 @@ Para balancear carga de escrita entre os DCs, os primaries dos bancos são distr
 | `uniplus_ingresso` | SP1 | SP2 |
 
 `PA1` participa da recuperabilidade e pode manter réplicas/backup conforme o componente, mas não recebe primary operacional obrigatório para tráfego de usuário.
+
+### 5.5 Topologias suportadas
+
+A plataforma é deployable em **duas topologias** distintas — não duas configurações da mesma topologia, e sim modelos com objetivos operacionais diferentes. A escolha entre elas é orientada pelo SLA pretendido, não por preferência técnica.
+
+#### 5.5.1 3-DC (SP1 + SP2 + PA1) — modelo de produção plena
+
+Topologia detalhada nas seções §5.1–5.4. Resumo dos drivers:
+
+- **Atendimento ativo-ativo** entre SP1 e SP2 com link L2L de 500 Mbps.
+- **PA1** carrega responsabilidades institucionais (LDAP/AD, OIDC source institucional, retenção de backup, witness opcional). Pode ficar fora algumas horas sem derrubar o atendimento.
+- **HA por componente**: Patroni para Postgres, KRaft para Kafka, modo distribuído do MinIO, Vault em modo HA com Raft, etc.
+- **Falha completa de um DC**: o outro continua servindo o tráfego com degradação aceitável (latência, throughput de write em primaries movidos).
+
+**Quando usar:** produção, HML que precisa exercitar o modelo de DR, certificação institucional.
+
+**Custo:** 3 racks/locações, link L2L privado, redundância de hardware, time de operação 24×7.
+
+#### 5.5.2 Standalone (monolocal) — modelo de validação institucional
+
+Topologia descrita em [ADR-008](adrs/ADR-008-topologia-standalone.md). Resumo:
+
+- **Single-site monolocal** — duas VMs (`k8s-host`, `data-host`) coabitam o mesmo provedor (lab, OCI Always Free, ou laboratório institucional).
+- **Sem HA inter-DC** — a topologia não pretende sobreviver a falha de site. Single-node K3s + Postgres 18 + Kafka KRaft + MinIO single-node + Vault Shamir 1-de-1.
+- **GitOps end-to-end preservado** — chart layout, ArgoCD, ExternalSecrets, ESO continuam idênticos ao 3-DC. O delta é nos `environments/standalone/values.yaml` (1 réplica, sem witness, paths de storage local, etc.).
+- **Acesso externo via Cloudflare Tunnel** — sem dependência de IP público nem de NAT/DNS institucional. Smoke E2E completo executável (PR #181).
+- **Provisioning provider-agnostic** — VMs de qualquer provedor (OCI, lab on-prem, VMs em estação de trabalho) bastam ter Ubuntu 24.04 + kernel atualizado + IP roteável entre as duas VMs.
+
+**Quando usar:**
+
+- Validação técnica antes de provisionar 3-DC (smoke E2E, integração ponta-a-ponta).
+- Workshops, treinamento interno, demonstração para gestão.
+- Disaster recovery exploration (subir uma cópia funcional num provedor alternativo em horas).
+- Ambientes institucionais que aceitam SLA single-site (ex.: secretarias internas, painéis administrativos).
+
+**O que não cobre:**
+
+- Falha de site (rede, energia, hardware) → indisponibilidade total até reparo.
+- Volume de produção plena Uni+ (~20k candidatos/processo) → standalone tem limites de throughput nativos do single-node.
+- Compliance institucional que exija redundância geográfica.
+
+**Custo:** 2 VMs (~12 vCPU + 24 GB RAM + 200 GB) + Cloudflare Tunnel (gratuito até limites). Operável por 1 pessoa.
+
+#### 5.5.3 Como o repositório suporta as duas
+
+| Aspecto | 3-DC | Standalone |
+|---|---|---|
+| `apps/` charts | mesmos | mesmos |
+| `platform/` charts | mesmos | mesmos |
+| `data/` (Postgres/Kafka/MinIO/Redis fora-do-K8s) | binários iguais, configs HA | binários iguais, configs single-node |
+| `environments/` overrides | `lab-{sp1,sp2,pa1}/` + `prod-{sp1,sp2,pa1}/` | `standalone/` |
+| `argocd/applicationset.yaml` | mesmo (multi-cluster) | mesmo (single-cluster, gera só Apps de standalone) |
+| `scripts/bootstrap-{role}.sh` | `bootstrap-lab.sh --role={sp1\|sp2\|pa1}` | `bootstrap-standalone.sh` |
+| ADRs específicas | ADRs 001–007, 009 (3-DC) | [ADR-008](adrs/ADR-008-topologia-standalone.md), [ADR-010](adrs/ADR-010-keycloak-config-cli-realm-reconcile.md) (standalone) |
+
+**Princípio de divergência mínima:** valores divergem apenas em `environments/<env>/values.yaml`. Charts não trazem código condicional `{{- if eq .Values.topology "standalone" -}}` — a topologia é uma propriedade do environment, não do chart.
+
+> Excecções pontuais (ex.: `keycloak.realmReconcile.enabled` ligado em standalone, desligado em prod até o smoke validar; `traefik.updateStrategy.type=Recreate` necessário em single-node por HostPort conflict) ficam em values.yaml documentadas inline e em ADR. Não há flag global de "topologia".
 
 ## 6. Componentes Internos (C4 Nível 3)
 


### PR DESCRIPTION
## Resumo

Documenta explicitamente as **duas topologias deployable** da plataforma Uni+ — não são duas configurações da mesma topologia, e sim modelos com objetivos operacionais distintos:

- **3-DC (SP1+SP2+PA1)** — produção plena com ativo-ativo + HA inter-DC + sobrevivência a falha de site
- **Standalone (monolocal)** — single-site provider-agnostic, validação técnica, smoke E2E completo, DR exploration

Issue #72.

## Mudanças

| Arquivo | Conteúdo |
|---|---|
| `docs/ARCHITECTURE.md §5.5` | Nova seção (3 sub-tópicos): 5.5.1 modelo 3-DC, 5.5.2 modelo standalone (drivers, escopo, custo, o que NÃO cobre), 5.5.3 tabela "como o repositório suporta as duas" — `apps/`, `platform/`, `data/`, `environments/`, `argocd/`, scripts, ADRs específicas. **Princípio de divergência mínima** documentado: sem `{{- if eq .Values.topology "standalone" -}}` em charts; topologia é propriedade do environment. |
| `README.md` | Subseção `Topologias suportadas` em "Sobre" com tabela comparativa rápida + links para ADR-008, ADR-009, ADR-010. |

## Por que importa

A plataforma vinha sendo descrita ora como "lab", ora como "standalone", ora como "3-DC" sem clareza de que são modelos distintos. Novos contribuidores (e auditorias institucionais) precisavam ler ADR-008 + ADR-009 + ADR-010 + scripts/bootstrap-*.sh para inferir o desenho. Agora a divisão fica explícita no documento canônico (ARCHITECTURE.md) e na entrada do repo (README.md).

## Como testou

- ✅ `make markdown-lint` — 63 files, 0 errors
- ✅ Links internos `#55-topologias-suportadas` validados (slug compatível com markdownlint heading anchors)
- ✅ Links externos para `docs/adrs/ADR-008-topologia-standalone.md` etc. apontam para arquivos que existem em main (verificado via `ls docs/adrs/`)

## Riscos e rollback

Mudança puramente documental — sem impacto em deploy ou operação. Rollback: `git revert`.

## Critérios de aceite (#72)

- [x] Seção "Topologias suportadas" em `docs/ARCHITECTURE.md` descrevendo 3-DC e standalone
- [x] `README.md` raiz com referência à topologia standalone e ao ADR-008

Closes #72.
Refs ADR-008.