### PR TITLE
fix(keycloak): adicionar mapper audience-uniplus ao client apicurio-registry

### DIFF
--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -154,6 +154,17 @@
             "userinfo.token.claim": "true",
             "claim.name": "groups"
           }
+        },
+        {
+          "name": "audience-uniplus",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "uniplus",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
         }
       ]
     },


### PR DESCRIPTION
## Resumo

Adiciona o protocol mapper `audience-uniplus` ao client confidential `apicurio-registry` no realm `uniplus`. Sem essa mudança, tokens emitidos via password grant por esse client não incluem `aud=uniplus`, fazendo as APIs Uni+ rejeitarem o token (audience validation do `Microsoft.AspNetCore.Authentication.JwtBearer`).

## Por que via apicurio-registry

- `uniplus-portal` é public + PKCE → `directAccessGrantsEnabled=false` → não dá pra usar password grant em smoke automatizado
- Os 3 service accounts (`uniplus-api-{portal,selecao,ingresso}`) têm `standardFlowEnabled=false` + `serviceAccountsEnabled=true` → só client_credentials, sem usuário humano
- `apicurio-registry` é o único client confidential com `directAccessGrantsEnabled=true` (já documentado como "para smoke" na própria description do client)

Tornar `apicurio-registry` capaz de emitir tokens com `aud=uniplus` permite que o smoke E2E seja **auto-suficiente** (sem browser).

## Risco

Baixo. O mapper só adiciona o claim `aud=uniplus` no access_token; não muda escopos, roles ou comportamento do client em produção (Apicurio Registry continua validando audience pra si mesmo via realm-level + outros mappers).

## Validação local

Antes:
```
JWT aud=["account"]    → API rejeita 401
```

Depois (mapper aplicado ad-hoc via kcadm para testar):
```
JWT aud=["uniplus","account"]   → API aceita 200
./scripts/test-uniplus-apis.sh: ALL PASS
```

## Plano de aplicação

1. Mergear este PR
2. ArgoCD sync → keycloak-config-cli aplica mudança no realm
3. Estado live no Keycloak já está alinhado (mudança ad-hoc preserva continuidade entre sync e merge)