### PR TITLE
feat(grafana): adicionar datasources Loki + Tempo com correlação trace↔logs

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -165,6 +165,51 @@ grafana:
           isDefault: true
           jsonData:
             timeInterval: 30s
+        # Loki — backend de logs (chart platform/observability/loki/, ADR-011).
+        - name: Loki
+          type: loki
+          uid: loki
+          access: proxy
+          url: http://platform-observability-loki-uniplus-standalone.observability-loki.svc.cluster.local:3100
+          jsonData:
+            # derivedFields: ao ver `traceID` (formato OTel) ou `trace_id` no log,
+            # Grafana renderiza link clicável que abre o trace no datasource Tempo.
+            # Habilita navegação log → trace (correlação via traceID dos apps
+            # .NET OpenTelemetry SDK).
+            derivedFields:
+              - name: TraceID
+                matcherRegex: "(?:traceID|trace_id|TraceId)\"?[=:]\\s*\"?([a-fA-F0-9]{32})"
+                url: "$${__value.raw}"
+                datasourceUid: tempo
+                urlDisplayLabel: "Ver trace no Tempo"
+        # Tempo — backend de traces (chart platform/observability/tempo/, ADR-012).
+        - name: Tempo
+          type: tempo
+          uid: tempo
+          access: proxy
+          url: http://platform-observability-tempo-uniplus-standalone.observability-tempo.svc.cluster.local:3200
+          jsonData:
+            # tracesToLogsV2: do trace, abre query no Loki filtrando pela
+            # mesma trace_id. Direção inversa da derivedFields acima — fecha
+            # o ciclo trace ↔ logs.
+            tracesToLogsV2:
+              datasourceUid: loki
+              spanStartTimeShift: "-5m"
+              spanEndTimeShift: "5m"
+              filterByTraceID: true
+              filterBySpanID: false
+              tags:
+                - key: service.name
+                  value: service_name
+            # Service Graph desligado — Tempo metricsGenerator off em standalone (ADR-012).
+            serviceMap:
+              datasourceUid: prometheus
+            nodeGraph:
+              enabled: true
+            search:
+              hide: false
+            lokiSearch:
+              datasourceUid: loki
 
 # ============================================================================
 # Wiring real do chart platform/observability/loki/ — overrides standalone:


### PR DESCRIPTION
Refs #3, #28, #29, #30

## Resumo

Fase 3 do plano de observability: agora que Loki (#28), Tempo (#29) e OTel Collector (#30) estão Healthy/Synced, habilita os 2 datasources que estavam gateados no values do Grafana standalone.

## O que entrega

- **Loki datasource** (uid: \`loki\`) — backend de logs
- **Tempo datasource** (uid: \`tempo\`) — backend de traces
- **derivedFields** no Loki: regex captura \`traceID\`/\`trace_id\`/\`TraceId\` em qualquer log entry, renderiza link **\"Ver trace no Tempo\"** clicável que abre o trace correspondente no datasource Tempo (correlação log → trace).
- **tracesToLogsV2** no Tempo: do trace aberto, abre query LogQL no Loki filtrada pela mesma \`trace_id\` (window ±5min). Tag \`service.name → service_name\` (label do k8sattributes do OTel Collector). Fecha o ciclo trace → log.

## Pré-requisitos satisfeitos

- ✅ Loki em \`observability-loki\` Healthy (PR #221)
- ✅ Tempo em \`observability-tempo\` Healthy (PR #222)
- ✅ OTel Collector em \`observability-otelcol\` Healthy + populando Loki/Tempo (PR #224)
- ✅ NetworkPolicy do Loki/Tempo já permite ingress de \`observability-grafana\` (em \`lokiWrapper.networkPolicy.ingressNamespaces\` e \`tempoWrapper.*\`)

## Validação local

\`\`\`bash
$ helm template platform-observability-grafana-uniplus-standalone \
    platform/observability/grafana -f environments/standalone/values.yaml | \
    grep -B1 -A3 'name: Loki\|name: Tempo'
# 2 datasources novos no ConfigMap grafana-datasources com URLs corretas
\`\`\`

## Plano pós-merge

1. Argo refresh + sync app \`platform-observability-grafana-uniplus-standalone\`
2. Sidecar de datasources do Grafana detecta novo ConfigMap → reload automático (sem restart do pod)
3. Browser: <https://standalone.portaluni.com.br/grafana/> → Connections → Data sources → ver Loki + Tempo
4. Explore: query \`{k8s_namespace_name=\"uniplus\"}\` em Loki retorna logs coletados pelo OTel Collector
5. Reportar snapshot

## Risco

Mínimo: apenas adiciona datasources read-only. Sem alteração nos backends. Rollback = revert do PR.

## Próximo (Fase 4)

- Smoke E2E completo: forçar erro 500 na API Uni+ → ver traceId no log do Loki → clicar derived field link → ver trace no Tempo (correlação visual ponta-a-ponta).
- Documentar em \`/home/jeferson/configs/uniplus-standalone/13-observability.md\`.