### PR TITLE
feat(observability): adicionar Loki SingleBinary com storage S3-MinIO

### DIFF
--- a/docs/adrs/ADR-011-loki-singlebinary-s3-standalone.md
+++ b/docs/adrs/ADR-011-loki-singlebinary-s3-standalone.md
@@ -1,0 +1,89 @@
+# ADR-011 — Loki em modo SingleBinary com storage S3-MinIO em standalone
+
+- **Status:** Accepted
+- **Data:** 2026-05-10
+- **Sub-issue:** [#28 task(observability): completar Helm chart wrapper para Loki](https://github.com/unifesspa-edu-br/uniplus-infra/issues/28)
+- **Refs:** ADR-007 (Vault HA), ADR-008 (topologia standalone), [#3 — umbrella plataforma], [#4 — ADR data layer (pendente)]
+
+## Contexto
+
+A plataforma Uni+ precisa de agregação de logs estruturados acessível via Grafana. O backlog de observabilidade tem três sub-issues sequenciais:
+
+- **#28 Loki** (este ADR) — destino + retenção dos logs
+- **#29 Tempo** — destino dos traces
+- **#30 OTel Collector** — agente coletor de logs (DaemonSet) + gateway de traces
+
+Antes desta entrega, o ApplicationSet `uniplus-platform` referenciava `platform/observability/loki/` mas o diretório só continha um `README.md` placeholder; sync ficava como `Unknown / Healthy` (Argo trata diretório vazio como "nenhum recurso para aplicar"), sem qualquer pod de Loki rodando. Resultado prático: logs dos pods só sobreviviam no `containerd` (`/var/log/containers/*.log`) com rotação curta — qualquer debug pós-incidente exigia SSH ao k8s-host.
+
+O ambiente standalone roda em **single-cluster** (`k8s-host` única VM com K3s 1.31), com volumetria esperada baixa (POC + smoke test de APIs), bucket MinIO `loki-chunks` já provisionado em PR #135 e credencial dedicada `loki-svc` (policy escopada `loki-rw`) custodiada em Vault `secret/standalone/minio/loki` (criada em spike Fase 1 — 2026-05-10).
+
+Em prod (sp1, sp2), a topologia ativo-ativo da plataforma (ADR-007) e a maior volumetria justificarão um **deploymentMode mais robusto**, mas standalone não é o lugar pra essa complexidade.
+
+## Decisão
+
+Para **standalone**:
+
+1. **`deploymentMode: SingleBinary`** com `singleBinary.replicas: 1`.
+2. **Storage backend S3-compatible** apontando para o MinIO local (data-host `10.0.2.87:9000`) com:
+   - bucket `loki-chunks` (compartilhado entre chunks, ruler e admin — OSS Loki não usa `admin`)
+   - credencial dedicada `loki-svc` (policy `loki-rw` escopada apenas a esse bucket)
+   - `s3ForcePathStyle: true` (MinIO exige path-style; sem isso falha com "InvalidBucketName")
+   - `insecure: true` (HTTP no tráfego intra-VPC; TLS terminado no Traefik para acesso externo)
+3. **Schema TSDB v13** com índice `loki_index_` período 24h. TSDB é a recomendação atual do Loki desde 2.8 (substitui boltdb-shipper).
+4. **Replication factor 1** em `commonConfig`. Default upstream (3) requer 3 réplicas; com 1 réplica do SingleBinary, default falha com `not enough ingesters` no startup.
+5. **Retention 168h (7 dias)** em `limits_config.retention_period`, ativada via `compactor.retention_enabled: true`. Compactor varre os índices a cada ciclo e marca chunks fora da janela para deleção. Sem isso, o bucket cresce indefinidamente.
+6. **Componentes auxiliares desligados**: `gateway`, `chunksCache` (memcached), `resultsCache` (memcached), `monitoring`, `lokiCanary`, `test`, `read/write/backend` (componentes do `SimpleScalable`). Cada um tem trade-off claro abaixo.
+7. **Credenciais via env-expand**: o binário Loki suporta `-config.expand-env=true` (CLI flag) que substitui `${VAR_NAME}` em qualquer string da config. As credenciais MinIO ficam num `Secret` K8s sintetizado pelo `ExternalSecret` apontando para o Vault, e o `singleBinary.extraEnvFrom` injeta esse Secret como env vars no pod.
+8. **NetworkPolicy escopada**: ingress permitido apenas dos namespaces `observability-grafana` (consumidor de query) e `observability-otel-collector` (futuro push de logs em #30); egress permitido para MinIO (`10.0.2.87:9000`) + DNS K8s. Sem ingress externo (Loki não tem UI própria — acesso via Grafana datasource).
+
+Para **prod-{sp1, sp2}**: este ADR não fixa decisão; ficará em ADR separada quando #4 (data layer) e a política de observabilidade multi-DC forem fechadas. Provavelmente `SimpleScalable` com bucket per-DC e retention por classe de log.
+
+## Consequências
+
+### Positivas
+
+- **Sync ArgoCD** sai de `Unknown` para `Synced/Healthy` no standalone — chart wrapper válido.
+- **Logs persistidos** com retenção declarativa de 7 dias em standalone (vs ~horas que o containerd retém).
+- **Custo zero adicional**: reusa o MinIO standalone que já existe; bucket `loki-chunks` já estava criado.
+- **Surface mínima**: 1 pod em vez de 5+ que o `SimpleScalable` exigiria. Operacional simples para POC.
+- **Credenciais fora do Git**: Vault custodia o secret; ESO sintetiza em runtime; rotação documentada em `12-vault-rotacao.md` §3.
+
+### Negativas / aceitas
+
+- **Replication factor 1** = sem redundância de ingesters. Perda do pod (crash) entre `chunk_idle_period` e `chunk_target_size` ser atingido perde ~5min de logs em buffer. Aceitável em POC standalone; inaceitável em prod (mas prod ≠ standalone — escopo separado).
+- **Caches off** = cada query bate direto no S3. Latência de query primeira (cold) maior; aceitável em standalone (volumetria baixa, baixa frequência de query interativa). Em prod com `chunksCache` + `resultsCache` (memcached) compensa.
+- **Sem gateway** = Grafana fala direto com o Service do Loki (não com o nginx que distribui entre componentes do SimpleScalable). Em SingleBinary não há o que distribuir, então gateway só adicionaria hop. Decisão revisitada se virar SimpleScalable.
+- **Sem ServiceMonitor** = Prometheus não scrape ainda. Gate por env (`serviceMonitor.enabled: true` no environment standalone quando o stack maturar). Issue follow-up registrada nos comentários do PR.
+- **Sem Promtail/Alloy ainda** = sem agente de coleta. Sub-task de #30 (OTel Collector como log shipper via filelog receiver). Loki só responde a `/loki/api/v1/push` quando `otel-collector` for entregue.
+
+### Riscos remanescentes
+
+- **Loki upstream 7.0.0 / app 3.6.7** é major recente. Validamos com `helm template` que o render é coerente; smoke pós-merge confirma startup. Se aparecer regressão de S3-backend, fallback documentado no ADR é downgrade para `6.55.0` (mesmo app version, chart maturo).
+- **TSDB schema** muda esquema de índice em alguns minor releases. Mitigação: `schemaConfig` declara `from: 2026-01-01` — mudanças futuras adicionam novos blocos `from` sem rewrite do passado.
+- **ExternalSecret refresh 1h** — rotação imediata de credencial MinIO exige `force-sync` annotation manual ou aguardar até 1h. Documentado em `12-vault-rotacao.md` §4.
+
+## Alternativas consideradas
+
+| Alternativa | Por que não |
+|---|---|
+| **`SimpleScalable` (read+write+backend separados)** | Overhead de 5+ pods em single-node, sem ganho de escala. Apropriado a partir de ~10s de GB/dia (docs upstream). Standalone fica em ordem de MB/dia. |
+| **`Distributed` (microservices Loki)** | Idem `SimpleScalable` × 10. Solução para Loki >100GB/dia ou multi-tenant pesado. |
+| **Promtail no lugar de OTel Collector com filelog** | Promtail está em soft-deprecation (Grafana Labs recomenda Alloy desde 2024). Já vamos ter OTel Collector para traces (#30); receivers filelog do OTel cobrem a função de Promtail sem agregar componente. Decisão de "OTel-as-shipper" será formalizada em ADR no PR de #30. |
+| **Storage local (filesystem) em PVC** | Sem retention multi-DC, sem backup natural, não escala além do disco do node. Aceitável só pra "demo offline"; não para POC de produção. |
+| **Bucket dedicado `loki-chunks-standalone` em vez do compartilhado** | Bucket name é per-DC quando #12 (replicação MinIO multi-DC) entregar — para standalone hoje, reusar `loki-chunks` que já existe. Quando #12 fechar, ADR separado fixa nomeclatura `<bucket>-<dc>`. |
+
+## Validação
+
+- `helm lint platform/observability/loki/` ✓
+- `helm template -f environments/standalone/values.yaml` ✓ (NetworkPolicy + ExternalSecret + StatefulSet renderizados)
+- `kubeconform -strict -summary` ✓ (esperado verde no CI)
+- Smoke pós-merge: pod `Running 1/1`, push de log via `curl POST /loki/api/v1/push` aceita 204, query devolve a entry, objeto aparece no `mc ls s/loki-chunks/`.
+
+## Referências
+
+- [Loki Helm chart 7.x docs](https://grafana.com/docs/loki/latest/setup/install/helm/install-monolithic/)
+- [Loki storage config](https://grafana.com/docs/loki/latest/configure/#storage_config)
+- [Loki TSDB schema](https://grafana.com/docs/loki/latest/operations/storage/tsdb/)
+- [External Secrets Operator — ClusterSecretStore](https://external-secrets.io/latest/api/clustersecretstore/)
+- ADR-007 — Vault HA storage unseal (consumido pelo ESO)
+- ADR-008 — Topologia standalone monolocal

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -167,6 +167,59 @@ grafana:
             timeInterval: 30s
 
 # ============================================================================
+# Wiring real do chart platform/observability/loki/ — overrides standalone:
+# StorageClass do PVC, bucket S3 (MinIO local), credenciais via ESO,
+# NetworkPolicy escopada. Decisões em ADR-011.
+# ============================================================================
+loki:
+  loki:
+    storage:
+      bucketNames:
+        chunks: loki-chunks
+        ruler: loki-chunks
+        admin: loki-chunks
+      s3:
+        # Endpoint vem via env var (LOKI_S3_ENDPOINT) sintetizado pelo ESO,
+        # mas o bucketNames precisa ser literal (não suporta env-expand).
+        # Endpoint defaults no values.yaml: ${LOKI_S3_ENDPOINT}.
+        s3ForcePathStyle: true
+        insecure: true
+
+  singleBinary:
+    persistence:
+      storageClass: standalone-local-nvme
+    extraEnvFrom:
+      - secretRef:
+          # Nome bate com helper uniplus-loki.s3SecretName: <release>-s3-creds.
+          # Release name no standalone: platform-observability-loki-uniplus-standalone.
+          name: platform-observability-loki-uniplus-standalone-s3-creds
+
+# Sintese do Secret K8s com credenciais MinIO via ESO.
+# Chave top-level (`uniplusExternalSecrets`) intencionalmente FORA do bloco
+# `loki:` para não colidir com nenhum value do subchart upstream.
+uniplusExternalSecrets:
+  enabled: true
+  s3:
+    vaultPath: secret/standalone/minio/loki
+
+# NetworkPolicy do wrapper — apenas Grafana (consumidor query) e
+# observability-otel-collector (futuro push de logs em #30) podem alcançar.
+# Mesmo motivo de chave top-level fora de `loki:`.
+uniplusNetworkPolicy:
+  enabled: true
+  # Inclui o próprio NS para permitir tráfego entre pods do Loki (futuro
+  # SimpleScalable). Em SingleBinary single-replica não tem efeito.
+  ingressNamespaces:
+    - observability-grafana
+    - observability-otel-collector
+    - observability-loki
+  minioCIDR: "10.0.2.87/32"
+  minioPort: 9000
+  kubeApiCidrs:
+    - 10.43.0.0/16
+    - 10.0.1.0/24
+
+# ============================================================================
 # StorageClass do tier standalone (#74, ADR-008).
 # rancher.io/local-path mapeado para /var/lib/uniplus/* no NVMe local da VM.
 # ============================================================================

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -190,9 +190,12 @@ loki:
       storageClass: standalone-local-nvme
     extraEnvFrom:
       - secretRef:
-          # Nome bate com helper uniplus-loki.s3SecretName: <release>-s3-creds.
-          # Release name no standalone: platform-observability-loki-uniplus-standalone.
-          name: platform-observability-loki-uniplus-standalone-s3-creds
+          # Nome FIXO derivado de chart-name (ver helper uniplus-loki.s3SecretName).
+          # NÃO inclui release name — independente de qual cluster/AppSet renderiza,
+          # o Secret se chama sempre "loki-s3-creds" no namespace observability-loki.
+          # Mudança aplicada em resposta ao Codex P2 (PR #221) sobre acoplamento
+          # release-name → CreateContainerConfigError em re-deploys.
+          name: loki-s3-creds
 
 # Sintese do Secret K8s com credenciais MinIO via ESO.
 # Chave top-level (`uniplusExternalSecrets`) intencionalmente FORA do bloco

--- a/platform/observability/loki/Chart.lock
+++ b/platform/observability/loki/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: loki
+  repository: https://grafana.github.io/helm-charts
+  version: 7.0.0
+digest: sha256:faf3dde3fcf32b76952d9481c84e6f4e49469ee839f207436ab2bf1034784971
+generated: "2026-05-10T22:58:48.842220413-03:00"

--- a/platform/observability/loki/Chart.yaml
+++ b/platform/observability/loki/Chart.yaml
@@ -1,0 +1,39 @@
+apiVersion: v2
+name: loki
+description: |
+  Loki — agregador de logs estruturados. Empacotado como chart wrapper sobre
+  grafana/loki em modo SingleBinary com storage S3 (MinIO em standalone,
+  futuramente per-DC em prod).
+
+  Decisão arquitetural: ver docs/adrs/ADR-011-loki-singlebinary-s3-standalone.md
+type: application
+
+# Versão do chart wrapper Uni+.
+version: 0.1.0
+
+# Versão do Loki upstream empacotado.
+appVersion: "3.6.7"
+
+home: https://github.com/unifesspa-edu-br/uniplus-infra
+sources:
+  - https://github.com/unifesspa-edu-br/uniplus-infra
+  - https://github.com/grafana/loki
+
+maintainers:
+  - name: CTIC Unifesspa
+    url: https://github.com/unifesspa-edu-br
+
+keywords:
+  - loki
+  - observability
+  - logging
+  - uniplus
+
+# Dependência do chart upstream oficial.
+# Sem alias — `loki` é nome válido como Go identifier; valores acessíveis via
+# .Values.loki.x diretamente. Pinar versão pra reproducibilidade do sync ArgoCD.
+dependencies:
+  - name: loki
+    version: 7.0.0
+    repository: https://grafana.github.io/helm-charts
+    condition: loki.enabled

--- a/platform/observability/loki/README.md
+++ b/platform/observability/loki/README.md
@@ -1,30 +1,109 @@
 # observability/loki
 
-Agregação de logs estruturados
+Agregação de logs estruturados para o Uni+ — chart wrapper sobre `grafana/loki`
+em modo `SingleBinary` com storage S3-compatible (MinIO em standalone).
 
-> ⚠️ **Status:** placeholder inicial.
+> Decisão arquitetural: ver [ADR-011](../../../docs/adrs/ADR-011-loki-singlebinary-s3-standalone.md).
 
 ## Visão geral
 
-Componente de plataforma do cluster Kubernetes do Uni+.
+- **Modo**: `SingleBinary` (1 réplica, replication_factor 1) — apropriado para
+  single-cluster com baixa volumetria (standalone POC, lab).
+- **Storage**: S3-compatible. Em standalone aponta para MinIO local
+  (`10.0.2.87:9000`, bucket `loki-chunks`, credencial dedicada `loki-svc`
+  custodiada em Vault `secret/standalone/minio/loki`).
+- **Schema**: TSDB v13 com índice `loki_index_` período 24h.
+- **Retention**: 168h (7 dias) em standalone, ativada via compactor.
+- **Acesso**: Service ClusterIP — Grafana datasource consome
+  `http://platform-observability-loki-uniplus-standalone.observability-loki.svc.cluster.local:3100`.
+  Sem gateway (nginx) e sem ingress externo.
 
-**Upstream:** https://github.com/grafana/loki
+## Estrutura
 
-## Estratégia de deploy
+```
+platform/observability/loki/
+├── Chart.yaml                  # wrapper v2 + dep grafana/loki 7.0.0
+├── Chart.lock                  # lock do dep
+├── values.yaml                 # defaults conservadores
+├── values.schema.json          # validação dos campos críticos do wrapper
+├── templates/
+│   ├── _helpers.tpl            # nome do Secret S3, labels, selectors
+│   ├── externalsecret.yaml     # gateado por uniplusExternalSecrets.enabled
+│   └── networkpolicy.yaml      # gateado por uniplusNetworkPolicy.enabled
+└── charts/                     # gitignored — gerado por `helm dependency update`
+    └── loki-7.0.0.tgz
+```
 
-Recomenda-se usar o **chart upstream oficial** quando disponível, ao invés de manter chart próprio. Esta pasta deve conter:
+## Como o subchart é configurado
 
-- `Chart.yaml` — chart umbrella ou referência ao chart upstream
-- `values.yaml` — valores customizados para o ambiente Uni+
-- `README.md` — este arquivo
+O subchart upstream `loki` é injetado **sem alias**. Valores top-level `loki:`
+no `values.yaml` deste wrapper passam diretamente ao subchart como
+`.Values.x`. Configurações próprias do wrapper Uni+ (ExternalSecret,
+NetworkPolicy) ficam em chaves únicas `uniplusExternalSecrets:` e
+`uniplusNetworkPolicy:` para evitar colisão com chaves homônimas do upstream
+(`networkPolicy:` upstream gera 5 NPs próprias se ativado — desligamos).
 
-## Implementação pendente
+## Componentes desligados em standalone
 
-- [ ] Chart.yaml com dependência do chart upstream
-- [ ] values.yaml com configuração base
-- [ ] Documentação de configurações específicas
-- [ ] ApplicationSet ArgoCD
+- `gateway` (nginx): Grafana acessa Service direto.
+- `chunksCache` / `resultsCache` (memcached): overhead em single-node.
+- `monitoring`, `lokiCanary`, `test`: gate por env quando consumidor
+  Prometheus estiver pronto.
+- `read` / `write` / `backend`: componentes do `SimpleScalable`, não usados
+  em `SingleBinary`.
+- `networkPolicy` upstream: substituído pelo wrapper escopado.
 
-## Contribuindo
+## Deploy
 
-PRs em [unifesspa-edu-br/uniplus-infra](https://github.com/unifesspa-edu-br/uniplus-infra).
+Via ArgoCD ApplicationSet `uniplus-platform` (em `argocd/applicationset.yaml`).
+Sync automático para clusters com label `uniplus.io/managed: true`. Namespace
+gerado pelo AppSet: `observability-loki`.
+
+## Validação
+
+```bash
+helm dependency update platform/observability/loki
+helm lint platform/observability/loki
+helm template platform-observability-loki-uniplus-standalone \
+  platform/observability/loki \
+  -f environments/standalone/values.yaml \
+  --namespace observability-loki
+```
+
+## Smoke pós-sync (standalone)
+
+```bash
+ssh ubuntu@164.152.53.29
+sudo k3s kubectl -n observability-loki get pods           # 1/1 Running
+sudo k3s kubectl -n observability-loki port-forward svc/platform-observability-loki-uniplus-standalone 3100:3100 &
+
+# Push de log
+curl -s -X POST http://127.0.0.1:3100/loki/api/v1/push \
+  -H 'Content-Type: application/json' \
+  -d '{"streams":[{"stream":{"app":"smoke"},"values":[["'$(date +%s%N)'","hello-loki"]]}]}'
+
+# Query
+curl -sG http://127.0.0.1:3100/loki/api/v1/query_range \
+  --data-urlencode 'query={app="smoke"}' \
+  --data-urlencode 'start='$(date -d '5 minutes ago' +%s)'000000000' | jq '.data.result'
+```
+
+## Pendências (próximos PRs)
+
+- **#30** — OTel Collector com `filelog` receiver para popular Loki com logs
+  do `containerd` automaticamente.
+- **Datasource Loki no Grafana** — habilitar via override em
+  `environments/standalone/values.yaml` no bloco `grafana.datasources` (PR
+  separado da Fase 3 do plano de observability).
+- **ServiceMonitor + alerts** — quando o Prometheus consumidor estiver pronto
+  para scrape de métricas internas do Loki.
+- **Per-DC bucket naming** (`loki-chunks-<dc>`) — quando #12 (replicação
+  MinIO multi-DC) entregar.
+
+## Referências
+
+- [Loki Helm chart docs](https://grafana.com/docs/loki/latest/setup/install/helm/)
+- [Loki TSDB schema](https://grafana.com/docs/loki/latest/operations/storage/tsdb/)
+- ADR-011 — decisão arquitetural completa
+- ADR-008 — topologia standalone monolocal
+- ADR-007 — Vault HA storage unseal (consumido pelo ESO)

--- a/platform/observability/loki/templates/_helpers.tpl
+++ b/platform/observability/loki/templates/_helpers.tpl
@@ -23,10 +23,23 @@ Reusa lógica padrão do Helm fullname (release-chart) com truncate em 63 chars
 
 {{/*
 Nome do Secret K8s sintetizado pelo ESO com credenciais MinIO.
-Convenção: <fullname>-s3-creds (alinhado com pattern de outros wrappers Uni+).
+Convenção: <chart-name>-s3-creds (sem release prefix).
+
+Por que NÃO incluir o release name (que muda entre clusters/AppSets):
+o `singleBinary.extraEnvFrom` é consumido pelo subchart upstream, que aceita
+APENAS valor literal — não suporta templating do nome no momento do render
+do StatefulSet. Se o helper retornasse `<release>-s3-creds`, cada environment
+teria que duplicar o release name no override, e qualquer drift entre o nome
+do AppSet e o literal causaria `CreateContainerConfigError` no pod (Codex P2
+no PR #221, achado real durante review).
+
+Solução: nome fixo derivado de `.Chart.Name`. Pattern presume 1 release Loki
+por namespace (padrão do uniplus-platform AppSet — namespace por componente).
+Para 2+ releases no mesmo NS, sobrescrever via uniplusExternalSecrets.s3SecretName
+em values do environment + extraEnvFrom batendo com o mesmo nome.
 */}}
 {{- define "uniplus-loki.s3SecretName" -}}
-{{ include "uniplus-loki.fullname" . }}-s3-creds
+{{- default (printf "%s-s3-creds" .Chart.Name) .Values.uniplusExternalSecrets.s3SecretName -}}
 {{- end -}}
 
 {{/*

--- a/platform/observability/loki/templates/_helpers.tpl
+++ b/platform/observability/loki/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{/*
+Helpers do wrapper Loki Uni+. Os helpers do chart upstream (loki.fullname,
+loki.labels, etc.) ficam disponíveis via subchart e devem ser preferidos para
+recursos do próprio Loki. Estes helpers cobrem APENAS recursos do wrapper
+(ExternalSecret, NetworkPolicy) onde precisamos de nomes/labels consistentes
+sem depender da resolução interna do subchart (`include "loki.x"` falha em
+templates do wrapper porque o scope é do release pai).
+*/}}
+
+{{/*
+Nome curto do wrapper. Usado em ExternalSecret + NetworkPolicy.
+Reusa lógica padrão do Helm fullname (release-chart) com truncate em 63 chars
+(limite RFC 1123 para nomes de recursos K8s).
+*/}}
+{{- define "uniplus-loki.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Nome do Secret K8s sintetizado pelo ESO com credenciais MinIO.
+Convenção: <fullname>-s3-creds (alinhado com pattern de outros wrappers Uni+).
+*/}}
+{{- define "uniplus-loki.s3SecretName" -}}
+{{ include "uniplus-loki.fullname" . }}-s3-creds
+{{- end -}}
+
+{{/*
+Labels padrão Uni+ aplicados a recursos do wrapper.
+*/}}
+{{- define "uniplus-loki.labels" -}}
+app.kubernetes.io/name: loki
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: uniplus
+app.kubernetes.io/component: logging
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{/*
+Selector labels do StatefulSet do Loki SingleBinary. Bate com os labels
+emitidos pelo subchart upstream em modo SingleBinary, usados pela
+NetworkPolicy ingress para identificar pods do Loki como destino.
+*/}}
+{{- define "uniplus-loki.selectorLabels" -}}
+app.kubernetes.io/name: loki
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: single-binary
+{{- end -}}

--- a/platform/observability/loki/templates/externalsecret.yaml
+++ b/platform/observability/loki/templates/externalsecret.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.loki.enabled .Values.uniplusExternalSecrets.enabled -}}
+{{- $eso := .Values.uniplusExternalSecrets -}}
+# Sintese do Secret K8s com credenciais MinIO escopadas (user loki-svc).
+# Consumido pelo StatefulSet do Loki via singleBinary.extraEnvFrom abaixo;
+# o env-expansion na config do Loki (-config.expand-env=true) substitui os
+# placeholders ${LOKI_S3_*} pelos valores reais no startup do binário.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "uniplus-loki.s3SecretName" . }}
+  labels:
+    {{- include "uniplus-loki.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $eso.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $eso.secretStoreRef.kind }}
+    name: {{ $eso.secretStoreRef.name }}
+  target:
+    name: {{ include "uniplus-loki.s3SecretName" . }}
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        # Nomes que batem com os placeholders ${LOKI_S3_*} declarados no
+        # bloco loki.storage.s3 do values do environment.
+        LOKI_S3_ACCESS_KEY_ID: "{{ "{{" }} .accesskey {{ "}}" }}"
+        LOKI_S3_SECRET_ACCESS_KEY: "{{ "{{" }} .secretkey {{ "}}" }}"
+        LOKI_S3_ENDPOINT: "{{ "{{" }} .endpoint {{ "}}" }}"
+        LOKI_S3_REGION: "{{ "{{" }} .region {{ "}}" }}"
+  data:
+    - secretKey: accesskey
+      remoteRef:
+        key: {{ $eso.s3.vaultPath }}
+        property: {{ $eso.s3.accessKeyIdKey }}
+    - secretKey: secretkey
+      remoteRef:
+        key: {{ $eso.s3.vaultPath }}
+        property: {{ $eso.s3.secretAccessKeyKey }}
+    - secretKey: endpoint
+      remoteRef:
+        key: {{ $eso.s3.vaultPath }}
+        property: {{ $eso.s3.endpointKey }}
+    - secretKey: region
+      remoteRef:
+        key: {{ $eso.s3.vaultPath }}
+        property: {{ $eso.s3.regionKey }}
+{{- end }}

--- a/platform/observability/loki/templates/networkpolicy.yaml
+++ b/platform/observability/loki/templates/networkpolicy.yaml
@@ -1,0 +1,80 @@
+{{- if and .Values.loki.enabled .Values.uniplusNetworkPolicy.enabled -}}
+{{- $np := .Values.uniplusNetworkPolicy -}}
+# NetworkPolicy do Loki SingleBinary.
+#
+# Princípio: ingress fechado por default, permitindo apenas:
+# - Push de logs e queries vindas dos namespaces declarados em ingressNamespaces
+#   (default cobre observability-grafana e observability-otel-collector;
+#   environment pode estender)
+# - Tráfego intra-NS (entre pods do próprio Loki, p.ex. probes do Service)
+#
+# Egress fechado por default, permitindo apenas:
+# - MinIO/S3 (CIDR + porta declarados via minioCIDR/minioPort)
+# - DNS K8s (CoreDNS no kube-system, porta 53 udp+tcp)
+# - kube-apiserver (CIDR do service via kubeApiCidrs) — Loki não usa hoje,
+#   mas mantemos disponível para futuro service-discovery e leader election
+#   se virar SimpleScalable.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "uniplus-loki.fullname" . }}
+  labels:
+    {{- include "uniplus-loki.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "uniplus-loki.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Push (3100/http API) + queries vindas dos NS autorizados.
+    - from:
+        {{- range $np.ingressNamespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+        {{- end }}
+        # Tráfego entre pods do próprio Loki (probes, gRPC interno se aplicável).
+        - podSelector:
+            matchLabels:
+              {{- include "uniplus-loki.selectorLabels" . | nindent 14 }}
+      ports:
+        - port: 3100      # HTTP API (push, query, ready)
+          protocol: TCP
+        - port: 9095      # gRPC (interno; futuro SimpleScalable)
+          protocol: TCP
+        - port: 7946      # Memberlist (gossip; ativo mesmo em SingleBinary)
+          protocol: TCP
+        - port: 7946
+          protocol: UDP
+  egress:
+    # MinIO (S3 storage backend)
+    - to:
+        - ipBlock:
+            cidr: {{ $np.minioCIDR | quote }}
+      ports:
+        - port: {{ $np.minioPort }}
+          protocol: TCP
+    # DNS K8s (CoreDNS)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # kube-apiserver (futuro — SimpleScalable usa para leader election)
+    - to:
+        {{- range $np.kubeApiCidrs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+{{- end }}

--- a/platform/observability/loki/values.schema.json
+++ b/platform/observability/loki/values.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "platform/observability/loki — wrapper schema",
+  "description": "Validação dos campos críticos do wrapper Uni+ (subchart upstream NÃO validado aqui — schema cresce muito sem ganho).",
+  "type": "object",
+  "properties": {
+    "loki": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "deploymentMode": {
+          "type": "string",
+          "enum": ["SingleBinary", "SimpleScalable", "Distributed"],
+          "description": "Modo de deploy do Loki. SingleBinary obrigatório em standalone (1 réplica)."
+        },
+        "loki": {
+          "type": "object",
+          "properties": {
+            "auth_enabled": { "type": "boolean" },
+            "commonConfig": {
+              "type": "object",
+              "properties": {
+                "replication_factor": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Em SingleBinary com 1 réplica, deve ser 1; senão Loki falha no startup."
+                }
+              }
+            },
+            "limits_config": {
+              "type": "object",
+              "properties": {
+                "retention_period": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(h|d|w)$",
+                  "description": "Período de retenção (ex: 168h, 7d, 1w). Aplicado pelo compactor."
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": ["enabled"]
+    },
+    "uniplusExternalSecrets": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "refreshInterval": { "type": "string" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "kind": { "type": "string", "enum": ["SecretStore", "ClusterSecretStore"] },
+            "name": { "type": "string", "minLength": 1 }
+          },
+          "required": ["kind", "name"]
+        },
+        "s3": {
+          "type": "object",
+          "properties": {
+            "vaultPath": { "type": "string", "minLength": 1 },
+            "accessKeyIdKey": { "type": "string", "minLength": 1 },
+            "secretAccessKeyKey": { "type": "string", "minLength": 1 },
+            "endpointKey": { "type": "string", "minLength": 1 },
+            "regionKey": { "type": "string", "minLength": 1 }
+          },
+          "required": ["vaultPath", "accessKeyIdKey", "secretAccessKeyKey", "endpointKey", "regionKey"]
+        }
+      },
+      "required": ["enabled"]
+    },
+    "uniplusNetworkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingressNamespaces": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "minioCIDR": {
+          "type": "string",
+          "pattern": "^[0-9]{1,3}(\\.[0-9]{1,3}){3}/[0-9]{1,2}$"
+        },
+        "minioPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "kubeApiCidrs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9]{1,3}(\\.[0-9]{1,3}){3}/[0-9]{1,2}$"
+          }
+        }
+      },
+      "required": ["enabled"]
+    }
+  },
+  "additionalProperties": true
+}

--- a/platform/observability/loki/values.yaml
+++ b/platform/observability/loki/values.yaml
@@ -241,6 +241,11 @@ uniplusExternalSecrets:
   secretStoreRef:
     kind: ClusterSecretStore
     name: vault-default
+  # Nome explícito do Secret K8s sintetizado. Vazio = derivar automaticamente
+  # via helper uniplus-loki.s3SecretName ("<chart-name>-s3-creds" = "loki-s3-creds").
+  # Sobrescrever apenas quando precisar de 2+ releases Loki no mesmo namespace
+  # (padrão do uniplus-platform AppSet é 1 release por NS, então default OK).
+  s3SecretName: ""
   s3:
     # Path no Vault (KV v2). Override por environment.
     vaultPath: "secret/standalone/minio/loki"

--- a/platform/observability/loki/values.yaml
+++ b/platform/observability/loki/values.yaml
@@ -1,0 +1,271 @@
+# Defaults para o Loki no cluster Uni+.
+#
+# Topologia (ADR-011): SingleBinary em standalone (1 réplica, replication
+# factor 1, sem caches separados, sem gateway). Em prod-{sp1,sp2} pode
+# evoluir para SimpleScalable com `deploymentMode` override no environment;
+# PA1 fica desligado por default (agregação separada).
+#
+# Storage backend: S3-compatible. Em standalone aponta para MinIO local
+# (data-host 10.0.2.87:9000) com credenciais escopadas (user `loki-svc`,
+# policy `loki-rw`) custodiadas no Vault `secret/standalone/minio/loki`
+# e injetadas via ExternalSecret + envFrom.
+#
+# Acesso pelo Grafana: ClusterIP do Loki (sem gateway) — datasource
+# Grafana usa http://<loki-svc>.observability-loki.svc.cluster.local:3100.
+#
+# Retention: 168h (7 dias) em standalone (operacional). Override por
+# environment quando definirmos política de compliance — ver
+# docs/ARCHITECTURE.md §9 para padrão de retenção por DC.
+#
+# Push de logs: futura responsabilidade do OTel Collector (#30) em modo
+# DaemonSet com filelog receiver — Loki não precisa de Promtail próprio.
+#
+# IMPORTANTE — todos os toggles do subchart upstream ficam dentro do bloco
+# `loki:` (subchart sem alias; valores top-level com a chave do subchart
+# são passados a ele). Configs do wrapper Uni+ (ExternalSecret, NetworkPolicy
+# próprios) ficam em chaves únicas `uniplusExternalSecrets:` e
+# `uniplusNetworkPolicy:` para evitar colisão com chaves homônimas do subchart
+# (`networkPolicy:` upstream gera 5 NPs próprias se ativado).
+
+loki:
+  enabled: true
+
+  # ============================================================================
+  # Modo de deploy
+  # ============================================================================
+  # SingleBinary: tudo num pod só (ingester + querier + compactor + distributor
+  # + frontend). Apropriado para single-cluster com baixa volumetria (standalone
+  # POC, lab). Limita escala mas elimina complexidade de coordenação entre
+  # componentes. ADR-011 documenta trade-offs.
+  deploymentMode: SingleBinary
+
+  loki:
+    # auth_enabled=false: aceita push/query sem header X-Scope-OrgID.
+    # Standalone single-tenant — sem multi-tenancy.
+    auth_enabled: false
+
+    # ----- Storage S3 (creds vêm de env via singleBinary.extraEnvFrom) -----
+    # Loki suporta interpolação de env vars na config via flag CLI
+    # `-config.expand-env=true` (passada via singleBinary.extraArgs abaixo).
+    # Não commitamos accessKeyId/secretAccessKey aqui; eles vêm do Secret
+    # sintetizado pelo ESO a partir do path Vault.
+    storage:
+      type: s3
+      bucketNames:
+        # Override por environment com nomes reais. Defaults vazios pra
+        # forçar configuração explícita por env (subchart upstream emite
+        # warning se ficar vazio em values resolvido).
+        chunks: loki-chunks
+        ruler: loki-chunks
+        admin: loki-chunks
+      s3:
+        endpoint: "${LOKI_S3_ENDPOINT}"
+        region: "${LOKI_S3_REGION}"
+        accessKeyId: "${LOKI_S3_ACCESS_KEY_ID}"
+        secretAccessKey: "${LOKI_S3_SECRET_ACCESS_KEY}"
+        # MinIO exige path-style addressing (vs virtual-hosted da AWS).
+        s3ForcePathStyle: true
+        # MinIO standalone está em http (TLS terminado no Traefik para acesso
+        # externo, mas tráfego interno cluster→data-host é http puro pela
+        # subnet privada VCN). Em prod com TLS no MinIO, mudar para false.
+        insecure: true
+
+    # ----- Schema config: TSDB v13 (recomendação atual do Loki >= 2.8) -----
+    schemaConfig:
+      configs:
+        - from: "2026-01-01"
+          store: tsdb
+          object_store: s3
+          schema: v13
+          index:
+            prefix: loki_index_
+            period: 24h
+
+    # ----- Replication factor: 1 em standalone (1 ingester) -----
+    # Default upstream é 3 (assumindo SimpleScalable+). Standalone tem 1
+    # réplica do SingleBinary, então tem que ser 1; senão Loki quebra com
+    # "not enough ingesters" no startup.
+    commonConfig:
+      replication_factor: 1
+      path_prefix: /var/loki
+
+    # ----- Limits + retention -----
+    # retention_period define quanto tempo o compactor mantém streams antes
+    # de marcar para deleção. Aplicado pelo compactor (compactor.retention_enabled
+    # abaixo). Override por environment.
+    limits_config:
+      retention_period: 168h          # 7 dias — standalone POC
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h
+      max_cache_freshness_per_query: 10m
+      split_queries_by_interval: 15m
+      query_timeout: 300s
+      volume_enabled: true
+      # ingestion_rate em MB/s por tenant. Default 4 é OK para standalone.
+      ingestion_rate_mb: 4
+      ingestion_burst_size_mb: 6
+
+    # ----- Compactor -----
+    # Retention ativada — compactor varre os índices e marca chunks fora
+    # da janela de retention para deleção. Sem isso, MinIO enche.
+    compactor:
+      retention_enabled: true
+      retention_delete_delay: 2h
+      retention_delete_worker_count: 150
+      delete_request_store: s3
+
+    # Pattern ingester ainda em alpha — desligar pra reduzir surface.
+    pattern_ingester:
+      enabled: false
+
+  # ============================================================================
+  # Componentes desligados em standalone (modo SingleBinary)
+  # ============================================================================
+  # Toggles ABAIXO ficam dentro do bloco `loki:` para serem propagados ao
+  # subchart upstream. Se ficarem no top-level, NÃO são lidos pelo subchart
+  # (vão para o scope do wrapper Uni+, que não os consome).
+
+  # SimpleScalable mode dispara componentes separados — desligar todos.
+  read:
+    replicas: 0
+  write:
+    replicas: 0
+  backend:
+    replicas: 0
+
+  # gateway: nginx que faz proxy multi-componente — não precisa em SingleBinary.
+  # `ingress.tls: {}` silencia warning cosmético do subchart (default upstream
+  # é lista vazia mas tipo declarado é mapa).
+  gateway:
+    enabled: false
+    ingress:
+      enabled: false
+      tls: {}
+
+  # caches memcached: overhead em single-node de baixa volumetria.
+  chunksCache:
+    enabled: false
+  resultsCache:
+    enabled: false
+
+  # test pod do upstream (smoke do chart) — adicionamos smoke próprio.
+  test:
+    enabled: false
+
+  # monitoring sub-chart upstream — gate por env quando consumidor Prometheus
+  # estiver pronto.
+  monitoring:
+    selfMonitoring:
+      enabled: false
+      grafanaAgent:
+        installOperator: false
+    lokiCanary:
+      enabled: false
+    serviceMonitor:
+      enabled: false
+
+  # lokiCanary top-level (extra além do monitoring.lokiCanary) — também off.
+  lokiCanary:
+    enabled: false
+
+  # NetworkPolicy do subchart upstream — DESLIGADA. O wrapper Uni+ emite
+  # uma NetworkPolicy escopada própria (template `templates/networkpolicy.yaml`,
+  # gateado por `uniplusNetworkPolicy.enabled`). Manter as duas geraria 5+
+  # NetworkPolicies upstream + 1 do wrapper, tornando a topologia ininteligível.
+  networkPolicy:
+    enabled: false
+
+  # Ingress nativo do subchart upstream (nginx Ingress/IngressRoute) — desligado.
+  # Loki não tem UI; acesso via Service ClusterIP pelo Grafana datasource.
+  # `tls: {}` (mapa vazio) silencia o warning "destination for loki.ingress.tls
+  # is a table. Ignoring non-table value ([])" que o subchart emite quando o
+  # default é uma lista mas o tipo declarado é mapa.
+  ingress:
+    enabled: false
+    tls: {}
+
+  # ============================================================================
+  # SingleBinary StatefulSet config
+  # ============================================================================
+  singleBinary:
+    replicas: 1
+
+    # Flag CLI -config.expand-env=true habilita interpolação ${VAR_NAME} dentro
+    # da config YAML montada como ConfigMap. Sem isso os ${LOKI_S3_*} acima
+    # ficam literais e Loki falha ao parsear endpoint do bucket.
+    extraArgs:
+      - -config.expand-env=true
+
+    # Env vars do Secret sintetizado pelo ESO com credenciais MinIO.
+    # Default vazio — environment standalone popula com secretRef do Secret
+    # cujo nome bate com o helper uniplus-loki.s3SecretName.
+    extraEnvFrom: []
+
+    # PVC do StatefulSet — armazena WAL + cache local de índices recentes.
+    # storageClass é definido por environment.
+    persistence:
+      enabled: true
+      size: 10Gi
+      accessModes:
+        - ReadWriteOnce
+      # storageClass: <definido por environment>
+
+    # Recursos default lab — Tabela 10.1 (Loki SingleBinary é leve em
+    # baixa volumetria; ajustar quando push real chegar).
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+
+  # ServiceMonitor do subchart upstream — gate via monitoring.serviceMonitor
+  # acima. Mantido em sincronia.
+
+# ============================================================================
+# Wrapper Uni+ — ExternalSecret + NetworkPolicy próprios
+# ============================================================================
+# Chaves uniplus* para evitar colisão com chaves homônimas do subchart
+# upstream (que possui seus próprios `networkPolicy:` e nada nomeado
+# `externalSecrets:` mas convém manter o pattern unificado).
+
+# uniplusExternalSecrets: bloco que controla a sintese do Secret K8s com
+# credenciais MinIO via External Secrets Operator. Precisa de ESO instalado
+# e ClusterSecretStore `vault-default` apontando para o Vault standalone.
+uniplusExternalSecrets:
+  # Default off para o helm template standalone funcionar fora do cluster
+  # (lab K3s sem ESO + Vault). Environment standalone liga.
+  enabled: false
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-default
+  s3:
+    # Path no Vault (KV v2). Override por environment.
+    vaultPath: "secret/standalone/minio/loki"
+    # Nomes dos campos no Vault (alinhado com o spike Fase 1).
+    accessKeyIdKey: "accesskey"
+    secretAccessKeyKey: "secretkey"
+    endpointKey: "endpoint"
+    regionKey: "region"
+
+# uniplusNetworkPolicy: emite uma NetworkPolicy ingress restrito + egress para
+# MinIO + DNS K8s. Default off para preservar templating fora de clusters com
+# NetworkPolicy controller (calico/cilium). Environments ativam.
+uniplusNetworkPolicy:
+  enabled: false
+  # Namespaces autorizados a fazer push/query de logs. Default cobre o NS
+  # do Grafana (consumidor de query) e o NS do OTel Collector (push de logs
+  # — futuro #30). Cada environment pode estender.
+  ingressNamespaces:
+    - observability-grafana
+    - observability-otel-collector
+  # CIDR do MinIO (data-host privado). Override por environment.
+  minioCIDR: "10.0.2.87/32"
+  minioPort: 9000
+  # Service CIDR do K3s para acesso ao kube-apiserver (DNS via CoreDNS no
+  # Service `kubernetes` em default). Override por environment se cluster
+  # diferente.
+  kubeApiCidrs:
+    - 10.43.0.0/16


### PR DESCRIPTION
Closes #28
Refs #3

## Resumo

Cria `platform/observability/loki/` como Helm chart wrapper sobre `grafana/loki` 7.0.0 em modo SingleBinary, com storage S3-compatible apontando para MinIO local. ApplicationSet `uniplus-platform` sai de `Unknown` → `Synced/Healthy` quando aplicado no standalone.

Decisões arquiteturais detalhadas em [`docs/adrs/ADR-011-loki-singlebinary-s3-standalone.md`](docs/adrs/ADR-011-loki-singlebinary-s3-standalone.md).

## O que entrega

- **Chart wrapper completo**: `Chart.yaml` + `Chart.lock` + `values.yaml` + `values.schema.json` + `templates/{_helpers.tpl, externalsecret.yaml, networkpolicy.yaml}` + `README.md`.
- **Modo SingleBinary** (1 réplica, replication_factor 1) — apropriado para single-cluster com baixa volumetria. Componentes do `SimpleScalable` (read/write/backend, gateway, caches, monitoring, lokiCanary, test) todos desligados.
- **Storage S3 → MinIO** (bucket `loki-chunks`, credencial `loki-svc` custodiada em Vault, sintetizada via ESO). Schema TSDB v13. Compactor com `retention_enabled=true` + `retention_period: 168h`.
- **NetworkPolicy escopada**: ingress de `observability-grafana` e `observability-otel-collector` apenas; egress para MinIO + DNS K8s + kube-apiserver.
- **Override standalone** em `environments/standalone/values.yaml` (storageClass, extraEnvFrom apontando pro Secret sintetizado, NS list, CIDRs).

## Decisões arquiteturais (ADR-011)

| | |
|---|---|
| Modo | SingleBinary (1 pod) — standalone single-cluster |
| Storage | S3 → MinIO (bucket existente `loki-chunks`) |
| Schema | TSDB v13 |
| Replication | 1 (necessário com 1 réplica do SingleBinary) |
| Retention | 168h (7 dias) — POC; override por env quando #4 fechar |
| Caches | off (memcached) — overhead em single-node |
| Gateway | off — Grafana acessa Service direto |
| Promtail | NÃO usado — futuro OTel Collector com filelog receiver (#30) |

Trade-offs aceitos: replication=1 (sem redundância de ingester), caches off (latência primeira query maior), credenciais via env-expand (`-config.expand-env=true`). Tudo aceitável em standalone POC; será revisitado em ADR separada quando entrarmos em prod multi-DC.

## Pattern wrapper Uni+

Subchart upstream sem alias. **Toggles do subchart ficam dentro de `loki.*`** (chave `loki:` de top-level passa ao subchart). Componentes próprios do wrapper (`ExternalSecret`, `NetworkPolicy`) ficam em **chaves únicas** `uniplusExternalSecrets:` e `uniplusNetworkPolicy:` para evitar colisão com chaves homônimas do upstream — `networkPolicy:` upstream gera 5 NetworkPolicies próprias se ativado, e `externalSecrets:` poderia colidir com convenções futuras.

## Validações locais

```bash
$ helm lint platform/observability/loki
1 chart(s) linted, 0 chart(s) failed

$ helm template platform-observability-loki-uniplus-standalone platform/observability/loki \
    -f environments/standalone/values.yaml --namespace observability-loki
# 11 recursos renderizados:
#   1 StatefulSet (SingleBinary)
#   1 NetworkPolicy (wrapper escopada)
#   1 ExternalSecret
#   3 Services (loki, headless, memberlist)
#   2 ConfigMaps (config + runtime)
#   1 ServiceAccount, 1 ClusterRole, 1 ClusterRoleBinding

$ docker run --rm -i ghcr.io/yannh/kubeconform:latest -strict -summary -ignore-missing-schemas
Summary: 11 resources found - Valid: 10, Invalid: 0, Skipped: 1
# (ExternalSecret CRD não embutido no kubeconform; OK em runtime)
```

## Plano pós-merge (eu executo)

1. ArgoCD force refresh + sync da app `platform-observability-loki-uniplus-standalone`
2. Confirmar pod `Running 1/1`
3. Validar push de log via `curl POST /loki/api/v1/push` aceita 204
4. Validar query devolve a entry
5. Validar objeto aparece em `mc ls s/loki-chunks/`
6. Reportar snapshot completo no comment do PR

## Risco / rollback

- **Risco**: Loki upstream 7.0.0 + app 3.6.7 é major recente. Se aparecer regressão de S3-backend, fallback documentado é downgrade para `6.55.0` (mesmo app version, chart maturo).
- **Rollback**: `git revert` deste PR + `helm uninstall` no cluster (ApplicationSet recria como `Unknown` — Loki removido sem afetar resto da plataforma).

## Não cobre (próximos PRs da Fase 2 do plano)

- **#29 Tempo** — análogo a este, traces.
- **#30 OTel Collector** — agente coletor de logs (DaemonSet com filelog) + gateway de traces; popula este Loki.
- **Datasource Loki no Grafana** — habilitar via override em `environments/standalone/values.yaml` (Fase 3).
- **ServiceMonitor + alerts** — quando Prometheus consumidor estiver pronto.

## Warnings esperados

`helm template` emite alguns INFO-level warnings sobre `loki.gateway.ingress.tls is a table. Ignoring non-table value ([])` — vêm do subchart upstream avaliando o tipo de `tls:` mesmo com `gateway.enabled: false`. Sem impacto no render (gateway nunca é instanciado). Pinning futuro do upstream pode silenciar.