### PR TITLE
chore(keycloak-replica): adotar imagem composta uniplus-keycloak:26.6.1-0 + bump config-cli (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Não lançado]
 
+### Alterado
+
+- Chart `keycloak-replica` passa a consumir a imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0` (Keycloak 26.6.1 + JAR `cpf-matcher`) em vez do upstream vanilla `quay.io/keycloak/keycloak:26.6.1`. Standalone passa a validar exatamente o binário que vai pra HML/PROD (production parity). `appVersion` do Chart sincronizada com a tag composta. Issue #192, depende de `unifesspa-edu-br/uniplus-keycloak-providers#13` (Release `v26.6.1-0` em 2026-05-10).
+
 ### Corrigido
 
+- Tag de `quay.io/adorsys/keycloak-config-cli` em `apps/keycloak-replica/values.yaml` corrigida de `6.4.0-26.0.6` (inexistente — typo histórico do PR #183) para `6.5.0-26.5.4` (mais recente publicada; mesma major do KC vivo, admin API estável). Sem essa correção o Job `realm-reconcile` (ADR-010) ficava em `ImagePullBackOff` indefinidamente, bloqueando reconciliação automática do realm em re-deploy. Issue #192.
 - Keycloak client `uniplus-portal` (public + PKCE, frontend Angular) recebe `protocolMapper` `audience-uniplus` (`oidc-audience-mapper` com `included.custom.audience=uniplus`, projetado apenas no access_token). Sem o mapper o token vinha com `aud: ["account"]` e as APIs Uni+ — que validam `Auth__Audience=uniplus` — respondiam 401 a qualquer chamada do frontend. Mitigação manual via `kcadm.sh` foi aplicada durante o smoke #166; agora o mapper está persistido em `apps/keycloak-replica/files/uniplus-realm.json` e o Job `realm-reconcile` (ADR-010, post-install/post-upgrade) o reaplica em re-deploy. Issue #186.
 
 ### Adicionado

--- a/apps/keycloak-replica/Chart.yaml
+++ b/apps/keycloak-replica/Chart.yaml
@@ -6,10 +6,12 @@ description: |
 type: application
 
 # Versão do chart wrapper Uni+. Bump em qualquer mudança de template/values.
-version: 0.2.0
+version: 0.3.0
 
-# Versão do Keycloak upstream empacotada (sincronizar com image.tag).
-appVersion: "26.6.1"
+# Versão da imagem composta `uniplus-keycloak` empacotada (sincronizar com
+# image.tag). Scheme :<KC-VERSION>-<PATCH-PROVIDERS> — ver
+# unifesspa-edu-br/uniplus-keycloak-providers.
+appVersion: "26.6.1-0"
 
 home: https://github.com/unifesspa-edu-br/uniplus-infra
 sources:

--- a/apps/keycloak-replica/README.md
+++ b/apps/keycloak-replica/README.md
@@ -59,7 +59,7 @@ O chart codifica estas opções de configuração runtime do Keycloak 26.x:
 
 ## Decisões de design
 
-- **Imagem stock + `start --import-realm`** (sem rebuild custom): a imagem `quay.io/keycloak/keycloak:26.6.1` traz health/metrics built-in. `start` (sem `--optimized`) deixa o Keycloak fazer auto-build na primeira inicialização — `startupProbe.failureThreshold: 60` (×10s = 10min) absorve a janela.
+- **Imagem composta `uniplus-keycloak` + `start --import-realm`** (sem rebuild custom): a imagem `ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0` é Keycloak 26.6.1 upstream + JAR `cpf-matcher` (SPI institucional), com health/metrics built-in. `start` (sem `--optimized`) deixa o Keycloak fazer auto-build na primeira inicialização — `startupProbe.failureThreshold: 60` (×10s = 10min) absorve a janela. Standalone usa a mesma imagem que vai pra HML/PROD para garantir production parity.
 - **Realm import idempotente**: `--import-realm` em 26.x **não re-importa** se o realm já existir, preservando mudanças via Admin UI. Para forçar reimport: `kc.sh import` explícito (não automático).
 - **`uniplus-portal` é public client (SPA + PKCE)**: realm JSON declara `"publicClient": true` sem `client_secret`. Browsers não podem custodiar segredo; PKCE substitui o secret em fluxos de Authorization Code (`code_verifier` gerado pelo SPA garante a posse do code). Para futuros clients confidenciais (ex.: backend BFF, Vault UI integration #34), criar entradas separadas no realm com seus próprios secrets via Vault.
 - **Sem PV**: estado durável vive todo no Postgres. `/tmp` em emptyDir.

--- a/apps/keycloak-replica/values.yaml
+++ b/apps/keycloak-replica/values.yaml
@@ -20,12 +20,15 @@ keycloak:
   enabled: false
 
   image:
-    registry: quay.io
-    repository: keycloak/keycloak
-    # Versão upstream estável validada para 26.x (mantém alinhamento com
-    # appVersion do Chart.yaml). Bumps de patch (26.6.x) são seguros;
-    # major/minor exige checagem de migration guide.
-    tag: "26.6.1"
+    registry: ghcr.io
+    repository: unifesspa-edu-br/uniplus-keycloak
+    # Imagem composta Uni+ = Keycloak upstream + JAR cpf-matcher (SPI providers
+    # institucionais). Tag scheme :<KC-VERSION>-<PATCH-PROVIDERS> publicado pelo
+    # workflow release.yml de unifesspa-edu-br/uniplus-keycloak-providers.
+    # Standalone usa a MESMA imagem que vai pra HML/PROD para garantir que o
+    # smoke E2E valida exatamente o binário de produção (production parity).
+    # Sincronizar com appVersion do Chart.yaml.
+    tag: "26.6.1-0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []
@@ -123,8 +126,12 @@ keycloak:
       repository: adorsys/keycloak-config-cli
       # Tag matching Keycloak 26.x — major.minor obrigatório (versões
       # diferentes podem falhar em migrations de schema). Versões em
-      # https://hub.docker.com/r/adorsys/keycloak-config-cli/tags
-      tag: "6.4.0-26.0.6"
+      # https://quay.io/repository/adorsys/keycloak-config-cli?tab=tags
+      # 6.5.0-26.5.4 é a tag mais recente disponível; KC 26.6.x ainda sem
+      # tag pareada upstream. Mesma major do KC vivo (26.6.1) → admin API
+      # estável (`/admin/realms/{realm}/clients/{id}/protocol-mappers/models`
+      # não muda). Quando adorsys publicar `*-26.6.x`, abrir follow-up.
+      tag: "6.5.0-26.5.4"
       pullPolicy: IfNotPresent
     # Tempo máximo de espera por Keycloak ficar disponível antes de
     # tentar reconciliar. Pod do KC pode estar em rolling restart após

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1659,7 +1659,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: kc-import
-          image: quay.io/keycloak/keycloak:26.6.1
+          image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0
           args:
             - import
             - --override=true
@@ -2639,8 +2639,9 @@ kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c '
     --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" >/dev/null
 
   # 1.1 Criar grupos /admins/kafka e /users/uniplus (idempotente — ignora se existem).
-  # NOTA: container quay.io/keycloak/keycloak:26.6.1 é RHEL 9 minimal e NÃO tem
-  # awk/jq/python — usar grep+cut. Pattern para extrair ID por name no CSV.
+  # NOTA: container ghcr.io/.../uniplus-keycloak:26.6.1-0 herda RHEL 9 minimal
+  # do upstream Keycloak e NÃO tem awk/jq/python — usar grep+cut. Pattern para
+  # extrair ID por name no CSV.
   for GP in "admins/kafka" "users/uniplus"; do
     PARENT=${GP%/*}; CHILD=${GP##*/}
     /opt/keycloak/bin/kcadm.sh create groups -r uniplus -s name="$PARENT" 2>/dev/null || true

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -488,7 +488,7 @@ services:
       - pa1-consensus-data:/etcd-data
 
   pa1-oidc-source:
-    image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2
+    image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0
     container_name: uniplus-pa1-oidc-source
     networks: [unifesspa-sim]
     ports:


### PR DESCRIPTION
## Resumo

Standalone (e demais ambientes que ligarem `keycloak.enabled=true`) passa a consumir a imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0` (Keycloak 26.6.1 + JAR `cpf-matcher`) em vez do upstream vanilla `quay.io/keycloak/keycloak:26.6.1`. **Production parity**: smoke E2E valida exatamente o binário que vai pra HML/PROD.

Corrige também a tag inválida do `keycloak-config-cli` no Job `realm-reconcile`: `6.4.0-26.0.6` (inexistente — typo histórico do PR #183) → `6.5.0-26.5.4`. Sem essa correção o Job ficava em `ImagePullBackOff` indefinidamente, bloqueando reconciliação automática do realm em re-deploy (descoberto durante operação de validar #191).

## O que mudou

| Arquivo | Mudança |
|---|---|
| `apps/keycloak-replica/values.yaml` | `keycloak.image`: registry/repo/tag → composta `:26.6.1-0`; `keycloak.realmReconcile.image.tag` → `6.5.0-26.5.4` |
| `apps/keycloak-replica/Chart.yaml` | `version: 0.2.0` → `0.3.0`; `appVersion: "26.6.1"` → `"26.6.1-0"` |
| `apps/keycloak-replica/README.md` | Decisão de imagem: stock vanilla → composta |
| `docs/SETUP.md` | Exemplo `:1.0.2` (obsoleto) → `:26.6.1-0` |
| `docs/RUNBOOKS.md` | 2 ocorrências de `quay.io/keycloak/keycloak:26.6.1` → composta |
| `CHANGELOG.md` | Subseções "Alterado" (origem da imagem) + "Corrigido" (tag config-cli) |

## Por que `6.5.0-26.5.4` para o config-cli (e não tag pareada com 26.6.x)

`adorsys/keycloak-config-cli` ainda não publicou tag `*-26.6.x` (último publicado em 2026-03-12: `6.5.0-26.5.4`). 26.5 → 26.6 é mesma major do Keycloak; a admin API que o config-cli usa (`/admin/realms/{realm}/clients/{id}/protocol-mappers/models`) é estável dentro da major. Funcional para reconciliar mappers em runtime.

Quando adorsys publicar tag `*-26.6.x`, abrir follow-up para bump.

## Validação local

```bash
helm template kc-test apps/keycloak-replica/ -f environments/standalone/values.yaml > /tmp/render.yaml
# render OK 905 linhas, exit 0

python3 -c "
import yaml, json
docs = list(yaml.safe_load_all(open('/tmp/render.yaml')))
dep = next(d for d in docs if d and d.get('kind')=='Deployment')
print('keycloak.image    =', dep['spec']['template']['spec']['containers'][0]['image'])
job = next(d for d in docs if d and d.get('kind')=='Job' and 'realm-reconcile' in d['metadata']['name'])
print('realm-reconcile   =', job['spec']['template']['spec']['containers'][0]['image'])
cm = next(d for d in docs if d and d.get('kind')=='ConfigMap' and 'realm' in d.get('metadata',{}).get('name',''))
realm = json.loads(cm['data'][next(k for k in cm['data'] if k.endswith('realm.json'))])
portal = next(c for c in realm['clients'] if c.get('publicClient'))
print('portal mappers    =', [m['name'] for m in portal.get('protocolMappers',[])])
"
# →
# keycloak.image    = ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0
# realm-reconcile   = quay.io/adorsys/keycloak-config-cli:6.5.0-26.5.4
# portal mappers    = ['audience-uniplus']    ← #186 preservado

helm lint apps/keycloak-replica/ -f environments/standalone/values.yaml   # ✅ 0 fails
yamllint -c .yamllint.yaml apps/keycloak-replica/                         # ✅ exit 0
```

Pacote GHCR confirmado PUBLIC (`imagePullSecrets: []` continua viável):

```bash
gh api orgs/unifesspa-edu-br/packages/container/uniplus-keycloak --jq '{visibility, version_count}'
# → {"visibility":"public","version_count":9}
```

## Codex CLI local review

`codex exec` rodado pré-PR — 0 P1, 3 findings (1 acionável aplicado, 2 não-bloqueantes):

- **P2.1 (aplicado)** — `Chart.yaml version` mantinha 0.2.0 apesar de mudança de template; bumpado para `0.3.0`
- **P2.2 (informativo)** — Confirmar pacote GHCR público com `imagePullSecrets: []` — já confirmado público (vide acima)
- **P3 (não-bloqueante)** — Compatibilidade `6.5.0-26.5.4` ↔ KC 26.6.1 amarrada à smoke pós-upgrade; é exatamente o escopo de #191

## Critério de aceite (issue #192)

- [ ] PR mergeado em `main`
- [ ] ArgoCD sincroniza `keycloak-replica-uniplus-standalone` para o novo commit
- [ ] Pod do Keycloak sobe com `image: ghcr.io/.../uniplus-keycloak:26.6.1-0`
- [ ] Job `realm-reconcile` completa com sucesso (sem `ImagePullBackOff`)
- [ ] `unifesspa-edu-br/uniplus-infra#191` (smoke audience-uniplus) executável

## Riscos & rollback

- **Risco config-cli**: se `6.5.0-26.5.4` falhar contra KC 26.6.1, Job fica em error mas Keycloak segue OK. Mitigação imediata: setar `keycloak.realmReconcile.enabled=false` via override ArgoCD.
- **Risco imagem composta**: se algum SPI quebrar contra runtime 26.6.1, pod entra em CrashLoop. Rollback: revert deste PR + sync ArgoCD.

Closes #192
Refs unifesspa-edu-br/uniplus-keycloak-providers#13, #186, #190, #191