### PR TITLE
fix(grafana): omitir bloco tls quando secretName vazio (Traefik CRD rejeita null)

### DIFF
--- a/platform/observability/grafana/templates/ingressroute.yaml
+++ b/platform/observability/grafana/templates/ingressroute.yaml
@@ -62,10 +62,17 @@ spec:
         - name: {{ $svcName }}
           port: {{ $svcPort }}
     {{- end }}
-  {{- if $ing.tls.enabled }}
+  {{- if and $ing.tls.enabled $ing.tls.secretName }}
   tls:
-    {{- if $ing.tls.secretName }}
     secretName: {{ $ing.tls.secretName | quote }}
-    {{- end }}
   {{- end }}
+  {{/*
+    NOTA: quando tls.enabled=true mas tls.secretName="" (cert default do Traefik
+    via cert-manager no nível do IngressRoute root), o bloco `tls:` é OMITIDO
+    aqui — o Traefik CRD rejeita `spec.tls: null` (precisa ser objeto válido
+    ou ausente). Como o entryPoint websecure já termina TLS com o default cert
+    quando há um, omitir o bloco produz o mesmo efeito sem violar o schema.
+    Padrão validado em standalone após erro:
+      "IngressRoute ... is invalid: spec.tls: Invalid value: \"null\": ..."
+  */}}
 {{- end }}


### PR DESCRIPTION
## Resumo

Template do IngressRoute do Grafana renderizava \`tls:\` sem children quando \`tls.enabled=true\` mas \`tls.secretName=\"\"\`. Traefik CRD interpreta como \`spec.tls: null\` e rejeita:

\`\`\`
IngressRoute ... is invalid: spec.tls: Invalid value: \"null\":
spec.tls in body must be of type object: \"null\"
\`\`\`

Resultado em standalone: ApplicationSet do Grafana ficava \`OutOfSync\` permanentemente; pods órfãos em estado \`Unknown\`; UI Grafana inacessível externa via Traefik.

## Cenário que dispara

\`environments/standalone/values.yaml\`:
\`\`\`yaml
grafana:
  ingressRoute:
    enabled: true
    tls:
      enabled: true
      secretName: \"\"   # ← cert default (cert-manager no IngressRoute root do FQDN compartilhado)
\`\`\`

A intenção era \"TLS sim, com cert default\" — mas o template emitia bloco \`tls:\` vazio.

## Fix

\`\`\`diff
- {{- if \$ing.tls.enabled }}
- tls:
-   {{- if \$ing.tls.secretName }}
-   secretName: {{ \$ing.tls.secretName | quote }}
-   {{- end }}
- {{- end }}
+ {{- if and \$ing.tls.enabled \$ing.tls.secretName }}
+ tls:
+   secretName: {{ \$ing.tls.secretName | quote }}
+ {{- end }}
\`\`\`

Comportamento esperado do Traefik: quando \`entryPoints\` inclui \`websecure\` mas o IngressRoute não tem bloco \`tls:\` próprio, o entryPoint usa o cert default configurado (no nosso caso, LE prod via cert-manager do IngressRoute root do FQDN). Resultado idêntico ao desejado, sem violar o schema do CRD.

## Validação

\`\`\`bash
helm template grafana-test platform/observability/grafana \\
  -f environments/standalone/values.yaml \\
  --show-only templates/ingressroute.yaml
\`\`\`

Antes: \`spec.tls:\` (sem children) → CRD rejeita.
Depois: campo \`tls\` ausente → CRD aceita; entryPoint websecure cobre TLS.

## Risco

Baixo. Cenários de uso:
- \`tls.enabled=false\`: nada muda (bloco continua suprimido).
- \`tls.enabled=true\` + \`secretName\` preenchido: nada muda (bloco renderiza igual).
- \`tls.enabled=true\` + \`secretName=\"\"\`: bloco agora é OMITIDO em vez de renderizar inválido — Traefik usa cert default, comportamento desejado pelo values.

Sem environment hoje usa \`secretName\` próprio para o Grafana — todos compartilham o cert do FQDN root.

## Plano de aplicação

1. Mergear este PR
2. ArgoCD sync → IngressRoute desaparece (ou re-renderiza correto)
3. Cleanup manual de pods Grafana \`Unknown\` se ainda existirem (não esperado — chart deve regenerar)
4. Confirmar UI <https://standalone.portaluni.com.br/grafana/> responde 200