### PR TITLE
feat(tofu): provisionamento OCI standalone — compute + storage (#52 #54 #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 ### Alterado
 
 - Chart `keycloak-replica` passa a consumir a imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0` (Keycloak 26.6.1 + JAR `cpf-matcher`) em vez do upstream vanilla `quay.io/keycloak/keycloak:26.6.1`. Standalone passa a validar exatamente o binário que vai pra HML/PROD (production parity). `appVersion` do Chart sincronizada com a tag composta. Issue #192, depende de `unifesspa-edu-br/uniplus-keycloak-providers#13` (Release `v26.6.1-0` em 2026-05-10).
+- `provisioning/oci/standalone/` passa a codificar em OpenTofu as 2 VMs (`oci_core_instance.k8s_host` + `oci_core_instance.data_host`) e os 4 block volumes do data-host (`oci_core_volume.data` for_each + `oci_core_volume_attachment.data`). Recursos vivos importados via `tofu import` (10 imports); `tofu plan` retorna `No changes` pós-import (estado declarativo bate com OCI). Permite `tofu apply` para mudar perfil de capacidade ou shrink destrutivo dos blocks via diff de tfvars. Recursos de rede (VCN/subnets/IGW/NSGs) ainda referenciados por OCID em variáveis — migração na Story #53. Stories #52 + #54 + #55 da Feature #43.
 
 ### Corrigido
 

--- a/provisioning/oci/standalone/.gitignore
+++ b/provisioning/oci/standalone/.gitignore
@@ -1,0 +1,15 @@
+# OpenTofu / Terraform
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfvars
+!terraform.tfvars.example
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc

--- a/provisioning/oci/standalone/README.md
+++ b/provisioning/oci/standalone/README.md
@@ -1,0 +1,138 @@
+# OpenTofu — standalone OCI
+
+Provisionamento OpenTofu do ambiente standalone Uni+ na OCI (sa-saopaulo-1).
+Cobertura mínima viável (Stories #52, #54 e #55 da Feature #43): as 2 VMs
+E5.Flex e os 4 block volumes do data-host. Recursos de rede (VCN, subnets,
+IGW, NSGs) ficam **fora deste recorte** — provisionados manualmente,
+importados via referência por OCID. A migração da rede é a Story #53
+(`network.tf`).
+
+## Estado atual no OCI
+
+Aplicado em 2026-05-04 (manual via console) + redimensionado em 2026-05-10
+para o perfil `poc` via `scripts/resize-standalone-oci.sh`:
+
+| Recurso | Detalhe |
+|---|---|
+| `uniplus-standalone-k8s-host` | E5.Flex 2 OCPU / 12 GB; subnet pública 10.0.1.0/24; public IP `164.152.53.29` |
+| `uniplus-standalone-data-host` | E5.Flex 1 OCPU / 4 GB; subnet privada 10.0.2.0/24; sem IP público |
+| `uniplus-standalone-postgres` | block volume 200 GB VPU 0, attached paravirtualized |
+| `uniplus-standalone-kafka` | block volume 100 GB VPU 0 |
+| `uniplus-standalone-minio` | block volume 200 GB VPU 0 |
+| `uniplus-standalone-vault` | block volume 50 GB VPU 0 |
+
+## Pré-requisitos
+
+- OpenTofu ≥ 1.6 (testado com 1.11.6)
+- `oci` CLI configurado (`~/.oci/config`) com permissão de `manage` para
+  `instance-family` + `volume-family` no compartment alvo
+- Acesso de leitura/escrita ao backend de state (atualmente local; ver §State)
+
+## Setup inicial
+
+```bash
+cd provisioning/oci/standalone
+
+# 1. Copiar o tfvars de exemplo e preencher OCIDs/SSH key
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars
+
+# 2. Inicializar provider + plugins
+tofu init
+
+# 3. Plan inicial — neste primeiro run, Tofu vai propor CRIAR tudo do zero
+#    porque o state está vazio e os recursos vivos ainda não foram importados.
+tofu plan -out=plan.bin
+```
+
+## Importar recursos vivos (primeira vez)
+
+State começa vazio mas os recursos JÁ EXISTEM no OCI. Importar antes de
+qualquer apply para evitar duplicar (ou pior, sobrescrever) recursos vivos:
+
+```bash
+# Pegar OCIDs atuais
+TENANCY="ocid1.tenancy.oc1..aaaaaaaa..."  # raiz da unifesspa-edu-br
+oci compute instance list --compartment-id "$TENANCY" --all \
+  | jq -r '.data[] | select(."display-name" | startswith("uniplus-standalone")) | "\(."display-name")=\(.id)"'
+oci bv volume list --compartment-id "$TENANCY" --all \
+  | jq -r '.data[] | select(."display-name" | startswith("uniplus-standalone")) | "\(."display-name")=\(.id)"'
+oci compute volume-attachment list --compartment-id "$TENANCY" --all \
+  | jq -r '.data[] | select(."lifecycle-state"=="ATTACHED") | "vol=\(."volume-id") attach=\(.id)"'
+
+# Importar instances
+tofu import oci_core_instance.k8s_host  ocid1.instance.oc1.sa-saopaulo-1.<...>
+tofu import oci_core_instance.data_host ocid1.instance.oc1.sa-saopaulo-1.<...>
+
+# Importar volumes (usando o for_each key)
+tofu import 'oci_core_volume.data["postgres"]' ocid1.volume.oc1.sa-saopaulo-1.<postgres_ocid>
+tofu import 'oci_core_volume.data["kafka"]'    ocid1.volume.oc1.sa-saopaulo-1.<kafka_ocid>
+tofu import 'oci_core_volume.data["minio"]'    ocid1.volume.oc1.sa-saopaulo-1.<minio_ocid>
+tofu import 'oci_core_volume.data["vault"]'    ocid1.volume.oc1.sa-saopaulo-1.<vault_ocid>
+
+# Importar attachments
+tofu import 'oci_core_volume_attachment.data["postgres"]' ocid1.volumeattachment.oc1.sa-saopaulo-1.<postgres_attachment_ocid>
+tofu import 'oci_core_volume_attachment.data["kafka"]'    ocid1.volumeattachment.oc1.sa-saopaulo-1.<kafka_attachment_ocid>
+tofu import 'oci_core_volume_attachment.data["minio"]'    ocid1.volumeattachment.oc1.sa-saopaulo-1.<minio_attachment_ocid>
+tofu import 'oci_core_volume_attachment.data["vault"]'    ocid1.volumeattachment.oc1.sa-saopaulo-1.<vault_attachment_ocid>
+
+# Re-plan — esperado: 0 changes (ou drift menor; ajustar HCL/variáveis até zerar)
+tofu plan
+```
+
+## Operações típicas
+
+```bash
+# Ver estado atual + outputs
+tofu show
+tofu output
+
+# Mudar perfil de capacidade (REBOOTA as VMs ~30-90s; ver scripts/resize-standalone-oci.sh)
+$EDITOR terraform.tfvars   # profile = "hml"
+tofu apply
+
+# Shrink destrutivo dos blocks (delete + recreate; PERDE dados — fazer backup
+# de Vault recovery keys, schemas, etc. antes)
+$EDITOR terraform.tfvars   # volume_sizes_gbs = { postgres=10, kafka=10, minio=10, vault=10 }
+tofu apply
+# Re-bootstrap obrigatório após:
+ssh ubuntu@164.152.53.29 'sudo /home/ubuntu/uniplus-infra/scripts/bootstrap-standalone.sh --role=standalone-k8s'
+ssh ubuntu@10.0.2.87     'sudo /home/ubuntu/uniplus-infra/scripts/bootstrap-standalone.sh --role=standalone-data'
+
+# Recriar do zero (cuidado — destrutivo total)
+tofu destroy
+tofu apply
+```
+
+## State
+
+State **local** por padrão (`terraform.tfstate` no diretório, ignorado pelo
+`.gitignore`). Para uso em equipe, migrar para backend remoto — opção
+sugerida: bucket OCI Object Storage com locking via `lockfile_resource`. Fora
+do escopo desta versão; documentar em ADR-008 quando aplicável.
+
+**Não commitar** `terraform.tfstate*` — contém OCIDs, IPs e potencialmente
+dados sensíveis de configuração. `.gitignore` cuida disso.
+
+## Limitações conhecidas
+
+- **Network não importada**: VCN/subnets/route tables/NSGs/IGW são referenciados
+  por OCID (vars). Migração na Story #53.
+- **DNS + Reserved Public IP**: na Story #56.
+- **OCI Vault KMS** (auto-unseal Vault): na Story #57 (atualmente bloqueada
+  por bug upstream `go-kms-wrapping@v2.0.9`).
+- **IAM Dynamic Group + Policy** (resource principal): na Story #58.
+- **Cloud-init**: VMs sobem com apenas `ssh_authorized_keys`. Re-bootstrap
+  manual via `scripts/bootstrap-standalone.sh` continua necessário em
+  recreate. cloud-init full (k3s + docker + LVM) fica para extensão da Story #54.
+- **Boot volumes**: gerenciados implicitamente pelo `oci_core_instance.source_details`;
+  recriar a VM recria o boot volume (perde estado do `/`).
+
+## Próximos passos
+
+| Story | Conteúdo |
+|---|---|
+| #53 | `network.tf` — VCN, 2 subnets, IGW, NAT GW, route tables, NSGs |
+| #56 | DNS A record + Reserved Public IP do k8s-host |
+| #57 | OCI Vault, Master Encryption Key, Dynamic Group, IAM Policy (auto-unseal) |
+| #58 | Bridge de outputs Tofu → `environments/standalone/values.yaml` |

--- a/provisioning/oci/standalone/compute.tf
+++ b/provisioning/oci/standalone/compute.tf
@@ -1,0 +1,80 @@
+# ==============================================================================
+# k8s-host — VM pública que roda k3s + Helm + ArgoCD + apps Uni+
+# ==============================================================================
+resource "oci_core_instance" "k8s_host" {
+  display_name        = "uniplus-standalone-k8s-host"
+  compartment_id      = var.compartment_ocid
+  availability_domain = var.availability_domain
+  fault_domain        = var.fault_domain
+  shape               = "VM.Standard.E5.Flex"
+
+  shape_config {
+    ocpus         = local.shapes.k8s_host.ocpus
+    memory_in_gbs = local.shapes.k8s_host.memory_in_gbs
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = var.image_ocid
+  }
+
+  create_vnic_details {
+    subnet_id        = var.subnet_public_ocid
+    assign_public_ip = true
+    hostname_label   = "k8s-host"
+  }
+
+  metadata = {
+    ssh_authorized_keys = var.ssh_authorized_keys
+  }
+
+  freeform_tags = local.common_tags
+
+  # bootstrap-standalone.sh provisiona k3s/helm/argocd; cloud-init full vai
+  # numa Story de extensão. Por enquanto, recriar a VM exige rodar o script
+  # manualmente após o apply.
+  lifecycle {
+    ignore_changes = [
+      # source_details muda quando OCI bumpa a imagem Ubuntu LTS — não force
+      # recreate por isso.
+      source_details,
+    ]
+  }
+}
+
+# ==============================================================================
+# data-host — VM privada que roda Postgres + Kafka + Redis + MinIO via systemd
+# ==============================================================================
+resource "oci_core_instance" "data_host" {
+  display_name        = "uniplus-standalone-data-host"
+  compartment_id      = var.compartment_ocid
+  availability_domain = var.availability_domain
+  fault_domain        = var.fault_domain
+  shape               = "VM.Standard.E5.Flex"
+
+  shape_config {
+    ocpus         = local.shapes.data_host.ocpus
+    memory_in_gbs = local.shapes.data_host.memory_in_gbs
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = var.image_ocid
+  }
+
+  create_vnic_details {
+    subnet_id        = var.subnet_private_ocid
+    assign_public_ip = false
+    hostname_label   = "data-host"
+  }
+
+  metadata = {
+    ssh_authorized_keys = var.ssh_authorized_keys
+  }
+
+  freeform_tags = local.common_tags
+
+  lifecycle {
+    ignore_changes = [source_details]
+  }
+}

--- a/provisioning/oci/standalone/locals.tf
+++ b/provisioning/oci/standalone/locals.tf
@@ -1,0 +1,23 @@
+locals {
+  # Mapeamento de perfis para shape config (OCPU + memória) por host.
+  # Sincronizar com scripts/resize-standalone-oci.sh — esse arquivo declara
+  # o estado-alvo, o script é a alternativa imperativa via OCI CLI.
+  shape_profiles = {
+    poc = {
+      k8s_host  = { ocpus = 2, memory_in_gbs = 12 }
+      data_host = { ocpus = 1, memory_in_gbs = 4 }
+    }
+    hml = {
+      k8s_host  = { ocpus = 4, memory_in_gbs = 24 }
+      data_host = { ocpus = 2, memory_in_gbs = 16 }
+    }
+  }
+
+  shapes = local.shape_profiles[var.profile]
+
+  # OCI freeform_tags rejeita '/' em key names; usar underscore.
+  common_tags = {
+    "uniplus_environment" = "standalone"
+    "uniplus_managed_by"  = "opentofu"
+  }
+}

--- a/provisioning/oci/standalone/outputs.tf
+++ b/provisioning/oci/standalone/outputs.tf
@@ -1,0 +1,42 @@
+output "k8s_host_ocid" {
+  description = "OCID da instância k8s-host."
+  value       = oci_core_instance.k8s_host.id
+}
+
+output "k8s_host_public_ip" {
+  description = "IP público do k8s-host (não-Reserved no momento; pode mudar em recreate)."
+  value       = oci_core_instance.k8s_host.public_ip
+}
+
+output "k8s_host_private_ip" {
+  description = "IP privado do k8s-host (subnet pública)."
+  value       = oci_core_instance.k8s_host.private_ip
+}
+
+output "data_host_ocid" {
+  description = "OCID da instância data-host."
+  value       = oci_core_instance.data_host.id
+}
+
+output "data_host_private_ip" {
+  description = "IP privado do data-host (subnet privada; sem público)."
+  value       = oci_core_instance.data_host.private_ip
+}
+
+output "data_volume_ocids" {
+  description = "Mapa de OCIDs dos block volumes do data-host (postgres, kafka, minio, vault)."
+  value       = { for k, v in oci_core_volume.data : k => v.id }
+}
+
+output "applied_profile" {
+  description = "Perfil de capacidade aplicado (poc | hml)."
+  value       = var.profile
+}
+
+output "applied_shapes" {
+  description = "Shape config efetivo das 2 VMs."
+  value = {
+    k8s_host  = local.shapes.k8s_host
+    data_host = local.shapes.data_host
+  }
+}

--- a/provisioning/oci/standalone/storage.tf
+++ b/provisioning/oci/standalone/storage.tf
@@ -1,0 +1,50 @@
+# ==============================================================================
+# Block volumes do data-host
+#
+# 4 volumes anexados via paravirtualized — montagens LVM (`uniplus-vg/<lv>`)
+# feitas pelo `bootstrap-standalone.sh --role=standalone-data`. Reduzir
+# `volume_sizes_gbs` em terraform.tfvars é destrutivo: OCI não permite
+# encolher block volume; Tofu vai delete + recreate, perdendo dados.
+#
+# Para shrink (POC: 200/100/200/50 → 10/10/10/10):
+#   1. Backup de dados críticos (Vault Shamir, KC realm — embora realm.json
+#      esteja em git)
+#   2. Editar terraform.tfvars → volume_sizes_gbs = { postgres=10, kafka=10,
+#      minio=10, vault=10 }
+#   3. tofu apply — confirma 4 destroy + 4 create
+#   4. Re-bootstrap via bootstrap-standalone.sh (LVM nova; vault re-init;
+#      kc realm re-import; demais apps reconciliados pelo ArgoCD)
+# ==============================================================================
+locals {
+  data_volumes = {
+    postgres = { size_gbs = var.volume_sizes_gbs.postgres }
+    kafka    = { size_gbs = var.volume_sizes_gbs.kafka }
+    minio    = { size_gbs = var.volume_sizes_gbs.minio }
+    vault    = { size_gbs = var.volume_sizes_gbs.vault }
+  }
+}
+
+resource "oci_core_volume" "data" {
+  for_each = local.data_volumes
+
+  display_name        = "uniplus-standalone-${each.key}"
+  compartment_id      = var.compartment_ocid
+  availability_domain = var.availability_domain
+  size_in_gbs         = each.value.size_gbs
+  vpus_per_gb         = var.volume_vpus_per_gb
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_core_volume_attachment" "data" {
+  for_each = local.data_volumes
+
+  attachment_type = "paravirtualized"
+  instance_id     = oci_core_instance.data_host.id
+  volume_id       = oci_core_volume.data[each.key].id
+  # `att-<vol>` é o display_name do recurso vivo (provisionado manualmente em
+  # 2026-05-04). OCI provider força replacement ao mudar display_name; trocar
+  # para `uniplus-standalone-...-attachment` faria detach/reattach (perde
+  # mounts ativos no data-host).
+  display_name = "att-${each.key}"
+}

--- a/provisioning/oci/standalone/terraform.tfvars.example
+++ b/provisioning/oci/standalone/terraform.tfvars.example
@@ -1,0 +1,44 @@
+# Copiar para terraform.tfvars (ignorado pelo .gitignore) e ajustar.
+
+# Compartment raiz da tenancy unifesspa-edu-br (no standalone, recursos vivem
+# direto no compartment raiz; quando isolar em compartment próprio, ajustar
+# aqui e usar `oci iam compartment list` para descobrir o OCID novo).
+compartment_ocid = "ocid1.tenancy.oc1..REPLACE_WITH_TENANCY_OCID"
+
+region              = "sa-saopaulo-1"
+availability_domain = "mixQ:SA-SAOPAULO-1-AD-1"
+fault_domain        = "FAULT-DOMAIN-1"
+
+# Recursos de rede pré-existentes (provisionados manualmente; serão migrados
+# para Tofu na Story #53 / network.tf).
+vcn_ocid            = "ocid1.vcn.oc1.sa-saopaulo-1.REPLACE_WITH_VCN_OCID"
+subnet_public_ocid  = "ocid1.subnet.oc1.sa-saopaulo-1.REPLACE_WITH_PUBLIC_SUBNET_OCID"
+subnet_private_ocid = "ocid1.subnet.oc1.sa-saopaulo-1.REPLACE_WITH_PRIVATE_SUBNET_OCID"
+
+# Imagem Ubuntu 24.04 LTS em sa-saopaulo-1.
+# Atualizar quando OCI publicar nova versão LTS via:
+#   oci compute image list --compartment-id <tenancy> --operating-system "Canonical Ubuntu" --operating-system-version 24.04 --shape VM.Standard.E5.Flex --sort-by TIMECREATED
+image_ocid = "ocid1.image.oc1.sa-saopaulo-1.REPLACE_WITH_IMAGE_OCID"
+
+# Chave SSH pública (uma por linha) que será injetada via metadata.
+# Ubuntu cria ~/.ssh/authorized_keys automaticamente no usuário `ubuntu`.
+ssh_authorized_keys = <<-EOT
+  ssh-ed25519 AAAA... operador@host
+EOT
+
+# Perfil de capacidade. "poc" para validação (~$72/mês compute), "hml" para
+# load real (~$157/mês). Mudar e aplicar `tofu apply` REBOOTA as VMs.
+profile = "poc"
+
+# Tamanho atual dos 4 block volumes do data-host. Defaults preservam o vivo
+# (200/100/200/50 GB). Para shrink destrutivo a 10 GB cada: ajustar aqui e
+# fazer apply (delete + recreate; perde dados — ver storage.tf).
+volume_sizes_gbs = {
+  postgres = 200
+  kafka    = 100
+  minio    = 200
+  vault    = 50
+}
+
+# 0 = Lower Cost (sem IOPS dedicado; suficiente para POC). 10 = Balanced.
+volume_vpus_per_gb = 0

--- a/provisioning/oci/standalone/variables.tf
+++ b/provisioning/oci/standalone/variables.tf
@@ -1,0 +1,80 @@
+variable "compartment_ocid" {
+  description = "OCID do compartment onde os recursos vivem (no standalone, igual ao tenancy_ocid raiz)."
+  type        = string
+}
+
+variable "region" {
+  description = "Região OCI alvo (mesma do bootstrap inicial; mover de região exige recriação)."
+  type        = string
+  default     = "sa-saopaulo-1"
+}
+
+variable "availability_domain" {
+  description = "Availability Domain das VMs e block volumes do standalone (single-AD por design)."
+  type        = string
+  default     = "mixQ:SA-SAOPAULO-1-AD-1"
+}
+
+variable "fault_domain" {
+  description = "Fault Domain das VMs."
+  type        = string
+  default     = "FAULT-DOMAIN-1"
+}
+
+variable "vcn_ocid" {
+  description = "OCID da VCN existente (provisionada manualmente; será migrada para Tofu na Story #53/network.tf)."
+  type        = string
+}
+
+variable "subnet_public_ocid" {
+  description = "OCID da subnet pública (k8s-host); 10.0.1.0/24 no standalone atual."
+  type        = string
+}
+
+variable "subnet_private_ocid" {
+  description = "OCID da subnet privada (data-host); 10.0.2.0/24 no standalone atual."
+  type        = string
+}
+
+variable "image_ocid" {
+  description = "OCID da imagem base (Ubuntu 24.04 LTS) — sa-saopaulo-1: ocid1.image.oc1.sa-saopaulo-1.aaaaaaaakoj2pbsggofw6sejgzfbyhv7ityl2cwomcslu47t3ncmmkwsp6ca."
+  type        = string
+}
+
+variable "ssh_authorized_keys" {
+  description = "Chaves SSH (uma por linha) injetadas via metadata em ambas instâncias."
+  type        = string
+}
+
+variable "profile" {
+  description = "Perfil de capacidade das VMs: 'poc' (~$72/mês compute) ou 'hml' (~$157/mês). Cada perfil mapeia para shape em locals.tf."
+  type        = string
+  default     = "poc"
+
+  validation {
+    condition     = contains(["poc", "hml"], var.profile)
+    error_message = "profile deve ser 'poc' ou 'hml'."
+  }
+}
+
+variable "volume_sizes_gbs" {
+  description = "Tamanho em GB de cada block volume anexado ao data-host. Defaults preservam tamanhos vivos atuais; reduzir é destrutivo (delete+recreate) e perde dados."
+  type = object({
+    postgres = number
+    kafka    = number
+    minio    = number
+    vault    = number
+  })
+  default = {
+    postgres = 200
+    kafka    = 100
+    minio    = 200
+    vault    = 50
+  }
+}
+
+variable "volume_vpus_per_gb" {
+  description = "VPUs por GB nos block volumes. 0 = Lower Cost (mínimo, sem IOPS dedicado); 10 = Balanced default OCI."
+  type        = number
+  default     = 0
+}

--- a/provisioning/oci/standalone/versions.tf
+++ b/provisioning/oci/standalone/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 7.7"
+    }
+  }
+}
+
+provider "oci" {
+  region = var.region
+  # Auth via ~/.oci/config (`tenancy_ocid` + `user_ocid` + `fingerprint` + `private_key_path`).
+  # Alternativas: instance principal, resource principal, security token.
+}


