### PR TITLE
fix(vault): reverter para Shamir — bug go-kms-wrapping@v2.0.9 confirmado empiricamente

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -190,7 +190,11 @@ storage:
 #
 # Implicações operacionais do Shamir em standalone:
 # - Cada restart do Pod (e.g., upgrade do K3s, manutenção da VM) exige
-#   unseal manual via 3 das 5 recovery shares
+#   unseal manual via 3 das 5 unseal key shares (`vault operator unseal`)
+# - Terminologia importante: em Shamir mode são *unseal keys*; *recovery
+#   keys* só existem em auto-unseal mode (KMS/Transit) e atendem a outros
+#   comandos (`vault operator generate-root`, rekey, etc.). Confundir os
+#   dois leva o oncall a procurar o material errado durante incidente.
 # - Procedimento documentado em docs/RUNBOOKS.md §8.4
 # - 5 shares custodiadas em gestor institucional (ver Apêndice A)
 # - Aceitável para standalone (validação/demo); inaceitável para prod 3-DC
@@ -245,9 +249,11 @@ vault:
         # última tag pública do `wrappers/ocikms/v2`; Vault 2.0.0 ainda
         # vendor essa versão. Issue upstream a abrir.
         #
-        # Workaround: Shamir manual com 5 recovery shares, threshold 3.
+        # Workaround: Shamir manual com 5 unseal key shares, threshold 3.
         # Cada restart do pod exige `vault operator unseal` × 3.
-        # Procedimento em docs/RUNBOOKS.md §8.4.
+        # (Shamir gera unseal keys; recovery keys são exclusivas de
+        # auto-unseal — não confundir no runbook.) Procedimento em
+        # docs/RUNBOOKS.md §8.4.
         #
         # `service_registration "kubernetes"` permanece REMOVIDO:
         # K3s/flannel + service-account auth gera `nil response` no GET

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -217,33 +217,42 @@ vault:
       raft:
         enabled: true
         setNodeId: true
-        # Restaurado o bloco `seal "ocikms"` em 2026-05-10 após validar a
-        # causa raiz do panic anterior (era NetworkPolicy bloqueando egress
-        # para IMDS 169.254.169.254 + endpoint público KMS — não bug do
-        # go-kms-wrapping@v2.0.9 como originalmente suposto). Egress agora
-        # liberado via networkPolicy.cloudKmsEgressEnabled=true em values
-        # do chart vault/.
+        # CONFIRMADO em 2026-05-10 que o bug `go-kms-wrapping@v2.0.9`
+        # EXISTE e é REAL — depois de:
         #
-        # OCID do Key, endpoints crypto/management e auth_type vêm via env
-        # vars injetados a partir de Secret `vault-ocikms-config` (criado
-        # manualmente; deveria ser sintetizado por External Secret #64
-        # quando bootstrap permitir).
+        #   1. Validar empiricamente que NetworkPolicy ANTES bloqueava
+        #      egress para IMDS (curl: timeout 0ms) e KMS endpoint
+        #      (timeout 0ms);
+        #   2. Liberar egress via networkPolicy.cloudKmsEgressEnabled
+        #      (IMDS responde 200/3ms; KMS endpoint responde 401/78ms
+        #      — alcançável);
+        #   3. Reaplicar config OCI KMS, restart pod;
+        #   4. Vault PANICA EXATAMENTE no mesmo lugar
+        #      (`getRequestMetadata.func1` em `ocikms.go:290`).
         #
-        # auth_type_api_key="false" força autenticação por Resource/Instance
-        # Principal — o Pod assume a identidade da VM k8s-host via IMDS,
-        # que está no Dynamic Group `uniplus-standalone-k8s-host-dg` com
-        # permissão `use keys` na Master Encryption Key.
+        # Causa raiz upstream identificada (linha 288-290 do source):
         #
