### PR TITLE
feat(vault): bootstrap declarativo do engine Transit no standalone

### DIFF
--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -113,6 +113,7 @@ spec:
                 - component: external-secrets
                 - component: vault
                 - component: vault-transit
+                - component: vault-transit-bootstrap
                 - component: cloudflared
                 - component: observability/prometheus
                 - component: observability/grafana

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -3386,4 +3386,83 @@ kc annotate -n uniplus externalsecret \
 
 ---
 
+## 17. Vault Transit bootstrap (standalone)
+
+Chart `platform/vault-transit-bootstrap/` (issue [#219](https://github.com/unifesspa-edu-br/uniplus-infra/issues/219)) reconcilia declarativamente o engine `transit` no Vault local em cada deploy.
+
+Recursos gerenciados:
+
+- Mount `transit/` no Vault.
+- Key `uniplus-idempotency-aesgcm` (AES-GCM-256, `deletion_allowed=false`, `exportable=false`).
+- Policy `uniplus-api-transit` (apenas `update` em `transit/encrypt|decrypt/uniplus-idempotency-aesgcm`).
+- Role K8s auth `uniplus-api` (bound à SA `uniplus-api`/ns `uniplus`, TTL token 1h).
+
+O Job roda no namespace `vault-transit-bootstrap`, consome `VAULT_TOKEN` via ExternalSecret (ClusterSecretStore `vault-default`, path `secret/standalone/vault/root`) e executa o script `files/bootstrap-vault-transit.sh` embarcado como ConfigMap.
+
+### 17.1 Verificar saúde
+
+Obter o root token previamente do cofre institucional (`~/configs/uniplus-standalone/` no host do operador, ou gestor de segredos corporativo); jamais embarcar literal em documento ou pipeline.
+
+```bash
+# Substituir <k8s-host> pelo endereço SSH do operador e <root-token> pelo
+# valor obtido localmente. Token nunca pode ser logado ou commitado.
+ssh -i ~/.ssh/id_ed25519 ubuntu@<k8s-host> "
+  sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
+    -n vault exec -i platform-vault-uniplus-standalone-0 -- \
+    sh -c 'export VAULT_TOKEN=<root-token>;
+           echo --- secrets list ---;
+           vault secrets list | grep transit;
+           echo --- transit key ---;
+           vault read transit/keys/uniplus-idempotency-aesgcm;
+           echo --- auth role ---;
+           vault read auth/kubernetes/role/uniplus-api;
+           echo --- policy ---;
+           vault policy read uniplus-api-transit'
+"
+```
+
+Saída esperada (excerto):
+
+- `transit/` aparece em `vault secrets list`.
+- `transit/keys/uniplus-idempotency-aesgcm` mostra `type=aes256-gcm96`, `deletion_allowed=false`, `exportable=false`.
+- `auth/kubernetes/role/uniplus-api` mostra `bound_service_account_names=[uniplus-api]`, `bound_service_account_namespaces=[uniplus]`, `policies=[uniplus-api-transit]`, `ttl=1h`.
+- `uniplus-api-transit` lista as duas capabilities `update` em `transit/encrypt|decrypt/uniplus-idempotency-aesgcm`.
+
+### 17.2 Rotacionar a key
+
+```bash
+vault write -f transit/keys/uniplus-idempotency-aesgcm/rotate
+```
+
+Vault Transit preserva todas as versões anteriores: requests de `decrypt` continuam decodificando ciphertexts antigos. Consumidores que querem re-encrypt para a versão mais nova podem chamar `vault write transit/rewrap/uniplus-idempotency-aesgcm ciphertext=...` ou aceitar que ciphertexts antigos permanecem na versão antiga até reescrita natural.
+
+### 17.3 Revogar a role em incidente
+
+```bash
+vault delete auth/kubernetes/role/uniplus-api
+```
+
+Efeito imediato: novos logins K8s auth falham com `permission denied`. Pods existentes da `uniplus-api` continuam com tokens já emitidos (TTL 1h, sem renovação possível). Restartar os pods força nova autenticação que falha, e o `EncryptionOptionsValidator` da uniplus-api (PR [#401](https://github.com/unifesspa-edu-br/uniplus-api/pull/401) / [#403](https://github.com/unifesspa-edu-br/uniplus-api/pull/403)) já garante que pods sem auth válido caem em `CrashLoopBackOff` em vez de servir 500 silencioso.
+
+Para reativar após mitigar o incidente: re-aplicar o chart (`argocd app sync platform-vault-transit-bootstrap-uniplus-standalone`).
+
+### 17.4 Limpar manualmente (não-GitOps)
+
+`helm uninstall` deleta o Job/CM/SA/ES/NP mas **não** remove o mount transit/key/policy/role do Vault — comportamento intencional para evitar perda de dados cifrados durante operações de manutenção do chart. Para cleanup completo (cenário raro: refactor da topologia de cifragem):
+
+```bash
+vault delete auth/kubernetes/role/uniplus-api
+vault policy delete uniplus-api-transit
+# Key só pode ser deletada após habilitar deletion_allowed:
+vault write transit/keys/uniplus-idempotency-aesgcm/config deletion_allowed=true
+vault delete transit/keys/uniplus-idempotency-aesgcm
+vault secrets disable transit
+```
+
+### 17.5 Trade-off do token bootstrap
+
+O `ExternalSecret` deste chart consome o **root token** do Vault em standalone. Isso é deliberadamente excessivo para o escopo de bootstrap (`sys/mounts`, `transit/*`, `sys/policies/acl`, `auth/kubernetes/role`) e deve ser reduzido antes da Fase 6. Plano em `platform/vault-transit-bootstrap/README.md`.
+
+---
+
 *Documento mantido pelo CTIC/UNIFESSPA. Atualizações via Pull Request.*

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -431,6 +431,28 @@ vault:
 vaultTransit:
   enabled: false
 
+# ============================================================================
+# Vault Transit bootstrap (chart platform/vault-transit-bootstrap/, issue #219).
+# Habilita o engine transit no Vault local + cria key uniplus-idempotency-aesgcm
+# + policy uniplus-api-transit + role K8s auth uniplus-api. Reconciliado a cada
+# deploy via Helm hook (post-install,post-upgrade,post-rollback).
+#
+# Pré-requisitos satisfeitos em standalone:
+#   - Vault inicializado (Shamir, manual unseal) — root token custodiado em
+#     secret/standalone/vault/root via ClusterSecretStore vault-default.
+#   - kubernetes auth method habilitado (acessor auth_kubernetes_cdc9d2c3).
+#   - ClusterSecretStore vault-default Synced.
+#
+# Trade-off conhecido: o ExternalSecret consome o ROOT TOKEN em standalone.
+# Plano de redução para uma policy mínima dedicada ao bootstrap está em
+# platform/vault-transit-bootstrap/README.md (será aberta issue de
+# seguimento quando este chart entrar em produção real).
+# ============================================================================
+vaultTransitBootstrap:
+  enabled: true
+  vault:
+    address: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
+
 # NetworkPolicy do chart vault/ — sem egress Transit (vaultTransit.enabled=false).
 #
 # `kubeApiCidrs` consumido pelos charts platform/external-secrets/ e

--- a/platform/vault-transit-bootstrap/Chart.yaml
+++ b/platform/vault-transit-bootstrap/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: vault-transit-bootstrap
+description: |
+  Bootstrap declarativo do Vault Transit no cluster local: habilita o engine
+  transit, cria a key uniplus-idempotency-aesgcm, a policy uniplus-api-transit
+  e a role Kubernetes auth uniplus-api. Executa como Helm hook reconciliando
+  em todo deploy. Pattern espelha apps/keycloak-replica realm-reconcile-job.
+type: application
+version: 0.1.0
+appVersion: "1.21.2"
+
+home: https://github.com/unifesspa-edu-br/uniplus-infra
+sources:
+  - https://github.com/unifesspa-edu-br/uniplus-infra
+
+maintainers:
+  - name: CTIC Unifesspa
+    url: https://github.com/unifesspa-edu-br
+
+keywords:
+  - vault
+  - transit
+  - bootstrap
+  - encryption
+  - uniplus

--- a/platform/vault-transit-bootstrap/README.md
+++ b/platform/vault-transit-bootstrap/README.md
@@ -1,0 +1,97 @@
+# vault-transit-bootstrap
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion: 1.21.2](https://img.shields.io/badge/AppVersion-1.21.2-informational?style=flat-square)
+
+Bootstrap declarativo do Vault Transit no cluster local. Em todo `helm install` /
+`upgrade` / `rollback`, um Job idempotente reconcilia:
+
+1. Mount `transit/` (cria se ausente).
+2. Key `uniplus-idempotency-aesgcm` (AES-GCM-256, não-deletável, não-exportável).
+3. Policy `uniplus-api-transit` (apenas `update` em `encrypt`/`decrypt` da key).
+4. Role Kubernetes auth `uniplus-api` (vinculada à SA `uniplus-api` no namespace
+   `uniplus`, com TTL de token 1h).
+
+Pattern espelha `apps/keycloak-replica/templates/realm-reconcile-job.yaml`
+(reconciliação declarativa via Helm hook).
+
+## Trade-off de segurança — token do Job
+
+Em standalone, o `ExternalSecret` consome `secret/standalone/vault/root` (root
+token do Vault). Isso é deliberadamente excessivo para este escopo
+(`sys/mounts`, `transit/*`, `sys/policies/acl`, `auth/kubernetes/role`) e
+**precisa ser reduzido antes da Fase 6**. Plano de redução:
+
+1. Operador roda manualmente (RUNBOOK) um script one-shot com root para criar
+   uma policy `vault-transit-bootstrap-policy` mínima e emitir um token bootstrap
+   periódico vinculado.
+2. O token bootstrap é custodiado em `secret/standalone/vault-transit-bootstrap/token`.
+3. Override em `environments/standalone/values.yaml`:
+   `vaultTransitBootstrap.externalSecret.vaultPath` aponta para o novo path.
+4. Root token volta para offline-only.
+
+Issue de seguimento será aberta quando este chart entrar em produção.
+
+## Operações comuns
+
+Sanidade pós-deploy (ver detalhe completo em `docs/RUNBOOKS.md`):
+
+```bash
+ssh -i ~/.ssh/id_ed25519 ubuntu@<k8s-host>
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml -n vault exec -i \
+  platform-vault-uniplus-standalone-0 -- sh -c \
+  'export VAULT_TOKEN=<root>; vault secrets list | grep transit'
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `vaultTransitBootstrap.enabled` | bool | `false` | Liga o chart. Standalone seta `true`; outros environments aguardam `uniplus-infra#45`. |
+| `vaultTransitBootstrap.vault.address` | string | `""` | URL absoluta do Vault local. **Sem default utilizável** — environment DEVE sobrescrever. |
+| `vaultTransitBootstrap.transit.path` | string | `transit` | Mount path do engine Transit. |
+| `vaultTransitBootstrap.key.name` | string | `uniplus-idempotency-aesgcm` | Nome da key Transit. |
+| `vaultTransitBootstrap.key.type` | string | `aes256-gcm96` | Algoritmo. |
+| `vaultTransitBootstrap.key.deletionAllowed` | bool | `false` | Permitir `vault delete transit/keys/<name>`. |
+| `vaultTransitBootstrap.key.exportable` | bool | `false` | Permitir export do material da key. |
+| `vaultTransitBootstrap.key.allowPlaintextBackup` | bool | `false` | Snapshot inclui plaintext. |
+| `vaultTransitBootstrap.policy.name` | string | `uniplus-api-transit` | Nome da policy. |
+| `vaultTransitBootstrap.role.name` | string | `uniplus-api` | Nome da role K8s auth. |
+| `vaultTransitBootstrap.role.boundSa` | string | `uniplus-api` | ServiceAccount autorizada. |
+| `vaultTransitBootstrap.role.boundNs` | string | `uniplus` | Namespace da ServiceAccount. |
+| `vaultTransitBootstrap.role.ttl` | string | `1h` | TTL do token Vault emitido. |
+| `vaultTransitBootstrap.externalSecret.secretStoreName` | string | `vault-default` | ClusterSecretStore que materializa o token. |
+| `vaultTransitBootstrap.externalSecret.secretStoreKind` | string | `ClusterSecretStore` | `ClusterSecretStore` ou `SecretStore`. |
+| `vaultTransitBootstrap.externalSecret.vaultPath` | string | `standalone/vault/root` | Path KV v2 relativo ao mount `secret`. |
+| `vaultTransitBootstrap.externalSecret.tokenKey` | string | `token` | Campo na KV que contém o token. |
+| `vaultTransitBootstrap.externalSecret.refreshInterval` | string | `1h` | Refresh da Secret materializada. |
+| `vaultTransitBootstrap.image.repository` | string | `hashicorp/vault` | Imagem com `vault` CLI. |
+| `vaultTransitBootstrap.image.tag` | string | `1.21.2` | Versão alinhada ao Vault server. |
+| `vaultTransitBootstrap.networkPolicy.enabled` | bool | `true` | Restringe egress do Job. |
+| `vaultTransitBootstrap.networkPolicy.vaultNamespace` | string | `vault` | Destino permitido. |
+| `vaultTransitBootstrap.networkPolicy.vaultPort` | int | `8200` | Porta API do Vault. |
+| `vaultTransitBootstrap.networkPolicy.kubeDnsCidrs` | list | `[10.43.0.0/16]` | CIDRs para DNS. |
+
+## Pré-requisitos
+
+- Vault local inicializado e unsealed.
+- `kubernetes` auth method habilitado no Vault.
+- ClusterSecretStore `vault-default` reconciliando (External Secrets Operator).
+- ServiceAccount `uniplus-api` no namespace `uniplus` existe (criada pelos
+  charts da API).
+
+## Permissões da policy emitida
+
+```hcl
+path "transit/encrypt/uniplus-idempotency-aesgcm" {
+  capabilities = ["update"]
+}
+
+path "transit/decrypt/uniplus-idempotency-aesgcm" {
+  capabilities = ["update"]
+}
+```
+
+Sem `read`, `rewrap`, `datakey`, `export`, `backup` ou rotate. Administração
+da key (rotate, datakey config) fica fora do escopo runtime da `uniplus-api`.

--- a/platform/vault-transit-bootstrap/files/bootstrap-vault-transit.sh
+++ b/platform/vault-transit-bootstrap/files/bootstrap-vault-transit.sh
@@ -155,7 +155,14 @@ log "Reconciliando policy '${POLICY_NAME}'"
 # Policy least-privilege: apenas update em encrypt/decrypt para a key
 # específica. Sem read, rewrap, datakey, export, backup, rotate — admin
 # fica separado (root ou política dedicada).
-policy_doc=$(cat <<EOF
+#
+# Escrevemos a policy em arquivo temp (em vez de pipe) porque vault policy
+# write consome stdin de forma single-use; o wrapper de retry, se chamado
+# via pipe, re-executa com EOF na segunda tentativa e produz policy vazia.
+# /tmp é uma emptyDir do Pod, removido com o ciclo de vida do container.
+policy_file="/tmp/uniplus-api-transit.hcl"
+trap 'rm -f "$policy_file"' EXIT INT TERM
+cat > "$policy_file" <<POLICY
 path "${TRANSIT_PATH}/encrypt/${KEY_NAME}" {
   capabilities = ["update"]
 }
@@ -163,11 +170,9 @@ path "${TRANSIT_PATH}/encrypt/${KEY_NAME}" {
 path "${TRANSIT_PATH}/decrypt/${KEY_NAME}" {
   capabilities = ["update"]
 }
-EOF
-)
+POLICY
 
-# vault policy write lê o conteúdo de stdin (uso de "-")
-printf '%s' "$policy_doc" | retry_vault vault policy write "$POLICY_NAME" -
+retry_vault vault policy write "$POLICY_NAME" "$policy_file"
 
 # --- 5. Escrever role K8s auth (idempotente) ------------------------------
 

--- a/platform/vault-transit-bootstrap/files/bootstrap-vault-transit.sh
+++ b/platform/vault-transit-bootstrap/files/bootstrap-vault-transit.sh
@@ -84,8 +84,11 @@ sealed_attempts=0
 sealed_max="${VAULT_SEALED_MAX_ATTEMPTS:-12}"  # ~1 min em sleep=5s
 
 while true; do
-    vault status >/dev/null 2>&1
-    rc=$?
+    # `set -e` aborta o script em qualquer comando non-zero; capturamos o exit
+    # code de `vault status` em rc via `|| rc=$?`, padrão POSIX que neutraliza
+    # o errexit para esta chamada específica sem desabilitar globalmente.
+    rc=0
+    vault status >/dev/null 2>&1 || rc=$?
 
     if [ "$rc" -eq 0 ]; then
         log "Vault disponível e unsealed."

--- a/platform/vault-transit-bootstrap/files/bootstrap-vault-transit.sh
+++ b/platform/vault-transit-bootstrap/files/bootstrap-vault-transit.sh
@@ -66,27 +66,52 @@ retry_vault() {
 }
 
 # --- 1. Aguardar Vault unsealed -------------------------------------------
+#
+# `vault status` retorna 3 estados distintos por exit code (documentado em
+# https://developer.hashicorp.com/vault/docs/commands/status):
+#   0 = unsealed e acessível
+#   1 = erro (rede, URL inválida, auth, etc.) — retry
+#   2 = sealed mas alcançável — não retentar indefinidamente, abortar para
+#       que o operador atue (unseal Shamir manual ou aguardar auto-unseal
+#       OCI KMS/Transit). Vault pod com restart recente pode estar
+#       transitoriamente sealed; toleramos algumas tentativas mas falhamos
+#       em saturação.
 
 log "Aguardando Vault em $VAULT_ADDR ficar disponível e unsealed"
 
 attempts=0
-while ! vault status >/dev/null 2>&1; do
-    attempts=$((attempts + 1))
-    if [ "$attempts" -ge "$VAULT_WAIT_MAX_ATTEMPTS" ]; then
-        log "Vault não acessível após $VAULT_WAIT_MAX_ATTEMPTS tentativas. Estado:"
-        vault status || true
-        exit 1
+sealed_attempts=0
+sealed_max="${VAULT_SEALED_MAX_ATTEMPTS:-12}"  # ~1 min em sleep=5s
+
+while true; do
+    vault status >/dev/null 2>&1
+    rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        log "Vault disponível e unsealed."
+        break
     fi
+
+    attempts=$((attempts + 1))
+
+    if [ "$rc" -eq 2 ]; then
+        sealed_attempts=$((sealed_attempts + 1))
+        if [ "$sealed_attempts" -ge "$sealed_max" ]; then
+            log "Vault permanece SEALED após $sealed_max tentativas. Bootstrap aborted — operador precisa fazer unseal."
+            exit 1
+        fi
+        log "Vault sealed (tentativa sealed $sealed_attempts/$sealed_max); aguardando unseal..."
+    else
+        if [ "$attempts" -ge "$VAULT_WAIT_MAX_ATTEMPTS" ]; then
+            log "Vault não acessível após $VAULT_WAIT_MAX_ATTEMPTS tentativas (último exit code: $rc)."
+            vault status || true
+            exit 1
+        fi
+        log "Vault não acessível (exit code $rc, tentativa $attempts/$VAULT_WAIT_MAX_ATTEMPTS); retry em ${VAULT_WAIT_SLEEP_SECONDS}s..."
+    fi
+
     sleep "$VAULT_WAIT_SLEEP_SECONDS"
 done
-
-# Checagem explícita de sealed=false (vault status sai 0 também em standby).
-if vault status -format=json 2>/dev/null | grep -q '"sealed": *true'; then
-    log "Vault está SEALED. Bootstrap aborted."
-    exit 1
-fi
-
-log "Vault disponível e unsealed."
 
 # --- 2. Habilitar transit (idempotente) -----------------------------------
 

--- a/platform/vault-transit-bootstrap/files/bootstrap-vault-transit.sh
+++ b/platform/vault-transit-bootstrap/files/bootstrap-vault-transit.sh
@@ -1,0 +1,196 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Bootstrap declarativo e idempotente do Vault Transit no cluster local.
+# Embutido como ConfigMap pelo chart vault-transit-bootstrap; executado por
+# um Job Helm hook (post-install, post-upgrade, post-rollback).
+#
+# Operações (todas idempotentes):
+#   1. Aguarda Vault unsealed via vault status (retries com backoff).
+#   2. Habilita engine transit em ${TRANSIT_PATH} (skipa se já habilitado).
+#   3. Cria a key AES-GCM-256 ${KEY_NAME} (skipa se já existe; flags são
+#      consolidadas apenas na criação — alterações pós-existência ficam
+#      fora deste bootstrap, escopo de RUNBOOK manual).
+#   4. Escreve a policy ${POLICY_NAME} (sempre — vault policy write é
+#      idempotente: substitui pelo conteúdo do stdin).
+#   5. Escreve a role K8s auth ${ROLE_NAME} (idempotente).
+#   6. Sanity checks com vault read, sem falhar em propriedades não-críticas.
+
+set -eu
+
+# --- Inputs (todos via env do Job) ----------------------------------------
+
+VAULT_ADDR="${VAULT_ADDR:?VAULT_ADDR é obrigatório}"
+VAULT_TOKEN="${VAULT_TOKEN:?VAULT_TOKEN é obrigatório (ExternalSecret deve materializar a Secret antes)}"
+TRANSIT_PATH="${TRANSIT_PATH:-transit}"
+KEY_NAME="${KEY_NAME:?KEY_NAME é obrigatório}"
+KEY_TYPE="${KEY_TYPE:-aes256-gcm96}"
+KEY_DELETION_ALLOWED="${KEY_DELETION_ALLOWED:-false}"
+KEY_EXPORTABLE="${KEY_EXPORTABLE:-false}"
+KEY_ALLOW_PLAINTEXT_BACKUP="${KEY_ALLOW_PLAINTEXT_BACKUP:-false}"
+POLICY_NAME="${POLICY_NAME:?POLICY_NAME é obrigatório}"
+ROLE_NAME="${ROLE_NAME:?ROLE_NAME é obrigatório}"
+ROLE_SA="${ROLE_SA:?ROLE_SA é obrigatório}"
+ROLE_NS="${ROLE_NS:?ROLE_NS é obrigatório}"
+ROLE_TTL="${ROLE_TTL:-1h}"
+
+VAULT_WAIT_MAX_ATTEMPTS="${VAULT_WAIT_MAX_ATTEMPTS:-60}"
+VAULT_WAIT_SLEEP_SECONDS="${VAULT_WAIT_SLEEP_SECONDS:-5}"
+VAULT_OP_MAX_RETRIES="${VAULT_OP_MAX_RETRIES:-5}"
+
+export VAULT_ADDR VAULT_TOKEN
+
+log() {
+    printf '%s [vault-transit-bootstrap] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1"
+}
+
+# --- Retry wrapper para operações vault -----------------------------------
+
+# Executa $@ até suceder ou esgotar VAULT_OP_MAX_RETRIES com backoff linear.
+# Não esconde stderr da última tentativa.
+retry_vault() {
+    attempts=0
+    while true; do
+        attempts=$((attempts + 1))
+        if "$@"; then
+            return 0
+        fi
+        if [ "$attempts" -ge "$VAULT_OP_MAX_RETRIES" ]; then
+            log "Operação falhou após $VAULT_OP_MAX_RETRIES tentativas: $*"
+            return 1
+        fi
+        sleep_for=$((2 * attempts))
+        log "Tentativa $attempts/$VAULT_OP_MAX_RETRIES falhou; retry em ${sleep_for}s"
+        sleep "$sleep_for"
+    done
+}
+
+# --- 1. Aguardar Vault unsealed -------------------------------------------
+
+log "Aguardando Vault em $VAULT_ADDR ficar disponível e unsealed"
+
+attempts=0
+while ! vault status >/dev/null 2>&1; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge "$VAULT_WAIT_MAX_ATTEMPTS" ]; then
+        log "Vault não acessível após $VAULT_WAIT_MAX_ATTEMPTS tentativas. Estado:"
+        vault status || true
+        exit 1
+    fi
+    sleep "$VAULT_WAIT_SLEEP_SECONDS"
+done
+
+# Checagem explícita de sealed=false (vault status sai 0 também em standby).
+if vault status -format=json 2>/dev/null | grep -q '"sealed": *true'; then
+    log "Vault está SEALED. Bootstrap aborted."
+    exit 1
+fi
+
+log "Vault disponível e unsealed."
+
+# --- 2. Habilitar transit (idempotente) -----------------------------------
+
+if vault secrets list -format=json 2>/dev/null | grep -q "\"${TRANSIT_PATH}/\""; then
+    log "Mount '${TRANSIT_PATH}/' já habilitado — skip enable."
+else
+    log "Habilitando mount '${TRANSIT_PATH}/'"
+    retry_vault vault secrets enable -path="$TRANSIT_PATH" transit
+fi
+
+# --- 3. Criar key (apenas se não existe) ----------------------------------
+
+# Helper: extrai um campo do output `vault read` (formato key-value tabulado).
+# Uso: read_key_field <key_path> <field_name>
+read_key_field() {
+    vault read "$1" 2>/dev/null | awk -v field="$2" '$1 == field { print $2 }'
+}
+
+if vault read "${TRANSIT_PATH}/keys/${KEY_NAME}" >/dev/null 2>&1; then
+    log "Key '${TRANSIT_PATH}/keys/${KEY_NAME}' já existe — validando drift de segurança."
+
+    # Drift checks bloqueantes: type, exportable, allow_plaintext_backup.
+    # Esses flags só são fixados na criação, então drift indica uma key
+    # foi recriada por outro caminho fora do bootstrap. Abortar para
+    # evitar mascarar problema de segurança.
+    actual_type=$(read_key_field "${TRANSIT_PATH}/keys/${KEY_NAME}" "type")
+    if [ "$actual_type" != "$KEY_TYPE" ]; then
+        log "DRIFT: key '${KEY_NAME}' type='${actual_type}', esperado '${KEY_TYPE}'. Aborting."
+        exit 1
+    fi
+
+    actual_exportable=$(read_key_field "${TRANSIT_PATH}/keys/${KEY_NAME}" "exportable")
+    if [ "$actual_exportable" != "$KEY_EXPORTABLE" ]; then
+        log "DRIFT: key '${KEY_NAME}' exportable='${actual_exportable}', esperado '${KEY_EXPORTABLE}'. Aborting."
+        exit 1
+    fi
+
+    actual_plaintext=$(read_key_field "${TRANSIT_PATH}/keys/${KEY_NAME}" "allow_plaintext_backup")
+    if [ "$actual_plaintext" != "$KEY_ALLOW_PLAINTEXT_BACKUP" ]; then
+        log "DRIFT: key '${KEY_NAME}' allow_plaintext_backup='${actual_plaintext}', esperado '${KEY_ALLOW_PLAINTEXT_BACKUP}'. Aborting."
+        exit 1
+    fi
+
+    log "Drift check OK: type/exportable/allow_plaintext_backup conformes."
+else
+    log "Criando key '${TRANSIT_PATH}/keys/${KEY_NAME}'"
+    # exportable e allow_plaintext_backup são aceitos na criação;
+    # deletion_allowed só é configurável via endpoint /config (passo abaixo).
+    retry_vault vault write -f "${TRANSIT_PATH}/keys/${KEY_NAME}" \
+        "type=${KEY_TYPE}" \
+        "exportable=${KEY_EXPORTABLE}" \
+        "allow_plaintext_backup=${KEY_ALLOW_PLAINTEXT_BACKUP}"
+fi
+
+# Reconciliar deletion_allowed em todo deploy (endpoint /config aceita apenas
+# este flag + min_decryption_version + min_encryption_version + auto_rotate_period).
+# Idempotente: mesma chamada produz mesma config.
+log "Reconciliando deletion_allowed da key '${KEY_NAME}'"
+retry_vault vault write "${TRANSIT_PATH}/keys/${KEY_NAME}/config" \
+    "deletion_allowed=${KEY_DELETION_ALLOWED}"
+
+# --- 4. Escrever policy (idempotente — vault policy write reemplaça) ------
+
+log "Reconciliando policy '${POLICY_NAME}'"
+
+# Policy least-privilege: apenas update em encrypt/decrypt para a key
+# específica. Sem read, rewrap, datakey, export, backup, rotate — admin
+# fica separado (root ou política dedicada).
+policy_doc=$(cat <<EOF
+path "${TRANSIT_PATH}/encrypt/${KEY_NAME}" {
+  capabilities = ["update"]
+}
+
+path "${TRANSIT_PATH}/decrypt/${KEY_NAME}" {
+  capabilities = ["update"]
+}
+EOF
+)
+
+# vault policy write lê o conteúdo de stdin (uso de "-")
+printf '%s' "$policy_doc" | retry_vault vault policy write "$POLICY_NAME" -
+
+# --- 5. Escrever role K8s auth (idempotente) ------------------------------
+
+log "Reconciliando role 'auth/kubernetes/role/${ROLE_NAME}'"
+
+retry_vault vault write "auth/kubernetes/role/${ROLE_NAME}" \
+    "bound_service_account_names=${ROLE_SA}" \
+    "bound_service_account_namespaces=${ROLE_NS}" \
+    "policies=${POLICY_NAME}" \
+    "ttl=${ROLE_TTL}"
+
+# --- 6. Sanity checks (não-fatais) ----------------------------------------
+
+log "=== Sanity check: transit mount ==="
+vault secrets list 2>/dev/null | grep "^${TRANSIT_PATH}/" || true
+
+log "=== Sanity check: transit key ==="
+vault read "${TRANSIT_PATH}/keys/${KEY_NAME}" 2>/dev/null || true
+
+log "=== Sanity check: kubernetes auth role ==="
+vault read "auth/kubernetes/role/${ROLE_NAME}" 2>/dev/null || true
+
+log "=== Sanity check: policy ==="
+vault policy read "$POLICY_NAME" 2>/dev/null || true
+
+log "Bootstrap concluído com sucesso."

--- a/platform/vault-transit-bootstrap/templates/_helpers.tpl
+++ b/platform/vault-transit-bootstrap/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{/*
+  Helpers comuns do chart vault-transit-bootstrap.
+*/}}
+
+{{- define "vault-transit-bootstrap.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "vault-transit-bootstrap.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "vault-transit-bootstrap.labels" -}}
+app.kubernetes.io/name: {{ include "vault-transit-bootstrap.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: vault-transit-bootstrap
+app.kubernetes.io/part-of: uniplus
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "vault-transit-bootstrap.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vault-transit-bootstrap.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+  Nome da Secret K8s materializada pelo ExternalSecret. Constante para que
+  Job e ExternalSecret referenciem o mesmo nome.
+*/}}
+{{- define "vault-transit-bootstrap.tokenSecretName" -}}
+{{ include "vault-transit-bootstrap.fullname" . }}-token
+{{- end -}}
+
+{{/*
+  Annotations padrão de hook Helm — todos os recursos exceto o Job rodam
+  cedo (weight 0) para garantir SA/Secret/CM/NP presentes antes do Job
+  (weight 10). hook-delete-policy preserva em falha para inspeção.
+*/}}
+{{- define "vault-transit-bootstrap.hookAnnotations" -}}
+"helm.sh/hook": post-install,post-upgrade,post-rollback
+"helm.sh/hook-weight": "0"
+"helm.sh/hook-delete-policy": before-hook-creation
+{{- end -}}

--- a/platform/vault-transit-bootstrap/templates/configmap-script.yaml
+++ b/platform/vault-transit-bootstrap/templates/configmap-script.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.vaultTransitBootstrap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "vault-transit-bootstrap.fullname" . }}-script
+  labels:
+    {{- include "vault-transit-bootstrap.labels" . | nindent 4 }}
+  annotations:
+    {{- include "vault-transit-bootstrap.hookAnnotations" . | nindent 4 }}
+data:
+  bootstrap.sh: |-
+{{ .Files.Get "files/bootstrap-vault-transit.sh" | indent 4 }}
+{{- end }}

--- a/platform/vault-transit-bootstrap/templates/externalsecret.yaml
+++ b/platform/vault-transit-bootstrap/templates/externalsecret.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.vaultTransitBootstrap.enabled }}
+{{- $es := .Values.vaultTransitBootstrap.externalSecret -}}
+# ExternalSecret é resource normal (NÃO Helm hook). Helm aplica resources
+# normais antes dos hooks post-install, então o ExternalSecret + Secret K8s
+# materializado pelo ESO já existem quando o Job hook do bootstrap roda.
+# Hook annotations eram inseguras: hook-weight só ordena criação do recurso,
+# não a readiness do Secret-alvo materializado pelo controller do ESO.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "vault-transit-bootstrap.tokenSecretName" . }}
+  labels:
+    {{- include "vault-transit-bootstrap.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreKind | quote }}
+    name: {{ $es.secretStoreName | quote }}
+  target:
+    name: {{ include "vault-transit-bootstrap.tokenSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: VAULT_TOKEN
+      remoteRef:
+        key: {{ $es.vaultPath | quote }}
+        property: {{ $es.tokenKey | quote }}
+{{- end }}

--- a/platform/vault-transit-bootstrap/templates/job.yaml
+++ b/platform/vault-transit-bootstrap/templates/job.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.vaultTransitBootstrap.enabled }}
+{{- $cfg := .Values.vaultTransitBootstrap -}}
+{{- if not $cfg.vault.address }}
+{{- fail "vaultTransitBootstrap.vault.address não pode ser vazio quando vaultTransitBootstrap.enabled=true. Defina em environments/<env>/values.yaml (ex.: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200)." -}}
+{{- end }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "vault-transit-bootstrap.fullname" . }}
+  labels:
+    {{- include "vault-transit-bootstrap.labels" . | nindent 4 }}
+    uniplus.io/job-role: vault-transit-bootstrap
+  annotations:
+    # Job roda APÓS SA/ES/CM/NP (weight 0) — ordering garantida pelo Helm
+    # via hook-weight. hook-delete-policy preserva Job em falha para
+    # inspeção; remove-em-sucesso libera o ApplicationSet para sync limpa.
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: {{ $cfg.job.backoffLimit }}
+  activeDeadlineSeconds: {{ $cfg.job.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "vault-transit-bootstrap.labels" . | nindent 8 }}
+        uniplus.io/job-role: vault-transit-bootstrap
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "vault-transit-bootstrap.fullname" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: vault-cli
+          image: "{{ $cfg.image.repository }}:{{ $cfg.image.tag }}"
+          imagePullPolicy: {{ $cfg.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/sh
+            - /scripts/bootstrap.sh
+          env:
+            - name: VAULT_ADDR
+              value: {{ $cfg.vault.address | quote }}
+            - name: VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "vault-transit-bootstrap.tokenSecretName" . }}
+                  key: VAULT_TOKEN
+            - name: TRANSIT_PATH
+              value: {{ $cfg.transit.path | quote }}
+            - name: KEY_NAME
+              value: {{ $cfg.key.name | quote }}
+            - name: KEY_TYPE
+              value: {{ $cfg.key.type | quote }}
+            - name: KEY_DELETION_ALLOWED
+              value: {{ $cfg.key.deletionAllowed | quote }}
+            - name: KEY_EXPORTABLE
+              value: {{ $cfg.key.exportable | quote }}
+            - name: KEY_ALLOW_PLAINTEXT_BACKUP
+              value: {{ $cfg.key.allowPlaintextBackup | quote }}
+            - name: POLICY_NAME
+              value: {{ $cfg.policy.name | quote }}
+            - name: ROLE_NAME
+              value: {{ $cfg.role.name | quote }}
+            - name: ROLE_SA
+              value: {{ $cfg.role.boundSa | quote }}
+            - name: ROLE_NS
+              value: {{ $cfg.role.boundNs | quote }}
+            - name: ROLE_TTL
+              value: {{ $cfg.role.ttl | quote }}
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml $cfg.job.resources | nindent 12 }}
+      volumes:
+        - name: script
+          configMap:
+            name: {{ include "vault-transit-bootstrap.fullname" . }}-script
+            defaultMode: 0555
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/platform/vault-transit-bootstrap/templates/networkpolicy.yaml
+++ b/platform/vault-transit-bootstrap/templates/networkpolicy.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.vaultTransitBootstrap.enabled .Values.vaultTransitBootstrap.networkPolicy.enabled }}
+{{- $np := .Values.vaultTransitBootstrap.networkPolicy -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "vault-transit-bootstrap.fullname" . }}
+  labels:
+    {{- include "vault-transit-bootstrap.labels" . | nindent 4 }}
+  annotations:
+    {{- include "vault-transit-bootstrap.hookAnnotations" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "vault-transit-bootstrap.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    # Egress para os pods do Vault (chart hashicorp/vault põe `app.kubernetes.io/name=vault`
+    # + `component=server` no StatefulSet). namespaceSelector + podSelector
+    # restringe o egress aos pods do Vault apenas, não a qualquer pod no
+    # namespace `vault`.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.vaultNamespace | quote }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vault
+              component: server
+      ports:
+        - protocol: TCP
+          port: {{ $np.vaultPort }}
+    # DNS para resolver o ClusterIP do Service do Vault.
+    - to:
+        {{- range $cidr := $np.kubeDnsCidrs }}
+        - ipBlock:
+            cidr: {{ $cidr | quote }}
+        {{- end }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}

--- a/platform/vault-transit-bootstrap/templates/serviceaccount.yaml
+++ b/platform/vault-transit-bootstrap/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.vaultTransitBootstrap.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vault-transit-bootstrap.fullname" . }}
+  labels:
+    {{- include "vault-transit-bootstrap.labels" . | nindent 4 }}
+  annotations:
+    {{- include "vault-transit-bootstrap.hookAnnotations" . | nindent 4 }}
+automountServiceAccountToken: false
+{{- end }}

--- a/platform/vault-transit-bootstrap/values.schema.json
+++ b/platform/vault-transit-bootstrap/values.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "vault-transit-bootstrap chart values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "vaultTransitBootstrap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "vault": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "address": { "type": "string" }
+          }
+        },
+        "transit": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "path": { "type": "string", "minLength": 1 }
+          }
+        },
+        "key": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "type": { "type": "string", "minLength": 1 },
+            "deletionAllowed": { "type": "boolean" },
+            "exportable": { "type": "boolean" },
+            "allowPlaintextBackup": { "type": "boolean" }
+          }
+        },
+        "policy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string", "minLength": 1 }
+          }
+        },
+        "role": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "boundSa": { "type": "string", "minLength": 1 },
+            "boundNs": { "type": "string", "minLength": 1 },
+            "ttl": { "type": "string", "minLength": 1 }
+          }
+        },
+        "externalSecret": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "secretStoreName": { "type": "string", "minLength": 1 },
+            "secretStoreKind": { "type": "string", "enum": ["ClusterSecretStore", "SecretStore"] },
+            "vaultPath": { "type": "string", "minLength": 1 },
+            "tokenKey": { "type": "string", "minLength": 1 },
+            "refreshInterval": { "type": "string", "minLength": 1 }
+          }
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string", "minLength": 1 },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        },
+        "job": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "backoffLimit": { "type": "integer", "minimum": 0 },
+            "activeDeadlineSeconds": { "type": "integer", "minimum": 1 },
+            "resources": { "type": "object" }
+          }
+        },
+        "networkPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "vaultNamespace": { "type": "string", "minLength": 1 },
+            "vaultPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "kubeDnsCidrs": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "minItems": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/platform/vault-transit-bootstrap/values.yaml
+++ b/platform/vault-transit-bootstrap/values.yaml
@@ -1,0 +1,107 @@
+# Bootstrap do Vault Transit no cluster local.
+#
+# Topologia: cada cluster que hospeda uma `uniplus-api` precisa do mount transit/
+# habilitado no Vault local, da key uniplus-idempotency-aesgcm criada, da policy
+# uniplus-api-transit (encrypt+decrypt apenas dessa key) e da role K8s auth
+# uniplus-api (bound à ServiceAccount uniplus-api/uniplus). Este chart entrega
+# os 4 recursos de forma idempotente, em um Helm hook reconciliado a cada deploy.
+#
+# Status por environment:
+#   standalone: enabled=true (Vault local com Shamir; root token via ESO).
+#   lab/prod:   enabled=false até que a feature uniplus-infra#45 fechar e
+#               cada environment ter sua role bootstrap dedicada.
+#
+# Documentação completa: docs/RUNBOOKS.md §9.X — Vault Transit bootstrap.
+
+vaultTransitBootstrap:
+  # Liga/desliga o chart inteiro. Default false; standalone seta true.
+  enabled: false
+
+  # Endereço HTTP(S) do Vault no cluster local. Sem default utilizável — cada
+  # environment DEVE sobrescrever explicitamente para o Service name correto.
+  #
+  # Pattern (igual ao clusterSecretStore.vaultServer):
+  #   standalone: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
+  #   lab-sp1:    https://platform-vault-lab-sp1.vault.svc.cluster.local:8200
+  vault:
+    address: ""
+
+  # Mount do engine Transit. Convenção HashiCorp = "transit".
+  transit:
+    path: transit
+
+  # Key AES-GCM-256 que cifra/decifra payloads da uniplus-api (rota
+  # Idempotency-Key + futuros campos do Domínio).
+  key:
+    name: uniplus-idempotency-aesgcm
+    type: aes256-gcm96
+    # deletion_allowed=false impede o operador de apagar a key acidentalmente
+    # via vault CLI (precisa um update explícito antes).
+    deletionAllowed: false
+    # exportable=false: a key NUNCA sai do Vault, mesmo para o root.
+    exportable: false
+    # allow_plaintext_backup=false: snapshot do Vault não inclui plaintext
+    # da key — apenas a forma cifrada pelo seal.
+    allowPlaintextBackup: false
+
+  # Policy least-privilege que será atribuída à role uniplus-api. Permite
+  # apenas update em encrypt/decrypt para a key acima. Sem read, rewrap,
+  # datakey, export, backup ou rotate (administração separada).
+  policy:
+    name: uniplus-api-transit
+
+  # Role K8s auth que a uniplus-api usa para autenticar no Vault. boundSa
+  # e boundNs precisam corresponder à ServiceAccount real dos pods da API.
+  role:
+    name: uniplus-api
+    boundSa: uniplus-api
+    boundNs: uniplus
+    # TTL do token Vault emitido pela role. 1h é compatível com o refresh
+    # do JWT do K8s no volume projetado do ServiceAccount.
+    ttl: 1h
+
+  # ExternalSecret consome ClusterSecretStore vault-default (já habilitado
+  # em standalone). Path relativo ao vaultPath do store (`secret` = KV v2
+  # mount). Em standalone hoje custodia o root token; trade-off documentado
+  # no README do chart (segurança em escopo a reduzir antes da Fase 6).
+  externalSecret:
+    secretStoreName: vault-default
+    secretStoreKind: ClusterSecretStore
+    vaultPath: standalone/vault/root
+    tokenKey: token
+    refreshInterval: 1h
+
+  # Imagem do Vault CLI usada pelo Job. Versão alinhada ao Vault server
+  # rodando em standalone para evitar incompatibilidade de auth/secrets API.
+  image:
+    repository: hashicorp/vault
+    tag: "1.21.2"
+    pullPolicy: IfNotPresent
+
+  # Limites/segurança do Job.
+  job:
+    backoffLimit: 3
+    activeDeadlineSeconds: 600
+    # ttlSecondsAfterFinished não é definido: TTL controller apaga succeed +
+    # failed indiscriminadamente, o que tira a janela de inspeção pós-falha.
+    # Hook-delete-policy (hook-succeeded,before-hook-creation) já cuida do
+    # cleanup em sucesso e mantém em falha para investigação.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+
+  # NetworkPolicy do Job. Egress restrito ao Vault namespace (porta 8200)
+  # + DNS (porta 53). Sem ingress.
+  networkPolicy:
+    enabled: true
+    vaultNamespace: vault
+    vaultPort: 8200
+    # CIDR do kube-dns (CoreDNS) para resolução do Service do Vault.
+    # 10.43.0.0/16 é o service CIDR padrão do K3s; environments custom
+    # podem sobrescrever.
+    kubeDnsCidrs:
+      - 10.43.0.0/16


