### PR TITLE
fix(traefik): adicionar observability-grafana aos appNamespaces

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -335,6 +335,7 @@ networkPolicy:
     - vault
     - keycloak
     - minio-console-proxy
+    - observability-grafana
 
   # Backends externos ao cluster — libera egress do Traefik para data-host.
   # Necessário para Services com Endpoints manuais cujo IP é externo (ex.:


### PR DESCRIPTION
## Resumo

Sem este fix, NetworkPolicy do Traefik bloqueia egress para o pod do Grafana no namespace \`observability-grafana\` — request externo retorna **502 Bad Gateway** apesar de:

- Pod Grafana 3/3 Running, listener em :3000
- Service ClusterIP com Endpoints válidos
- IngressRoute Synced no Argo
- Probe direto Pod IP (de outro namespace) retorna 200 com \`database: ok\`

Causa: \`platform/traefik/templates/networkpolicy.yaml\` enumera apenas namespaces declarados em \`networkPolicy.appNamespaces\`. \`observability-grafana\` faltava.

## Validação

Validado live com patch JSON (ArgoCD selfHeal reverteu, comprovando que só via values persiste):

\`\`\`bash
# Após patch live com namespaceSelector observability-grafana:
$ kubectl -n traefik exec <traefik-pod> -- wget -qO- http://10.42.0.114:3000/api/health
{"database":"ok","version":"12.3.1",...}
\`\`\`

## Plano

1. Mergear → ArgoCD sync → NetworkPolicy regenerada com observability-grafana incluído
2. Confirmar HTTP 200 em \`https://standalone.portaluni.com.br/grafana/api/health\`

## Pattern

Mesmo pattern de \`uniplus\`, \`vault\`, \`keycloak\`, \`minio-console-proxy\` — cada NS consumidor de IngressRoute precisa estar declarado.