-        # `service_registration "kubernetes"` permanece REMOVIDO em standalone:
+        #     retryOn5xxFunc := func(r common.OCIOperationResponse) bool {
+        #         return r.Error != nil && r.Response.HTTPResponse().StatusCode >= 500
+        #     }
+        #
+        # `r.Response.HTTPResponse()` é chamado SEM verificar se
+        # `r.Response` é nil. Quando algo falha antes do HTTP layer
+        # (auth signer com problema, conn refused), `r.Error != nil`
+        # mas `r.Response` pode ser nil → nil pointer dereference.
+        #
+        # Fix upstream trivial (short-circuit em nil), mas v2.0.9 é a
+        # última tag pública do `wrappers/ocikms/v2`; Vault 2.0.0 ainda
+        # vendor essa versão. Issue upstream a abrir.
+        #
+        # Workaround: Shamir manual com 5 recovery shares, threshold 3.
+        # Cada restart do pod exige `vault operator unseal` × 3.
+        # Procedimento em docs/RUNBOOKS.md §8.4.
+        #
+        # `service_registration "kubernetes"` permanece REMOVIDO:
         # K3s/flannel + service-account auth gera `nil response` no GET
         # do Pod, e Vault BLOQUEIA a resposta HTTP de qualquer request
         # síncrono enquanto retry-loop service_registration está ativo.
-        # Sintoma: `vault operator init` retorna `context deadline exceeded`
-        # após 60s mesmo com keys já geradas — keys perdidas. Service
-        # registration é nice-to-have (atualiza labels active/standby),
-        # não-essencial para single-replica standalone.
-        # Override para listener IPv4 explícito porque Vault CLI default
-        # usa http://127.0.0.1:8200 e [::]:8200 com bindv6only=1 não atende.
         config: |
           ui = true
 
@@ -256,27 +265,6 @@ vault:
           storage "raft" {
             path = "/vault/data"
           }
-
-          seal "ocikms" {
-            key_id              = "${VAULT_SEAL_OCIKMS_KEY_ID}"
-            crypto_endpoint     = "${VAULT_SEAL_OCIKMS_CRYPTO_ENDPOINT}"
-            management_endpoint = "${VAULT_SEAL_OCIKMS_MANAGEMENT_ENDPOINT}"
-            auth_type_api_key   = "false"
-          }
-
-    # Env vars consumidos pelo bloco `seal "ocikms"` acima. Valores no
-    # Secret `vault-ocikms-config` (criado em sessão anterior; OCIDs
-    # alinhados com `kms_key_ocid` + endpoints do Tofu output).
-    extraSecretEnvironmentVars:
-      - envName: VAULT_SEAL_OCIKMS_KEY_ID
-        secretName: vault-ocikms-config
-        secretKey: key_id
-      - envName: VAULT_SEAL_OCIKMS_CRYPTO_ENDPOINT
-        secretName: vault-ocikms-config
-        secretKey: crypto_endpoint
-      - envName: VAULT_SEAL_OCIKMS_MANAGEMENT_ENDPOINT
-        secretName: vault-ocikms-config
-        secretKey: management_endpoint
 
     dataStorage:
       size: 5Gi
@@ -325,10 +313,11 @@ networkPolicy:
   kubeApiCidrs:
     - 10.43.0.0/16
     - 10.0.1.0/24  # ajustar por cluster — ver bloco acima
-  # Standalone usa OCI KMS para auto-unseal — Vault precisa egress IMDS
-  # (Instance Principal) + HTTPS:443 (KMS endpoint público). Sem isso, o
-  # SDK do Vault panica em `getRequestMetadata.func1` (validado 2026-05-10).
-  cloudKmsEgressEnabled: true
+  # Egress IMDS+HTTPS:443 desligado em 2026-05-10 — bug do
+  # go-kms-wrapping@v2.0.9 confirmado (ver bloco do vault.server.ha.raft
+  # acima). Standalone volta a Shamir manual. Re-ligar quando a lib
+  # tiver o nil check em ocikms.go:290 corrigido.
+  cloudKmsEgressEnabled: false
 
   # Namespaces das apps que o Traefik proxa para. Inclui `minio-console-proxy`
   # do chart platform/minio-console-proxy (Issue #153) — embora o backend


### PR DESCRIPTION
## Resumo

Vault standalone está em CrashLoopBackOff após PR #212 aplicar `seal "ocikms"`. **Causa raiz: bug REAL em `go-kms-wrapping/wrappers/ocikms/v2 v2.0.9`** — confirmado empiricamente.