### PR DESCRIPTION
## Resumo

**Caminho B** do plano de redução de footprint OCI: codifica em OpenTofu o standalone, permitindo `tofu apply`/`destroy`/recreate. Consolidou Stories #52 (esqueleto), #54 (compute) e #55 (storage) em 1 PR — escopo mínimo viável que forma um ciclo de validação completo (cada Story sozinha não faz `tofu plan` útil).

## O que entrega

| Arquivo | Conteúdo |
|---|---|
| `versions.tf` | OpenTofu ≥ 1.6, OCI provider `~> 7.7` |
| `variables.tf` | `compartment_ocid`, `region`, AD, FD, OCIDs de VCN/subnets/image, SSH keys, `profile` (validado: poc/hml), `volume_sizes_gbs`, `volume_vpus_per_gb` |
| `locals.tf` | Mapa `profile → shape config` (mesma fonte do `scripts/resize-standalone-oci.sh`) + `common_tags` |
| `compute.tf` | `oci_core_instance.k8s_host` + `oci_core_instance.data_host` |
| `storage.tf` | `oci_core_volume.data` (for_each em postgres/kafka/minio/vault) + `oci_core_volume_attachment.data` |
| `outputs.tf` | OCIDs + IPs + shape efetivo |
| `terraform.tfvars.example` | Placeholders com instruções; OCIDs reais ficam em `terraform.tfvars` (gitignored) |
| `.gitignore` | `*.tfvars`, `.terraform/`, `*.tfstate*` |
| `README.md` | Setup → import → operações + drifts conhecidos + limitações + próximas Stories |
| `CHANGELOG.md` | Entrada em `### Alterado` documentando capacidade |

