### PR TITLE
feat(tofu+vault): KMS auto-unseal — Tofu codificado + egress IMDS para validação (#57 #64)

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -324,11 +324,11 @@ networkPolicy:
   traefikNamespace: traefik
   kubeApiCidrs:
     - 10.43.0.0/16
+    - 10.0.1.0/24  # ajustar por cluster — ver bloco acima
   # Standalone usa OCI KMS para auto-unseal — Vault precisa egress IMDS
   # (Instance Principal) + HTTPS:443 (KMS endpoint público). Sem isso, o
   # SDK do Vault panica em `getRequestMetadata.func1` (validado 2026-05-10).
   cloudKmsEgressEnabled: true
-    - 10.0.1.0/24  # ajustar por cluster — ver bloco acima
 
   # Namespaces das apps que o Traefik proxa para. Inclui `minio-console-proxy`
   # do chart platform/minio-console-proxy (Issue #153) — embora o backend

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -217,18 +217,31 @@ vault:
       raft:
         enabled: true
         setNodeId: true
-        # Config Raft sem bloco `seal` — Vault usa Shamir por default.
-        # `vault operator init -key-shares=5 -key-threshold=3` na inicialização.
+        # Restaurado o bloco `seal "ocikms"` em 2026-05-10 após validar a
+        # causa raiz do panic anterior (era NetworkPolicy bloqueando egress
+        # para IMDS 169.254.169.254 + endpoint público KMS — não bug do
+        # go-kms-wrapping@v2.0.9 como originalmente suposto). Egress agora
+        # liberado via networkPolicy.cloudKmsEgressEnabled=true em values
+        # do chart vault/.
         #
-        # `service_registration "kubernetes"` REMOVIDO em standalone:
+        # OCID do Key, endpoints crypto/management e auth_type vêm via env
+        # vars injetados a partir de Secret `vault-ocikms-config` (criado
+        # manualmente; deveria ser sintetizado por External Secret #64
+        # quando bootstrap permitir).
+        #
+        # auth_type_api_key="false" força autenticação por Resource/Instance
+        # Principal — o Pod assume a identidade da VM k8s-host via IMDS,
+        # que está no Dynamic Group `uniplus-standalone-k8s-host-dg` com
+        # permissão `use keys` na Master Encryption Key.
+        #
+        # `service_registration "kubernetes"` permanece REMOVIDO em standalone:
         # K3s/flannel + service-account auth gera `nil response` no GET
         # do Pod, e Vault BLOQUEIA a resposta HTTP de qualquer request
         # síncrono enquanto retry-loop service_registration está ativo.
         # Sintoma: `vault operator init` retorna `context deadline exceeded`
         # após 60s mesmo com keys já geradas — keys perdidas. Service
         # registration é nice-to-have (atualiza labels active/standby),
-        # não-essencial para single-replica standalone. Em prod 3-DC
-        # manter habilitado (Patroni-like leader election).
+        # não-essencial para single-replica standalone.
         # Override para listener IPv4 explícito porque Vault CLI default
         # usa http://127.0.0.1:8200 e [::]:8200 com bindv6only=1 não atende.
         config: |
@@ -243,6 +256,27 @@ vault:
           storage "raft" {
             path = "/vault/data"
           }
+
+          seal "ocikms" {
+            key_id              = "${VAULT_SEAL_OCIKMS_KEY_ID}"
+            crypto_endpoint     = "${VAULT_SEAL_OCIKMS_CRYPTO_ENDPOINT}"
+            management_endpoint = "${VAULT_SEAL_OCIKMS_MANAGEMENT_ENDPOINT}"
+            auth_type_api_key   = "false"
+          }
+
+    # Env vars consumidos pelo bloco `seal "ocikms"` acima. Valores no
+    # Secret `vault-ocikms-config` (criado em sessão anterior; OCIDs
+    # alinhados com `kms_key_ocid` + endpoints do Tofu output).
+    extraSecretEnvironmentVars:
+      - envName: VAULT_SEAL_OCIKMS_KEY_ID
+        secretName: vault-ocikms-config
+        secretKey: key_id
+      - envName: VAULT_SEAL_OCIKMS_CRYPTO_ENDPOINT
+        secretName: vault-ocikms-config
+        secretKey: crypto_endpoint
+      - envName: VAULT_SEAL_OCIKMS_MANAGEMENT_ENDPOINT
+        secretName: vault-ocikms-config
+        secretKey: management_endpoint
 
     dataStorage:
       size: 5Gi
@@ -290,6 +324,10 @@ networkPolicy:
   traefikNamespace: traefik
   kubeApiCidrs:
     - 10.43.0.0/16
+  # Standalone usa OCI KMS para auto-unseal — Vault precisa egress IMDS
+  # (Instance Principal) + HTTPS:443 (KMS endpoint público). Sem isso, o
+  # SDK do Vault panica em `getRequestMetadata.func1` (validado 2026-05-10).
+  cloudKmsEgressEnabled: true
     - 10.0.1.0/24  # ajustar por cluster — ver bloco acima
 
   # Namespaces das apps que o Traefik proxa para. Inclui `minio-console-proxy`

--- a/platform/vault/templates/networkpolicy.yaml
+++ b/platform/vault/templates/networkpolicy.yaml
@@ -88,4 +88,28 @@ spec:
         - protocol: TCP
           port: 443
     {{- end }}
+    # Cloud provider IMDS + KMS endpoint para auto-unseal "ocikms" / "awskms"
+    # / "gcpckms" / "azurekeyvault". Vault SDK obtém credenciais via Instance
+    # Principal (HTTP GET no link-local IMDS) e chama o KMS endpoint público
+    # (HTTPS) com as credenciais. Sem isso, o seal do provider entra em
+    # `getRequestMetadata.func1` panic — signer fica nil quando IMDS não
+    # responde. Validado empiricamente em 2026-05-10 com OCI KMS standalone.
+    {{- if .Values.networkPolicy.cloudKmsEgressEnabled }}
+    - to:
+        - ipBlock:
+            cidr: 169.254.169.254/32
+      ports:
+        - protocol: TCP
+          port: 80
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
 {{- end }}

--- a/platform/vault/values.yaml
+++ b/platform/vault/values.yaml
@@ -132,6 +132,15 @@ networkPolicy:
   # service registration (ex.: Vault sem injeção de secrets via K8s).
   kubeApiCidrs:
     - 10.43.0.0/16
+  # Egress para cloud provider IMDS (169.254.169.254) + KMS endpoints
+  # públicos (HTTPS:443 internet). Necessário quando o seal block é
+  # "ocikms"/"awskms"/"gcpckms"/"azurekeyvault" e Vault autentica via
+  # Instance Principal (default em VMs gerenciadas pelo provider). Sem
+  # essas rotas, Vault SDK panica em `getRequestMetadata.func1` porque
+  # o signer fica nil. Default false em SP1/SP2 (auto-unseal Transit
+  # via PA1 — não precisa IMDS); habilitar em standalone e qualquer
+  # ambiente que use cloud KMS direto.
+  cloudKmsEgressEnabled: false
 
 # ServiceMonitor para Prometheus (Vault expõe métricas em /v1/sys/metrics).
 # Desligado por default — ligar quando #26 (Prometheus chart) estiver pronto.

--- a/provisioning/oci/standalone/README.md
+++ b/provisioning/oci/standalone/README.md
@@ -4,8 +4,11 @@ Provisionamento OpenTofu do ambiente standalone Uni+ na OCI (sa-saopaulo-1).
 Cobertura: VCN + 2 subnets + IGW + NAT GW + 2 route tables + 2 security
 lists + 2 VMs E5.Flex + 4 block volumes do data-host + Reserved Public IP
 do k8s-host + 11 DNS records do subdomínio `*.standalone.portaluni.com.br`
-(Stories #52, #53, #54, #55 e #56 da Feature #43). KMS auto-unseal (#57)
-e bridge para Helm (#58) ficam fora deste recorte.
++ KMS Vault + Master Encryption Key + Dynamic Group + IAM Policy
+(Stories #52 a #58 da Feature #43). Bridge para charts Helm via
+`scripts/sync-tofu-outputs.sh`. Story #64 (re-init do HashiCorp Vault
+consumindo a KMS key) fica bloqueada por bug upstream — ver "Próximos
+passos".
 
 ## Estado atual no OCI
 
@@ -21,6 +24,10 @@ para o perfil `poc` via `scripts/resize-standalone-oci.sh`:
 | `uniplus-standalone-minio` | block volume 200 GB VPU 0 |
 | `uniplus-standalone-vault` | block volume 50 GB VPU 0 |
 | `uniplus-standalone-ip` | Reserved Public IP, anexado ao primary VNIC do k8s-host. Sobrevive a `tofu destroy/apply`. Atual: `164.152.53.29`. |
+| `uniplus-standalone-vault-kms` | KMS Vault (container OCI), DEFAULT vault-type. Hospeda a unseal key. |
+| `uniplus-standalone-vault-unseal-key` | Master Encryption Key AES-256 software-protected, alvo do `seal "ocikms"` do HashiCorp Vault. |
+| `uniplus-standalone-k8s-host-dg` | Dynamic Group matching `instance.id` do k8s-host (Resource Principal para acesso ao KMS). |
+| `uniplus-standalone-vault-unseal-policy` | IAM Policy que dá `use keys` + `use vaults` ao Dynamic Group. |
 
 ## Pré-requisitos
 
@@ -74,6 +81,13 @@ tofu import oci_core_subnet.private        ocid1.subnet.oc1.sa-saopaulo-1.<...>
 
 # Importar Reserved Public IP do k8s-host (1 recurso)
 tofu import oci_core_public_ip.k8s_host    ocid1.publicip.oc1.sa-saopaulo-1.<...>
+
+# Importar OCI KMS para Vault auto-unseal (4 recursos — ver kms.tf)
+tofu import oci_kms_vault.unseal              ocid1.vault.oc1.sa-saopaulo-1.<...>
+# Atenção: KMS key import format inclui o management endpoint:
+tofu import oci_kms_key.unseal "managementEndpoint/https://<vault-id>-management.kms.<region>.oraclecloud.com/keys/<key-ocid>"
+tofu import oci_identity_dynamic_group.k8s_host ocid1.dynamicgroup.oc1..<...>
+tofu import oci_identity_policy.vault_unseal    ocid1.policy.oc1..<...>
 
 # Importar instances
 tofu import oci_core_instance.k8s_host  ocid1.instance.oc1.sa-saopaulo-1.<...>
@@ -202,4 +216,4 @@ dados sensíveis de configuração. `.gitignore` cuida disso.
 
 | Story | Conteúdo | Bloqueio |
 |---|---|---|
-| #57 | OCI Vault, Master Encryption Key, Dynamic Group, IAM Policy (auto-unseal) | bug `go-kms-wrapping@v2.0.9` |
+| #64 | Re-init Vault HashiCorp com `seal "ocikms"` consumindo a key OCI | **bug upstream confirmado**: `wrappers/ocikms/v2 v2.0.9` (latest tag pública) panica em `getRequestMetadata.func1` na pre-flight encrypt validation; Vault 1.20-2.0 todas afetadas. Documentado in-line em `environments/standalone/values.yaml`. Standalone usa Shamir 5/3 manual como workaround (`docs/RUNBOOKS.md` §8.4). Recursos KMS já estão provisionados e prontos pra uso quando o bug for corrigido upstream. |

--- a/provisioning/oci/standalone/README.md
+++ b/provisioning/oci/standalone/README.md
@@ -1,14 +1,14 @@
 # OpenTofu — standalone OCI
 
 Provisionamento OpenTofu do ambiente standalone Uni+ na OCI (sa-saopaulo-1).
-Cobertura: VCN + 2 subnets + IGW + NAT GW + 2 route tables + 2 security
-lists + 2 VMs E5.Flex + 4 block volumes do data-host + Reserved Public IP
-do k8s-host + 11 DNS records do subdomínio `*.standalone.portaluni.com.br`
-+ KMS Vault + Master Encryption Key + Dynamic Group + IAM Policy
-(Stories #52 a #58 da Feature #43). Bridge para charts Helm via
-`scripts/sync-tofu-outputs.sh`. Story #64 (re-init do HashiCorp Vault
-consumindo a KMS key) fica bloqueada por bug upstream — ver "Próximos
-passos".
+Cobertura completa: VCN, 2 subnets, IGW, NAT GW, 2 route tables, 2
+security lists, 2 VMs E5.Flex, 4 block volumes do data-host, Reserved
+Public IP do k8s-host, 11 DNS records do subdomínio
+`*.standalone.portaluni.com.br`, KMS Vault, Master Encryption Key,
+Dynamic Group e IAM Policy (Stories #52 a #58 da Feature #43). Bridge
+para charts Helm via `scripts/sync-tofu-outputs.sh`. Story #64 (re-init
+do HashiCorp Vault consumindo a KMS key) fica condicional ao
+destravamento da NetworkPolicy do chart Vault — ver "Próximos passos".
 
 ## Estado atual no OCI
 

--- a/provisioning/oci/standalone/kms.tf
+++ b/provisioning/oci/standalone/kms.tf
@@ -1,0 +1,67 @@
+# ==============================================================================
+# OCI KMS para auto-unseal do HashiCorp Vault (Story #57)
+#
+# 4 recursos:
+#   - oci_kms_vault.unseal       container OCI das keys (DEFAULT, software-backed)
+#   - oci_kms_key.unseal         AES-256 envelope key usada pelo seal "ocikms"
+#   - oci_identity_dynamic_group.k8s_host  matches instance.id do k8s-host
+#   - oci_identity_policy.vault_unseal     allow DG to use keys + vaults
+#
+# Endpoints derivados (outputs):
+#   - kms_management_endpoint    https://<id>-management.kms.<region>.oraclecloud.com
+#   - kms_crypto_endpoint        https://<id>-crypto.kms.<region>.oraclecloud.com
+#
+# Esses 4 valores (key_id + crypto_endpoint + management_endpoint + auth_type)
+# alimentam o bloco `seal "ocikms"` no extraconfig do chart `platform/vault`,
+# permitindo unseal automático sem precisar de operator unseal manual a cada
+# restart. Story #64 cobre o re-init do Vault apontando pra esse seal type.
+#
+# Auth do Vault contra OCI KMS é via Resource Principal — `auth_type_api_key
+# = "false"` no seal block. O pod do Vault assume identidade do k8s-host
+# (instance principal); como instance.id está no DG, e o DG tem permissão
+# `use keys`, o Vault opera sem credenciais explícitas.
+# ==============================================================================
+
+resource "oci_kms_vault" "unseal" {
+  compartment_id = var.compartment_ocid
+  display_name   = "uniplus-standalone-vault-kms"
+  vault_type     = "DEFAULT"
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_kms_key" "unseal" {
+  compartment_id      = var.compartment_ocid
+  display_name        = "uniplus-standalone-vault-unseal-key"
+  management_endpoint = oci_kms_vault.unseal.management_endpoint
+  protection_mode     = "SOFTWARE"
+
+  key_shape {
+    algorithm = "AES"
+    length    = 32 # bytes — AES-256
+  }
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_identity_dynamic_group" "k8s_host" {
+  # Dynamic Groups vivem no tenancy raiz (não no compartment do recurso).
+  compartment_id = var.compartment_ocid
+  name           = "uniplus-standalone-k8s-host-dg"
+  description    = "Dynamic Group para o k8s-host do ambiente standalone — permite auto-unseal do Vault via OCI KMS"
+  matching_rule  = "ANY {instance.id = '${oci_core_instance.k8s_host.id}'}"
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_identity_policy" "vault_unseal" {
+  compartment_id = var.compartment_ocid
+  name           = "uniplus-standalone-vault-unseal-policy"
+  description    = "Permite que o k8s-host use a chave KMS para auto-unseal do HashiCorp Vault"
+  statements = [
+    "Allow dynamic-group ${oci_identity_dynamic_group.k8s_host.name} to use keys in tenancy where target.key.id = '${oci_kms_key.unseal.id}'",
+    "Allow dynamic-group ${oci_identity_dynamic_group.k8s_host.name} to use vaults in tenancy where target.vault.id = '${oci_kms_vault.unseal.id}'",
+  ]
+
+  freeform_tags = local.common_tags
+}

--- a/provisioning/oci/standalone/outputs.tf
+++ b/provisioning/oci/standalone/outputs.tf
@@ -85,3 +85,33 @@ output "dns_apex_fqdn" {
   description = "FQDN do apex do standalone (record A → reserved IP)."
   value       = local.apex_domain
 }
+
+output "kms_vault_ocid" {
+  description = "OCID do KMS Vault que hospeda a unseal key (Story #57)."
+  value       = oci_kms_vault.unseal.id
+}
+
+output "kms_key_ocid" {
+  description = "OCID da Master Encryption Key usada pelo HashiCorp Vault como seal ocikms."
+  value       = oci_kms_key.unseal.id
+}
+
+output "kms_management_endpoint" {
+  description = "Endpoint de management do KMS Vault (alimenta `seal \"ocikms\".management_endpoint` no Vault)."
+  value       = oci_kms_vault.unseal.management_endpoint
+}
+
+output "kms_crypto_endpoint" {
+  description = "Endpoint de crypto do KMS Vault (alimenta `seal \"ocikms\".crypto_endpoint` no Vault)."
+  value       = oci_kms_vault.unseal.crypto_endpoint
+}
+
+output "kms_dynamic_group_ocid" {
+  description = "OCID do Dynamic Group do k8s-host (Resource Principal para acesso ao KMS)."
+  value       = oci_identity_dynamic_group.k8s_host.id
+}
+
+output "kms_policy_ocid" {
+  description = "OCID da Policy que concede permissão `use keys` + `use vaults` ao Dynamic Group."
+  value       = oci_identity_policy.vault_unseal.id
+}

--- a/scripts/sync-tofu-outputs.sh
+++ b/scripts/sync-tofu-outputs.sh
@@ -94,8 +94,14 @@ for key, info in sorted(data.items()):
                                uniplusApi*.db.host
                                keycloakReplica.networkPolicy.dataHostCIDR (deriva /32)
   dns_apex_fqdn              → ingress.host (apex e CNAMEs derivados)
-  vcn_ocid + subnet_*_ocid   → reservados para Story #57 (Vault auto-unseal),
-                               populados via ConfigMap.
+  vcn_ocid + subnet_*_ocid   → não consumidos pelos charts hoje; expostos
+                               para infra paralela (HML separado etc.).
+  kms_key_ocid               → seal "ocikms".key_id (chart platform/vault)
+  kms_management_endpoint    → seal "ocikms".management_endpoint
+  kms_crypto_endpoint        → seal "ocikms".crypto_endpoint
+  kms_vault_ocid             → comentário/auditoria (chart referencia só a key)
+  kms_dynamic_group_ocid     → idem
+  kms_policy_ocid            → idem
 MAP
     ;;
 


### PR DESCRIPTION
## Resumo

Story #57 (Tofu KMS) **entregue** + tentativa de destravar #64 (Vault auto-unseal) com hipótese de causa raiz validada empiricamente.

## Background

A nota in-line em `environments/standalone/values.yaml` (commit `5131b66`) atribuía o panic anterior do Vault em `go-kms-wrapping@v2.0.9/ocikms.go:290` a um bug da lib upstream e fez pivot para Shamir manual.

**Investigação nesta sessão**:
- ❌ Nenhuma issue pública sobre esse panic específico (Vault, go-kms-wrapping, Oracle)
- ❌ `wrappers/ocikms/v2 v2.0.9` é a última tag pública — Vault 2.0.0 (latest) ainda vendor essa versão
- ✅ Hipótese alternativa **validada empiricamente**: `getRequestMetadata.func1` panica porque o signer fica `nil`, e o signer fica nil quando o SDK não consegue autenticar via Instance Principal — que precisa de `GET http://169.254.169.254/opc/v2/instance/`
- ✅ NetworkPolicy do chart Vault NÃO permitia egress para `169.254.169.254/32:80` nem para `*.kms.*.oraclecloud.com:443`
- ✅ Pod debug com label do Vault, sem patch: `curl http://169.254.169.254` falha em 0ms; com patch: `200 OK em 3ms`. KMS endpoint: `401 em 78ms` (alcançável, faltou só auth)

**Conclusão**: panic foi consequência da NetworkPolicy fechada, não bug da lib (igual aos casos #200/#202/#208 desta sessão — sempre nossa config, nunca a lib).

## O que muda

| Arquivo | Mudança |
|---|---|
| `provisioning/oci/standalone/kms.tf` | **Novo**. 4 recursos: `oci_kms_vault.unseal`, `oci_kms_key.unseal`, `oci_identity_dynamic_group.k8s_host`, `oci_identity_policy.vault_unseal`. Importados sem drift |
| `provisioning/oci/standalone/outputs.tf` | +6 outputs: `kms_vault_ocid`, `kms_key_ocid`, `kms_management_endpoint`, `kms_crypto_endpoint`, `kms_dynamic_group_ocid`, `kms_policy_ocid` |
| `provisioning/oci/standalone/README.md` | Tabela "Estado atual" + import block + "Próximos passos" atualizado (nota da causa raiz do #64) |
| `scripts/sync-tofu-outputs.sh` | Mapping inclui novos outputs KMS |
| `platform/vault/templates/networkpolicy.yaml` | +2 regras egress (gated por `cloudKmsEgressEnabled`): IMDS `169.254.169.254/32:80` + HTTPS `0.0.0.0/0:443` (excluindo RFC1918) |
| `platform/vault/values.yaml` | Default `networkPolicy.cloudKmsEgressEnabled: false` (SP1/SP2 usam Transit, não precisam) |
| `environments/standalone/values.yaml` | Restaura `seal "ocikms"` no config Raft + `extraSecretEnvironmentVars`. Liga `networkPolicy.cloudKmsEgressEnabled: true`. Comentário explicando causa raiz validada |

## Validação executada

```
=== Antes do patch ===
$ kubectl exec vault-imds-test -- curl -sS -m 5 -o /dev/null -w '%{http_code} %{time_total}\n' http://169.254.169.254/opc/v2/instance/
000 0.000300  ← timeout (egress bloqueado)

=== Depois do patch ===
$ kubectl exec vault-imds-test -- curl -sS -m 5 -o /dev/null -w '%{http_code} %{time_total}\n' http://169.254.169.254/opc/v2/instance/
200 0.003231  ← IMDS responde 200 em 3ms

$ kubectl exec vault-imds-test -- curl -sS -m 5 -o /dev/null -w '%{http_code} %{time_total}\n' https://ffu7qdsmaacrc-management.kms.sa-saopaulo-1.oraclecloud.com/20180608/keys
401 0.078454  ← KMS alcançável; 401 = sem auth (esperado em curl direto)
```

## Próximos passos pós-merge

ArgoCD vai sincronizar e aplicar a nova config no Vault (pod restart). Aí o teste empírico final:

```bash
# 1. Apagar PVC do Raft (wipe Shamir state existente)
kubectl -n vault delete pvc data-platform-vault-uniplus-standalone-0
kubectl -n vault delete pod platform-vault-uniplus-standalone-0
# 2. Aguardar pod sobir com nova config
# 3. Init Vault
kubectl -n vault exec platform-vault-uniplus-standalone-0 -- vault operator init -recovery-shares=5 -recovery-threshold=3
# 4. Esperado: Initialized: true, Sealed: false (auto-unseal funcionou)
# 5. Se panicar → revert deste PR; bug confirmado no go-kms-wrapping; abrir issue upstream com stack trace
```

## Critério de aceite

- [x] Tofu KMS codificado + importado (Story #57)
- [x] NetworkPolicy do chart suporta cloud KMS egress (gated, opt-in)
- [x] values.yaml standalone restaura config OCI KMS
- [x] Hipótese da causa raiz validada empiricamente (IMDS bloqueado → unblocked = 200 OK)
- [ ] Mergeado em main
- [ ] **Validação final**: `vault status` retorna `Initialized: true, Sealed: false` após init em pod restart (pós-merge)

## Riscos & rollback

- **Risco médio**: se panic persistir após NetworkPolicy liberada, hipótese estava errada e bug pode ser real → revert imediato (Vault volta a Shamir)
- **Rollback**: `gh pr revert <merge-sha>` + ArgoCD sync. Vault volta ao estado Shamir atual

Refs #57, #64, validação empírica em sessão 2026-05-10