Reverte o values.yaml standalone para Shamir manual. **Mantém kms.tf/network/etc.** do PR #212 — recursos OCI KMS ficam codificados e prontos pra uso quando a lib for corrigida.

## Bug upstream

Source [`ocikms.go:287-290 v2.0.9`](https://github.com/hashicorp/go-kms-wrapping/blob/wrappers/ocikms/v2.0.9/wrappers/ocikms/ocikms.go#L287-L290):

```go
retryOn5xxFunc := func(r common.OCIOperationResponse) bool {
    return r.Error != nil && r.Response.HTTPResponse().StatusCode >= 500
}
```

`r.Response.HTTPResponse()` chamado **sem verificar se `r.Response` é nil**. Quando algo falha antes do HTTP layer (auth signer construído errado, conn refused), `r.Error != nil` mas `r.Response` é nil → nil pointer dereference. Stack trace exato:

```
error parsing Seal configuration: failed key_id validation: error encrypting data:
panicked while retrying operation. Panic was: runtime error: invalid memory address
or nil pointer dereference

panic({0xadea2a0?, 0x16818690?})
github.com/hashicorp/go-kms-wrapping/wrappers/ocikms/v2.(*Wrapper).getRequestMetadata.func1(...)
    /home/runner/go/pkg/mod/github.com/hashicorp/go-kms-wrapping/wrappers/ocikms/v2@v2.0.9/ocikms.go:290 +0x5d
```

## Evidências coletadas

| Teste | Resultado |
|---|---|
| Pod debug com label vault, NetworkPolicy aberta — `curl IMDS` | ✅ 200/3ms |
| Pod debug — `curl https://*.kms.*.oraclecloud.com` | ✅ 401/78ms (alcançável; sem auth) |
| Pod default sem hostNetwork — `oci kms crypto encrypt` Instance Principal | ✅ Ciphertext válido |
| Vault pod (mesma config network) — `Encrypt` em validação | ❌ Panic ocikms.go:290 |

Conclusão: **encrypt funciona via Instance Principal em outros pods Go/Python**; só o Vault panica. Diferença está no path Resource Principal do Go SDK consumido por `go-kms-wrapping` — Resource Principal handler espera `OCI_RESOURCE_PRINCIPAL_*` env vars que existem em **OKE managed** mas **não em k3s self-hosted**. Quando handler retorna nil, retry policy panica por falta de nil check.

## O que muda

`environments/standalone/values.yaml`:
- Remove bloco `seal "ocikms"` do `vault.server.ha.raft.config`
- Remove `extraSecretEnvironmentVars` (env vars do KMS)
- Desliga `networkPolicy.cloudKmsEgressEnabled` (egress IMDS+HTTPS:443 não necessário)
- Comentário extenso documentando investigação completa para evitar repetir o exercício no futuro

## O que **NÃO** muda (mantém do PR #212)

- `provisioning/oci/standalone/kms.tf` — recursos OCI KMS gerenciados pelo Tofu (Story #57 entregue)
- `platform/vault/templates/networkpolicy.yaml` — flag `cloudKmsEgressEnabled` continua disponível para o dia que a lib for corrigida ou que rodemos em OKE
- `platform/vault/values.yaml` — default false, tudo opt-in

## Workarounds futuros (nenhum imediato)

1. **Fix upstream em go-kms-wrapping** — PR trivial (nil check); a abrir em hashicorp/go-kms-wrapping
2. **Migrar Vault para OKE managed** — Resource Principal nativo
3. **DaemonSet OCI Resource Principal manual** em k3s — complexo
4. **Continuar com Shamir manual** ← escolha desta sessão (operacional em POC)

## Critério de aceite

- [x] Vault standalone sai de CrashLoopBackOff após sync ArgoCD
- [x] Comentário in-line documenta investigação completa (causa raiz + evidências)
- [x] Tofu KMS preservado (não regride Story #57)
- [ ] PR mergeado
- [ ] Issue upstream em `hashicorp/go-kms-wrapping` aberta apontando linha 290 (próxima sessão)

## Riscos & rollback

- **Risco**: nenhum funcional — Vault volta ao estado pré-#212 (Shamir manual)
- **Rollback**: revert deste PR retorna ao OCI KMS broken state

Refs #57, #64, PR #212