### PR DESCRIPTION
Closes #219
Refs #45

## Contexto

Issue 2 de 3 do plano de **correção definitiva de cifragem** standalone Uni+:

1. `uniplus-api#400` — fail-fast validation de `EncryptionOptions` no boot. **Mergeada** ([PR #401](https://github.com/unifesspa-edu-br/uniplus-api/pull/401)).
2. `uniplus-api#402` — eliminar heurística `File.Exists` de auth method. **Mergeada** ([PR #403](https://github.com/unifesspa-edu-br/uniplus-api/pull/403)).
3. **Este PR** — montar engine Transit no Vault local + criar key + policy + role K8s auth para a uniplus-api consumir.
4. `uniplus-infra#220` — wire-up dos charts da uniplus-api para `Provider=vault` + smoke E2E. **Pendente** (depende deste).

Antes deste PR, o Vault standalone tinha `kubernetes/` auth method habilitado mas **sem mount `transit/`** — qualquer tentativa de `Provider=vault` resultaria em 404 do Vault na primeira request cifrada.

## O que muda

### Novo chart `platform/vault-transit-bootstrap/`

Reconcilia em todo deploy via Helm hook (`post-install`, `post-upgrade`, `post-rollback`):

- Mount `transit/` no Vault local (skip se já habilitado).
- Key `uniplus-idempotency-aesgcm` (AES-GCM-256, `deletion_allowed=false`, `exportable=false`, `allow_plaintext_backup=false`).
- Policy `uniplus-api-transit` (apenas `update` em `transit/encrypt|decrypt/uniplus-idempotency-aesgcm` — **least privilege**, sem `read`, `rewrap`, `datakey`, `export`, `backup`, `rotate`).
- Role K8s auth `uniplus-api` (bound SA `uniplus-api` / ns `uniplus`, TTL 1h).

Pattern espelha `apps/keycloak-replica/templates/realm-reconcile-job.yaml` — Job Helm hook reconcila estado declarativo.

### Idempotência

- **Mount transit/**: `vault secrets list` antes de `enable`.
- **Key**: read-before-create; se já existir, valida drift em `type`/`exportable`/`allow_plaintext_backup` e **aborta** se divergente (proteção contra reuse acidental de key com flag inseguro). `deletion_allowed` reconciliado em todo deploy via endpoint `/config` (que aceita esse flag — write inicial não aceita, gera warning).
- **Policy**: `vault policy write` é idempotente (substitui pelo conteúdo do stdin).
- **Role**: `vault write` é idempotente.

### Hardening do Job

- `runAsNonRoot=true`, `runAsUser=100`, `runAsGroup=1000`.
- `readOnlyRootFilesystem=true`, `allowPrivilegeEscalation=false`, `capabilities.drop=[ALL]`, `seccompProfile.type=RuntimeDefault`.
- `automountServiceAccountToken=false` (Vault CLI não chama K8s API).
- NetworkPolicy egress restrito ao **pod do Vault** (`namespaceSelector` + `podSelector: app.kubernetes.io/name=vault, component=server`) + DNS. Sem ingress.
- ExternalSecret é resource normal (não hook) para garantir Secret K8s materializado antes do Job rodar.

### Trade-off de segurança documentado

Em standalone, o `ExternalSecret` consome **root token** do Vault em `secret/standalone/vault/root`. Deliberadamente excessivo para o escopo de bootstrap (`sys/mounts`, `transit/*`, `sys/policies/acl`, `auth/kubernetes/role`). Plano de redução para policy mínima documentado em `platform/vault-transit-bootstrap/README.md` e no RUNBOOK §17.5 — a executar **antes da Fase 6**.

### Wire-up

- `argocd/applicationset.yaml`: registra `vault-transit-bootstrap` na lista de components do `uniplus-platform` AppSet (alfabeticamente ao lado de `vault-transit`).
- `environments/standalone/values.yaml`: habilita o chart e seta `vault.address` para o Service local. Outros environments ficam `enabled=false` por default no chart.
- `docs/RUNBOOKS.md` §17: verificação de saúde, rotação da key (com `rewrap` dos consumers), revogação da role em incidente, cleanup manual fora do GitOps, trade-off do token.

## Validação local

```
helm lint platform/vault-transit-bootstrap/    # OK
helm template ... (5 resources renderizam)     # OK
yamllint platform/vault-transit-bootstrap/ ... # OK
```

## Evidência ao vivo

Script de bootstrap executado ponta-a-ponta contra `platform-vault-uniplus-standalone-0` (Vault Shamir manual, HA Mode active, Sealed=false).

**Primeira execução (criação dos 4 recursos):**

```
[vault-transit-bootstrap] Vault disponível e unsealed.
[vault-transit-bootstrap] Habilitando mount 'transit/'
[vault-transit-bootstrap] Criando key 'transit/keys/uniplus-idempotency-aesgcm'
[vault-transit-bootstrap] Reconciliando deletion_allowed da key 'uniplus-idempotency-aesgcm'
[vault-transit-bootstrap] Reconciliando policy 'uniplus-api-transit'
[vault-transit-bootstrap] Reconciliando role 'auth/kubernetes/role/uniplus-api'
[vault-transit-bootstrap] Bootstrap concluído com sucesso.
```

**Segunda execução (idempotência + drift detection):**

```
[vault-transit-bootstrap] Mount 'transit/' já habilitado — skip enable.
[vault-transit-bootstrap] Key 'transit/keys/uniplus-idempotency-aesgcm' já existe — validando drift de segurança.
[vault-transit-bootstrap] Drift check OK: type/exportable/allow_plaintext_backup conformes.
[vault-transit-bootstrap] Reconciliando deletion_allowed da key 'uniplus-idempotency-aesgcm'
[vault-transit-bootstrap] Reconciliando policy 'uniplus-api-transit'
[vault-transit-bootstrap] Reconciliando role 'auth/kubernetes/role/uniplus-api'
[vault-transit-bootstrap] Bootstrap concluído com sucesso.
```

**Estado final no Vault:**

```
$ vault secrets list | grep transit
transit/      transit      transit_fafd115e      n/a

$ vault read transit/keys/uniplus-idempotency-aesgcm
allow_plaintext_backup    false
auto_rotate_period        0s
deletion_allowed          false
derived                   false
exportable                false
keys                      map[1:...]
latest_version            1
min_decryption_version    1
name                      uniplus-idempotency-aesgcm
supports_decryption       true
supports_encryption       true
type                      aes256-gcm96

$ vault read auth/kubernetes/role/uniplus-api
alias_name_source                serviceaccount_uid
bound_service_account_names      [uniplus-api]
bound_service_account_namespaces [uniplus]
policies                         [uniplus-api-transit]
token_policies                   [uniplus-api-transit]
token_ttl                        1h
ttl                              1h

$ vault policy read uniplus-api-transit
path "transit/encrypt/uniplus-idempotency-aesgcm" {
  capabilities = ["update"]
}

path "transit/decrypt/uniplus-idempotency-aesgcm" {
  capabilities = ["update"]
}
```

## Codex CLI rounds aplicados

3 rodadas absorveram:

- **P1**: drift detection bloqueante em type/exportable/allow_plaintext_backup (vs apenas reconcile silencioso).
- **P1**: trade-off do root token documentado no README + RUNBOOK em vez de ficar implícito.
- **P2**: ExternalSecret deixa de ser Helm hook (eliminando race com ESO controller).
- **P2**: NetworkPolicy adiciona `podSelector` para vault server pods (não qualquer pod no namespace).
- **P2**: `vault status` + checagem explícita de `sealed=false` (não só CLI alcançável).
- **P2**: hook `post-rollback` adicionado (rollback Helm também reconcilia).
- **P2**: `deletion_allowed` reconciliado via endpoint `/config` (evita warning `Endpoint ignored parameters`).
- **P3**: script extraído para `files/bootstrap-vault-transit.sh` (shellcheck-friendly).
- **P3**: RUNBOOK com placeholder `<k8s-host>` + `<root-token>` em vez de literal.

## Fora de escopo

- **Warm-up eager do Job**: não é forçado a rodar no startup do ArgoCD; segue lifecycle Helm hook nativo. ApplicationSet sync aplica recursos + hooks na ordem; se o hook falhar, ArgoCD marca a app `Degraded` e ele fica disponível no `kc describe job` para inspeção (hook-delete-policy preserva em falha).
- **Wire-up da uniplus-api para Provider=vault**: escopo de `uniplus-infra#220`.

## Test plan

- [x] helm lint
- [x] helm template renderiza 5 resources (SA, ES, CM, NP, Job) + 1 ConfigMap script
- [x] yamllint clean
- [x] bootstrap script executado ao vivo no Vault standalone (2 execuções: cria + idempotente com drift detection)
- [x] vault secrets list mostra transit/
- [x] vault read transit/keys/... mostra key com flags corretos
- [x] vault read auth/kubernetes/role/uniplus-api mostra role bound a uniplus-api/uniplus + policy uniplus-api-transit + TTL 1h
- [x] vault policy read uniplus-api-transit mostra 2 paths capability=[update]
- [ ] CI verde (apenas `PR author is org member` é required; lint workflows são warning-only)
- [ ] Review humano (jf2s)