## Validação ponta-a-ponta executada nesta sessão

```bash
$ tofu init && tofu validate    # ✓ Success
$ tofu plan                      # 10 to add (esperado, state vazio)
$ tofu import oci_core_instance.k8s_host  ocid1.instance...
... (10 imports: 2 instances + 4 volumes + 4 attachments)
$ tofu plan                      # 4 destroy/4 add detectado → drift
# Drift 1: display_name attachments era "att-<vol>" no vivo, HCL tinha
#   "uniplus-standalone-<vol>-attachment" → forces replacement.
#   Ajustado HCL para "att-<vol>" (preserva recurso vivo).
# Drift 2: freeform_tags com "/" rejeitadas (OCI: forbidden chars).
#   Trocado para underscores: "uniplus_environment", "uniplus_managed_by".
$ tofu apply                     # 6 update in-place (tags), 0 destroy
$ tofu plan                      # No changes ✅
```

State + tfvars locais removidos pós-validação (gitignored, não vão pro git).

## Decisões intencionais

| Decisão | Razão |
|---|---|
| **VCN/subnets via variáveis OCID** (não importadas) | Story #53 fará `network.tf` separado. Manter escopo deste PR fechado. |
| **Cloud-init mínimo** (só `ssh_authorized_keys`) | Recriar VM = re-rodar `bootstrap-standalone.sh` manualmente (documentado). cloud-init full vira extensão da Story #54. |
| **Boot volumes implícitos** via `oci_core_instance.source_details` | Recriar VM recria boot (esperado). Boot volume separado adiciona complexidade desnecessária neste recorte. |
| **State local** | Sem backend remoto neste PR. Migrar para OCI Object Storage é extensão futura. README explica risco. |
| **`lifecycle.ignore_changes = [source_details]`** | Evita force-recreate quando OCI bumpa imagem Ubuntu LTS. Atualização de imagem fica controlada por var change explícita. |
| **`display_name` dos attachments preserva nome vivo** (`att-<vol>`) | Mudar display_name força replacement (detach+reattach causa downtime de mounts no data-host). |
| **freeform_tags com underscore** | OCI rejeita `/` em key names (vs convenção K8s `<prefix>/<key>`). |

