### PR TITLE
fix(grafana): desligar initChownData + fsGroupChangePolicy=OnRootMismatch

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -115,6 +115,21 @@ kubePrometheusStack:
 # K3s) e sobrescreve a URL do Prometheus datasource com o nome real do
 # Service (release name dinâmico do ApplicationSet).
 grafana:
+  # Substitui o init container `init-chown-data` (busybox 1.31.1 com
+  # capabilities.add=[CHOWN] que falha em subdirs criados pelo Grafana com
+  # mode 700 — sintoma "Permission denied" em /var/lib/grafana/{csv,pdf,png}
+  # mesmo rodando como root). Solução: kubelet faz chown nativo via
+  # fsGroupChangePolicy=OnRootMismatch durante o mount do PVC, evitando o
+  # init e o bug. Suportado em K8s ≥ 1.20 (k3s 1.31 OK).
+  initChownData:
+    enabled: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 472
+    runAsGroup: 472
+    fsGroup: 472
+    fsGroupChangePolicy: OnRootMismatch
+
   persistence:
     storageClassName: standalone-local-nvme
   grafana.ini:


### PR DESCRIPTION
## Resumo

Init container \`init-chown-data\` do chart upstream do Grafana (busybox 1.31.1 + \`capabilities.add: [CHOWN]\`) falha com \"Permission denied\" em subdirs \`/var/lib/grafana/{csv,pdf,png}\` (mode 700 criados pelo próprio Grafana), mesmo rodando como root.

Sintoma observado em standalone após qualquer restart que reuse o PVC:
\`\`\`
Init:CrashLoopBackOff
chown: /var/lib/grafana/pdf: Permission denied
chown: /var/lib/grafana/png: Permission denied
chown: /var/lib/grafana/csv: Permission denied
\`\`\`

Workaround manual (deletar subdirs via debug pod root) não persiste — Grafana recria os subdirs no próximo write e o ciclo volta na próxima reinicialização.

## Solução

1. \`grafana.initChownData.enabled: false\` — remove o init bugado.
2. \`grafana.securityContext.fsGroupChangePolicy: OnRootMismatch\` no Pod — kubelet faz chown nativo no mount do volume. \`OnRootMismatch\` só aplica quando o root do volume tem ownership diferente de \`fsGroup\` (otimização documentada em [K8s Volumes — fsGroupChangePolicy](https://kubernetes.io/docs/concepts/storage/volumes/#configure-volume-permission-and-ownership-change-policy-for-pods)), evitando full \`chown -R\` em volumes grandes.

Suportado em K8s ≥ 1.20; k3s 1.31 (standalone) OK.

## Validação

\`\`\`bash
helm template grafana platform/observability/grafana \\
  -f environments/standalone/values.yaml | \\
  grep -A3 fsGroupChange
\`\`\`

Render esperado:
- Pod spec sem \`initContainers\`
- \`securityContext.fsGroupChangePolicy: OnRootMismatch\`
- Demais campos (runAsUser=472, fsGroup=472) preservados

## Plano de aplicação

1. Mergear este PR
2. ArgoCD sync → Deployment regenerado sem init container
3. Pod restart → kubelet aplica chown automático no mount, sobe direto

## Risco

Baixo:
- \`fsGroupChangePolicy=OnRootMismatch\` é apenas otimização — comportamento fallback é o mesmo \`Always\`.
- Sem init container = menos componentes que podem falhar.
- Outros environments (sp1, sp2, pa1) não são afetados (override apenas em \`environments/standalone/values.yaml\`).