### PR TITLE
fix(keycloak): persiste audience-uniplus mapper no client uniplus-portal (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Não lançado]
 
+### Corrigido
+
+- Keycloak client `uniplus-portal` (public + PKCE, frontend Angular) recebe `protocolMapper` `audience-uniplus` (`oidc-audience-mapper` com `included.custom.audience=uniplus`, projetado apenas no access_token). Sem o mapper o token vinha com `aud: ["account"]` e as APIs Uni+ — que validam `Auth__Audience=uniplus` — respondiam 401 a qualquer chamada do frontend. Mitigação manual via `kcadm.sh` foi aplicada durante o smoke #166; agora o mapper está persistido em `apps/keycloak-replica/files/uniplus-realm.json` e o Job `realm-reconcile` (ADR-010, post-install/post-upgrade) o reaplica em re-deploy. Issue #186.
+
 ### Adicionado
 
 - Keycloak realm `uniplus` ganha 3 confidential clients para fluxo M2M `client_credentials` — `uniplus-api-portal`, `uniplus-api-selecao`, `uniplus-api-ingresso`. Cada um com `serviceAccountsEnabled=true`, audience mapper para `apicurio-registry` e hardcoded-claim mapper que projeta `groups: ["/users/uniplus"]` (Apicurio mapeia → role `sr-developer`). Destrava `uniplus-api#358` (integração Apicurio Schema Registry). RUNBOOKS §15.6 documenta procedure de recuperação do `client_secret` pós-import. Issue #163.

--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -56,6 +56,19 @@
         "address",
         "phone",
         "offline_access"
+      ],
+      "protocolMappers": [
+        {
+          "name": "audience-uniplus",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "uniplus",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
       ]
     },
     {


### PR DESCRIPTION
## Resumo

Corrige bug descoberto no smoke E2E do cluster standalone (#166): o client `uniplus-portal` (public + PKCE, frontend Angular) emitia tokens com `aud: ["account"]` apenas — porém as 3 APIs Uni+ validam `Auth__Audience=uniplus`, então qualquer chamada do frontend retornava 401.

Persiste no source-of-truth (`apps/keycloak-replica/files/uniplus-realm.json`) o `protocolMapper` `audience-uniplus` que estava sendo aplicado em runtime via `kcadm.sh` durante o smoke.

## O que mudou

| Arquivo | Mudança |
|---|---|
| `apps/keycloak-replica/files/uniplus-realm.json` | +13 linhas — bloco `protocolMappers` adicionado ao client `uniplus-portal` |
| `CHANGELOG.md` | Nova subseção `### Corrigido` em `[Não lançado]` |

## Detalhes do mapper

| Campo | Valor | Por quê |
|---|---|---|
| `name` | `audience-uniplus` | Convenção `audience-<target>` herdada dos M2M (PR #169) |
| `protocolMapper` | `oidc-audience-mapper` | Built-in do Keycloak para projetar `aud` |
| `included.custom.audience` | `uniplus` | Forma correta para audiences que **não** são `clientId` do realm — `uniplus` é apenas o valor configurado em `Auth__Audience` das APIs |
| `id.token.claim` | `false` | id_token segue enxuto; só access_token recebe o aud |
| `access.token.claim` | `true` | Validação JWT da API roda contra access_token |
| `consentRequired` | `false` | Audience não expõe PII; alinhado com pattern dos M2M |

## Por que mudou

- **Causa raiz**: o realm.json declarava o client `uniplus-portal` sem nenhum `protocolMappers`. Os scopes default (`profile`, `roles`, `email`) não emitem audience custom — só `account` aparece como aud genérica.
- **Consequência**: nenhum frontend Angular conseguia chamar APIs (401 imediato).
- **Por que não pegou antes**: smokes anteriores usavam clients M2M (`uniplus-api-*` confidential) que **já tinham** o audience mapper para `apicurio-registry` — o gap só aparece com client público + APIs validando aud.

## Reconciliação em cluster vivo

O Job `realm-reconcile` (ADR-010, PR #183) com hook `post-install,post-upgrade` consome o **mesmo** ConfigMap do realm.json e aplica via `keycloak-config-cli` (idempotente). Portanto:

- **ArgoCD-managed**: reconciliação automática na próxima sync.
- **Operação manual**: `helm upgrade` no chart `keycloak-replica` dispara o Job.
- **Não é instantâneo** sobre o cluster vivo — exige re-deploy do chart para o Job rodar.

## Validação local

```bash
helm template kc-test apps/keycloak-replica/ -f environments/standalone/values.yaml > /tmp/render.yaml
# Render OK (905 linhas)
python3 -c "import yaml,json; d=list(yaml.safe_load_all(open('/tmp/render.yaml')))
cm=next(x for x in d if x and x.get('kind')=='ConfigMap' and 'realm' in x['metadata']['name'])
realm=json.loads(cm['data'][next(k for k in cm['data'] if k.endswith('realm.json'))])
portal=next(c for c in realm['clients'] if c.get('publicClient'))
print(portal['protocolMappers'])"
# → [{'name': 'audience-uniplus', 'protocolMapper': 'oidc-audience-mapper', 'config': {...}}]

helm lint apps/keycloak-replica/ -f environments/standalone/values.yaml   # ✅ 0 fails
yamllint -c .yamllint.yaml apps/keycloak-replica/                         # ✅ exit 0
npx markdownlint-cli2 CHANGELOG.md                                         # ✅ 0 errors
```

## Critérios de aceite (issue #186)

- [x] Mapper persistido em `apps/keycloak-replica/files/uniplus-realm.json` na seção `protocolMappers` do client `uniplus-portal`
- [x] Job `realm-reconcile` (#177 / ADR-010) aplica o mapper automaticamente em re-deploy
- [ ] Smoke #166 re-executável sem precisar do workaround manual — **validação operacional pós-merge**, dispara após `helm upgrade` ou sync ArgoCD

## Riscos & rollback

- **Risco**: nenhum em runtime — `keycloak-config-cli` é idempotente; aplicar/remover o mapper não afeta sessões existentes (claims só aparecem em **novos** tokens emitidos).
- **Rollback**: reverter este PR + `helm upgrade` (Job re-aplica realm sem o mapper). Tokens antigos em circulação continuam válidos até expirarem (TTL padrão 5min).

Closes #186
Refs #166, #169, #177