### PR TITLE
ci: bypass do gate pr-author-org-member para bots confiáveis (whitelist)

### DIFF
--- a/.github/workflows/pr-author-org-member.yml
+++ b/.github/workflows/pr-author-org-member.yml
@@ -12,7 +12,28 @@ jobs:
     name: PR author is org member
     runs-on: ubuntu-latest
     steps:
+      # Bots confiáveis instalados pelo Owner da org (Dependabot, GitHub Actions,
+      # Renovate) não são "members" no sentido organizacional — não passam pelo
+      # endpoint /collaborators/{login}/permission e nem aparecem em
+      # ?affiliation=outside. Operam com o GITHUB_TOKEN do repo, sem vetor de
+      # impersonation externa.
+      #
+      # Importante: whitelist NOMINAL (não `user.type == 'Bot'` genérico) — caso
+      # contrário qualquer GitHub App de terceiros instalado em qualquer momento
+      # passaria o gate. Para incluir um novo bot, adicionar o login aqui após
+      # revisão do Owner.
+      - name: Bypass para bots confiáveis do GitHub
+        if: |
+          github.event.pull_request.user.type == 'Bot' &&
+          contains(fromJSON('["dependabot[bot]", "github-actions[bot]", "renovate[bot]"]'), github.event.pull_request.user.login)
+        run: |
+          echo "PR autor ${{ github.event.pull_request.user.login }} é Bot confiável (whitelist) — bypass do gate org-member."
+          exit 0
+
       - name: Validate author is org member with write access
+        if: |
+          github.event.pull_request.user.type != 'Bot' ||
+          !contains(fromJSON('["dependabot[bot]", "github-actions[bot]", "renovate[bot]"]'), github.event.pull_request.user.login)
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Resumo

Aplica o mesmo fix já em produção em `uniplus-api`, `uniplus-web` e `uniplus-docs` para manter os 4 repos da org alinhados no gate `pr-author-org-member`.

## Problema

O workflow `.github/workflows/pr-author-org-member.yml` valida `author_association` contra whitelist humana. Bots (Dependabot, GitHub Actions, Renovate) retornam 404 em `/collaborators/{login}/permission`. Resultado: todo PR aberto pelo bot trava no gate.

## Fix

Step de bypass com **whitelist nominal** por `user.login`. Não é `user.type == 'Bot'` genérico — Codex P1 em `uniplus-web#372` apontou que aceitar qualquer bot abriria a porta para apps de terceiros instalados acidentalmente. Para incluir um bot novo agora é preciso editar o array, forçando trilha de auditoria.

Bots autorizados:

- `dependabot[bot]`
- `github-actions[bot]`
- `renovate[bot]`

## Histórico

- `uniplus-api` — bypass introduzido em `9b0151f` (10/05 17:56Z), versão final com whitelist em PR `#399`
- `uniplus-web` — PR `#372` (já com whitelist nominal)
- `uniplus-docs` — PR `#119` (já com whitelist nominal)
- Este PR — propagação para `uniplus-infra`

Workflow byte-idêntico aos 3 repos irmãos pós-merge.

Refs unifesspa-edu-br/uniplus-api#396