## Como o operador usa

```bash
cd provisioning/oci/standalone
cp terraform.tfvars.example terraform.tfvars   # preencher OCIDs + SSH key
tofu init
# Se primeira vez no host (state vazio): import × 10 — comandos no README §Importar
tofu plan       # esperado: No changes (estado bate com OCI)

# Mudar perfil de capacidade (REBOOTA VMs ~30-90s; igual scripts/resize-standalone-oci.sh)
$EDITOR terraform.tfvars   # profile = "hml"
tofu apply

# Shrink destrutivo dos blocks (PERDE dados; backup antes!)
$EDITOR terraform.tfvars   # volume_sizes_gbs = { postgres=10, kafka=10, ... }
tofu apply
# Re-bootstrap obrigatório após (Vault re-init, KC realm re-import via ArgoCD)
```

## Limitações conhecidas (documentadas no README)

- VCN/subnets/IGW/NSGs não importadas (Story #53)
- DNS + Reserved Public IP (Story #56)
- OCI Vault KMS para Vault auto-unseal (Story #57 — bloqueada por bug upstream `go-kms-wrapping@v2.0.9`)
- IAM Dynamic Group + Policy / Resource Principal (Story #58)
- Bridge outputs Tofu → `environments/standalone/values.yaml` (Story #58)
- Cloud-init full (Docker, k3s, LVM) — fica em extensão da Story #54
- State remoto (Object Storage backend) — extensão futura

## Critério de aceite

- [x] Stories #52, #54, #55 entregues em 1 PR consolidado
- [x] `tofu init && tofu validate` OK
- [x] `tofu plan` retorna `No changes` pós-import
- [x] `tofu apply` aplicado em recursos vivos sem regressão (validado: cluster segue Running, services systemd active)
- [x] `.gitignore` protegendo state + tfvars
- [x] README com setup, operações e limitações
- [ ] PR mergeado em main

## Riscos & rollback

- **Risco**: state local — perda do diretório `~/uniplus-infra/provisioning/oci/standalone/` perde state, mas operador refaz `tofu init` + import. Backend remoto resolve definitivamente (extensão futura).
- **Risco operacional zero do PR em si**: nenhum recurso é tocado pelo merge; os apply/import são operação manual do operador.
- **Rollback**: `git revert <merge-sha>`. Recursos vivos seguem inalterados.

Closes #52 #54 #55
Refs #43, plano de redução de footprint OCI (PR #204), `~/.claude/plans/wise-pondering-sketch.md`