### PR TITLE
feat(api): plugar uniplus-api ao Vault Transit no standalone

### DIFF
--- a/apps/uniplus-api-ingresso/templates/deployment.yaml
+++ b/apps/uniplus-api-ingresso/templates/deployment.yaml
@@ -14,6 +14,14 @@
 {{- if and .Values.uniplusApiIngresso.kafka.enabled (not .Values.uniplusApiIngresso.kafka.bootstrapServers) -}}
 {{- fail "uniplusApiIngresso.kafka.bootstrapServers é obrigatório quando kafka.enabled=true." -}}
 {{- end -}}
+{{- if eq .Values.uniplusApiIngresso.encryption.provider "vault" -}}
+  {{- if not .Values.uniplusApiIngresso.encryption.vaultAddress -}}
+  {{- fail "uniplusApiIngresso.encryption.vaultAddress é obrigatório quando encryption.provider=vault. Configurar em environments/<env>/values.yaml (ex.: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200)." -}}
+  {{- end -}}
+  {{- if not .Values.uniplusApiIngresso.encryption.kubernetesRole -}}
+  {{- fail "uniplusApiIngresso.encryption.kubernetesRole é obrigatório quando encryption.provider=vault. A role precisa existir no Vault (uniplus-infra#219) com bound_service_account_names incluindo a SA deste chart." -}}
+  {{- end -}}
+{{- end -}}
 {{- if not .Values.uniplusApiIngresso.externalSecrets.enabled -}}
 {{- fail "uniplusApiIngresso.enabled=true requer externalSecrets.enabled=true. Deployment depende dos Secrets sintetizados pelo ESO (Postgres password, Redis, MinIO, Kafka, OIDC)." -}}
 {{- end -}}
@@ -40,6 +48,12 @@ spec:
         {{- include "uniplusApiIngresso.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "uniplusApiIngresso.serviceAccountName" . }}
+      # automountServiceAccountToken=true é necessário quando Provider=vault:
+      # VaultTransitEncryptionService lê o JWT projetado em
+      # /var/run/secrets/kubernetes.io/serviceaccount/token e autentica no
+      # Vault via auth/kubernetes/login. Modo local não usa o token, mas
+      # manter true não tem custo prático e mantém simetria entre providers.
+      automountServiceAccountToken: true
       {{- with .Values.uniplusApiIngresso.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -130,6 +144,20 @@ spec:
               value: {{ .Values.uniplusApiIngresso.oidc.issuerUri | quote }}
             - name: Auth__Audience
               value: {{ .Values.uniplusApiIngresso.oidc.audience | quote }}
+            {{- end }}
+            # === Cifragem (UniPlus:Encryption — uniplus-api #400/#402/#404/#405) ===
+            # Provider=local exige LocalKey via env/Secret; Provider=vault exige
+            # VaultAddress + KubernetesRole bound à ServiceAccount deste Deployment.
+            # EncryptionOptionsValidator (uniplus-api) derruba o pod no boot se a
+            # combinação estiver inconsistente; EncryptionWarmupHostedService força
+            # a resolução do singleton em Host.StartAsync para fail-fast garantido.
+            - name: UniPlus__Encryption__Provider
+              value: {{ .Values.uniplusApiIngresso.encryption.provider | quote }}
+            {{- if eq .Values.uniplusApiIngresso.encryption.provider "vault" }}
+            - name: UniPlus__Encryption__VaultAddress
+              value: {{ .Values.uniplusApiIngresso.encryption.vaultAddress | quote }}
+            - name: UniPlus__Encryption__KubernetesRole
+              value: {{ .Values.uniplusApiIngresso.encryption.kubernetesRole | quote }}
             {{- end }}
             
             {{- range $i, $origin := .Values.uniplusApiIngresso.cors.allowedOrigins }}

--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -32,8 +32,22 @@ uniplusApiIngresso:
       memory: 512Mi
 
   serviceAccount:
+    # Nome FIXO para que a role Vault Kubernetes auth (uniplus-api) — que
+    # vincula bound_service_account_names — encontre esta SA independente
+    # do release name gerado pelo ApplicationSet (`uniplus-api-ingresso-<env>`).
+    # Mesmo pattern usado em platform/external-secrets/values.yaml linha 31.
     create: true
-    name: ""
+    name: uniplus-api-ingresso
+
+  # Cifragem (UniPlus:Encryption). Default Provider=local exige LocalKey via
+  # appsettings/Vault — environment override pode trocar para vault em cluster
+  # onde platform/vault-transit-bootstrap está aplicado (uniplus-infra#219).
+  # Pré-requisito quando Provider=vault: kubernetesRole deve existir no Vault
+  # com bound_service_account_names incluindo serviceAccount.name acima.
+  encryption:
+    provider: local
+    vaultAddress: ""
+    kubernetesRole: ""
 
   aspnet:
     environment: Production

--- a/apps/uniplus-api-portal/templates/deployment.yaml
+++ b/apps/uniplus-api-portal/templates/deployment.yaml
@@ -14,6 +14,14 @@
 {{- if and .Values.uniplusApiPortal.kafka.enabled (not .Values.uniplusApiPortal.kafka.bootstrapServers) -}}
 {{- fail "uniplusApiPortal.kafka.bootstrapServers é obrigatório quando kafka.enabled=true." -}}
 {{- end -}}
+{{- if eq .Values.uniplusApiPortal.encryption.provider "vault" -}}
+  {{- if not .Values.uniplusApiPortal.encryption.vaultAddress -}}
+  {{- fail "uniplusApiPortal.encryption.vaultAddress é obrigatório quando encryption.provider=vault. Configurar em environments/<env>/values.yaml (ex.: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200)." -}}
+  {{- end -}}
+  {{- if not .Values.uniplusApiPortal.encryption.kubernetesRole -}}
+  {{- fail "uniplusApiPortal.encryption.kubernetesRole é obrigatório quando encryption.provider=vault. A role precisa existir no Vault (uniplus-infra#219) com bound_service_account_names incluindo a SA deste chart." -}}
+  {{- end -}}
+{{- end -}}
 {{- if not .Values.uniplusApiPortal.externalSecrets.enabled -}}
 {{- fail "uniplusApiPortal.enabled=true requer externalSecrets.enabled=true. Deployment depende dos Secrets sintetizados pelo ESO (Postgres password, Redis, MinIO, Kafka, OIDC)." -}}
 {{- end -}}
@@ -40,6 +48,12 @@ spec:
         {{- include "uniplusApiPortal.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "uniplusApiPortal.serviceAccountName" . }}
+      # automountServiceAccountToken=true é necessário quando Provider=vault:
+      # VaultTransitEncryptionService lê o JWT projetado em
+      # /var/run/secrets/kubernetes.io/serviceaccount/token e autentica no
+      # Vault via auth/kubernetes/login. Modo local não usa o token, mas
+      # manter true não tem custo prático e mantém simetria entre providers.
+      automountServiceAccountToken: true
       {{- with .Values.uniplusApiPortal.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -130,6 +144,20 @@ spec:
               value: {{ .Values.uniplusApiPortal.oidc.issuerUri | quote }}
             - name: Auth__Audience
               value: {{ .Values.uniplusApiPortal.oidc.audience | quote }}
+            {{- end }}
+            # === Cifragem (UniPlus:Encryption — uniplus-api #400/#402/#404/#405) ===
+            # Provider=local exige LocalKey via env/Secret; Provider=vault exige
+            # VaultAddress + KubernetesRole bound à ServiceAccount deste Deployment.
+            # EncryptionOptionsValidator (uniplus-api) derruba o pod no boot se a
+            # combinação estiver inconsistente; EncryptionWarmupHostedService força
+            # a resolução do singleton em Host.StartAsync para fail-fast garantido.
+            - name: UniPlus__Encryption__Provider
+              value: {{ .Values.uniplusApiPortal.encryption.provider | quote }}
+            {{- if eq .Values.uniplusApiPortal.encryption.provider "vault" }}
+            - name: UniPlus__Encryption__VaultAddress
+              value: {{ .Values.uniplusApiPortal.encryption.vaultAddress | quote }}
+            - name: UniPlus__Encryption__KubernetesRole
+              value: {{ .Values.uniplusApiPortal.encryption.kubernetesRole | quote }}
             {{- end }}
             
             {{- range $i, $origin := .Values.uniplusApiPortal.cors.allowedOrigins }}

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -32,8 +32,22 @@ uniplusApiPortal:
       memory: 512Mi
 
   serviceAccount:
+    # Nome FIXO para que a role Vault Kubernetes auth (uniplus-api) — que
+    # vincula bound_service_account_names — encontre esta SA independente
+    # do release name gerado pelo ApplicationSet (`uniplus-api-portal-<env>`).
+    # Mesmo pattern usado em platform/external-secrets/values.yaml linha 31.
     create: true
-    name: ""
+    name: uniplus-api-portal
+
+  # Cifragem (UniPlus:Encryption). Default Provider=local exige LocalKey via
+  # appsettings/Vault — environment override pode trocar para vault em cluster
+  # onde platform/vault-transit-bootstrap está aplicado (uniplus-infra#219).
+  # Pré-requisito quando Provider=vault: kubernetesRole deve existir no Vault
+  # com bound_service_account_names incluindo serviceAccount.name acima.
+  encryption:
+    provider: local
+    vaultAddress: ""
+    kubernetesRole: ""
 
   aspnet:
     environment: Production

--- a/apps/uniplus-api-selecao/templates/deployment.yaml
+++ b/apps/uniplus-api-selecao/templates/deployment.yaml
@@ -14,6 +14,14 @@
 {{- if and .Values.uniplusApiSelecao.kafka.enabled (not .Values.uniplusApiSelecao.kafka.bootstrapServers) -}}
 {{- fail "uniplusApiSelecao.kafka.bootstrapServers é obrigatório quando kafka.enabled=true." -}}
 {{- end -}}
+{{- if eq .Values.uniplusApiSelecao.encryption.provider "vault" -}}
+  {{- if not .Values.uniplusApiSelecao.encryption.vaultAddress -}}
+  {{- fail "uniplusApiSelecao.encryption.vaultAddress é obrigatório quando encryption.provider=vault. Configurar em environments/<env>/values.yaml (ex.: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200)." -}}
+  {{- end -}}
+  {{- if not .Values.uniplusApiSelecao.encryption.kubernetesRole -}}
+  {{- fail "uniplusApiSelecao.encryption.kubernetesRole é obrigatório quando encryption.provider=vault. A role precisa existir no Vault (uniplus-infra#219) com bound_service_account_names incluindo a SA deste chart." -}}
+  {{- end -}}
+{{- end -}}
 {{- if not .Values.uniplusApiSelecao.externalSecrets.enabled -}}
 {{- fail "uniplusApiSelecao.enabled=true requer externalSecrets.enabled=true. Deployment depende dos Secrets sintetizados pelo ESO (Postgres password, Redis, MinIO, Kafka, OIDC)." -}}
 {{- end -}}
@@ -40,6 +48,12 @@ spec:
         {{- include "uniplusApiSelecao.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "uniplusApiSelecao.serviceAccountName" . }}
+      # automountServiceAccountToken=true é necessário quando Provider=vault:
+      # VaultTransitEncryptionService lê o JWT projetado em
+      # /var/run/secrets/kubernetes.io/serviceaccount/token e autentica no
+      # Vault via auth/kubernetes/login. Modo local não usa o token, mas
+      # manter true não tem custo prático e mantém simetria entre providers.
+      automountServiceAccountToken: true
       {{- with .Values.uniplusApiSelecao.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -130,6 +144,20 @@ spec:
               value: {{ .Values.uniplusApiSelecao.oidc.issuerUri | quote }}
             - name: Auth__Audience
               value: {{ .Values.uniplusApiSelecao.oidc.audience | quote }}
+            {{- end }}
+            # === Cifragem (UniPlus:Encryption — uniplus-api #400/#402/#404/#405) ===
+            # Provider=local exige LocalKey via env/Secret; Provider=vault exige
+            # VaultAddress + KubernetesRole bound à ServiceAccount deste Deployment.
+            # EncryptionOptionsValidator (uniplus-api) derruba o pod no boot se a
+            # combinação estiver inconsistente; EncryptionWarmupHostedService força
+            # a resolução do singleton em Host.StartAsync para fail-fast garantido.
+            - name: UniPlus__Encryption__Provider
+              value: {{ .Values.uniplusApiSelecao.encryption.provider | quote }}
+            {{- if eq .Values.uniplusApiSelecao.encryption.provider "vault" }}
+            - name: UniPlus__Encryption__VaultAddress
+              value: {{ .Values.uniplusApiSelecao.encryption.vaultAddress | quote }}
+            - name: UniPlus__Encryption__KubernetesRole
+              value: {{ .Values.uniplusApiSelecao.encryption.kubernetesRole | quote }}
             {{- end }}
             
             {{- range $i, $origin := .Values.uniplusApiSelecao.cors.allowedOrigins }}

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -32,8 +32,22 @@ uniplusApiSelecao:
       memory: 512Mi
 
   serviceAccount:
+    # Nome FIXO para que a role Vault Kubernetes auth (uniplus-api) — que
+    # vincula bound_service_account_names — encontre esta SA independente
+    # do release name gerado pelo ApplicationSet (`uniplus-api-selecao-<env>`).
+    # Mesmo pattern usado em platform/external-secrets/values.yaml linha 31.
     create: true
-    name: ""
+    name: uniplus-api-selecao
+
+  # Cifragem (UniPlus:Encryption). Default Provider=local exige LocalKey via
+  # appsettings/Vault — environment override pode trocar para vault em cluster
+  # onde platform/vault-transit-bootstrap está aplicado (uniplus-infra#219).
+  # Pré-requisito quando Provider=vault: kubernetesRole deve existir no Vault
+  # com bound_service_account_names incluindo serviceAccount.name acima.
+  encryption:
+    provider: local
+    vaultAddress: ""
+    kubernetesRole: ""
 
   aspnet:
     environment: Production

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -3482,9 +3482,15 @@ A role Kubernetes auth `uniplus-api` no Vault tem `bound_service_account_names=u
 ### 18.2 Validar consumo via smoke E2E
 
 ```bash
+# Credenciais Keycloak (apicurio-registry client com directGrants habilitado)
 export KEYCLOAK_CLIENT_SECRET=<apicurio-registry client_secret>
 export KEYCLOAK_USERNAME=jeferson.ferreira
 export KEYCLOAK_PASSWORD=<senha>
+
+# Token Vault necessário para listar audit devices (sys/audit requer capability
+# sudo). Em standalone, usar root token; em ambientes onde uma policy bootstrap
+# mínima existir, usar o token dedicado.
+export VAULT_TOKEN_FOR_AUDIT=<root token ou token com sys/audit>
 
 ./scripts/smoke-encryption-e2e.sh
 ```

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -3465,4 +3465,92 @@ O `ExternalSecret` deste chart consome o **root token** do Vault em standalone. 
 
 ---
 
+## 18. Wire-up uniplus-api → Vault Transit (standalone)
+
+Issue [#220](https://github.com/unifesspa-edu-br/uniplus-infra/issues/220). Os 3 charts `apps/uniplus-api-{portal,selecao,ingresso}` em standalone passam a usar `Provider=vault` por padrão, consumindo a key `uniplus-idempotency-aesgcm` provisionada pelo chart `platform/vault-transit-bootstrap` (§17).
+
+### 18.1 Topologia das ServiceAccounts
+
+Cada chart cria sua própria ServiceAccount com nome FIXO:
+
+- `uniplus-api-portal` (chart `apps/uniplus-api-portal`)
+- `uniplus-api-selecao` (chart `apps/uniplus-api-selecao`)
+- `uniplus-api-ingresso` (chart `apps/uniplus-api-ingresso`)
+
+A role Kubernetes auth `uniplus-api` no Vault tem `bound_service_account_names=uniplus-api-portal,uniplus-api-selecao,uniplus-api-ingresso` (CSV, namespace `uniplus`) e `policies=[uniplus-api-transit]` — única role para os 3 charts.
+
+### 18.2 Validar consumo via smoke E2E
+
+```bash
+export KEYCLOAK_CLIENT_SECRET=<apicurio-registry client_secret>
+export KEYCLOAK_USERNAME=jeferson.ferreira
+export KEYCLOAK_PASSWORD=<senha>
+
+./scripts/smoke-encryption-e2e.sh
+```
+
+O script:
+
+1. Obtém token OIDC do realm `uniplus` validando audience.
+2. POST `/api/v1/selecao/editais` com `Idempotency-Key` UUID — exercita o `IdempotencyFilter` da uniplus-api que toca cifragem.
+3. Espera HTTP 201/422 (ambos válidos — qualquer 5xx é regressão).
+4. Lê audit log do Vault buscando entrada `transit/encrypt/uniplus-idempotency-aesgcm`.
+
+Pré-requisito: audit device habilitado no Vault. Se ausente, o script pula o passo 4 com aviso. Para habilitar:
+
+```bash
+ssh -i ~/.ssh/id_ed25519 ubuntu@<k8s-host> "
+  sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml -n vault exec -i \
+    platform-vault-uniplus-standalone-0 -- \
+    env VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=<root> \
+    vault audit enable file file_path=/vault/audit/audit.log"
+```
+
+### 18.3 Inspecionar o Pod da uniplus-api
+
+```bash
+sudo kubectl -n uniplus describe pod uniplus-api-selecao-uniplus-standalone-...
+# Confirmar:
+#   - serviceAccountName=uniplus-api-selecao
+#   - automountServiceAccountToken=true
+#   - env UniPlus__Encryption__Provider=vault
+#   - env UniPlus__Encryption__VaultAddress=http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
+#   - env UniPlus__Encryption__KubernetesRole=uniplus-api
+
+sudo kubectl -n uniplus logs deploy/uniplus-api-selecao-uniplus-standalone-... | grep -i encryption
+# Esperado: log inicial mostra Provider=vault sendo selecionado. Sem mensagens
+# de fail-fast (CrashLoopBackOff indicaria validator/warmup bloqueando).
+```
+
+### 18.4 Rollback para Provider=local
+
+Trocar `encryption.provider` de `vault` para `local` em `environments/standalone/values.yaml` para cada um dos 3 blocos `uniplusApi{Portal,Selecao,Ingresso}` **não basta** — o pod entrará em `CrashLoopBackOff` porque `EncryptionOptionsValidator` da uniplus-api (PR #401) exige `LocalKey` quando Provider=local.
+
+Rollback completo é um PR separado, pois os charts atuais não têm wire-up de `UniPlus__Encryption__LocalKey` via Secret. Passos:
+
+1. **Gerar e custodiar a chave**:
+
+   ```bash
+   head -c 32 /dev/urandom | base64
+   # Custodiar em Vault: vault kv put secret/standalone/uniplus-api/encryption-local key=<gerada>
+   ```
+
+2. **No PR de rollback**:
+   - Adicionar `ExternalSecret` (`apps/uniplus-api-*/templates/externalsecret.yaml`) materializando Secret K8s com key `LOCAL_KEY` a partir de `secret/standalone/uniplus-api/encryption-local`.
+   - Adicionar env var no Deployment: `UniPlus__Encryption__LocalKey` referenciando o Secret via `secretKeyRef`.
+   - Trocar `encryption.provider: vault` para `local` no environments/standalone/values.yaml + zerar `vaultAddress`/`kubernetesRole`.
+
+3. **Aplicar via ArgoCD + verificar** que o pod não está mais consumindo Transit no audit log.
+
+Em emergência (rollback de produção sem PR), aplicar manualmente os 2 recursos via `kubectl apply -f` e setar override `--set encryption.provider=local --set encryption.localKey=<chave>` na próxima sync do ArgoCD. **Avisar o time** porque a mudança vai ser sobrescrita pelo próximo `argocd sync` se não for committada.
+
+### 18.5 Dependência da imagem
+
+O fail-fast completo (validator + warmup hosted service) está nos PRs uniplus-api#401, #403, #406, #407 — mergeados nesta sessão. A próxima imagem GHCR publicada (provavelmente `v0.2.x` após cut da release) terá esses bits. Até lá, em produção standalone:
+
+- Se a imagem atual NÃO tiver os bits do #400/#405, configurações inconsistentes ainda caem em "500 silencioso na primeira request cifrada" em vez de `CrashLoopBackOff`. O wire-up deste #220 funciona mesmo assim — apenas perde a defesa em profundidade.
+- Para validar fail-fast completo, executar smoke #220 contra imagem nova quando publicada.
+
+---
+
 *Documento mantido pelo CTIC/UNIFESSPA. Atualizações via Pull Request.*

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -949,6 +949,13 @@ uniplusApiPortal:
     enabled: true
     dataHostCIDR: 10.0.2.0/24
     oidcIssuerCIDR: 164.152.53.29/32
+  # Cifragem via Vault Transit local (uniplus-infra#219 + uniplus-api#400/#402/#404/#405).
+  # KubernetesRole=uniplus-api é a role criada pelo chart platform/vault-transit-bootstrap/
+  # com bound_service_account_names incluindo uniplus-api-portal/uniplus-api-selecao/uniplus-api-ingresso.
+  encryption:
+    provider: vault
+    vaultAddress: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
+    kubernetesRole: uniplus-api
 
 uniplusApiSelecao:
   enabled: true
@@ -983,6 +990,10 @@ uniplusApiSelecao:
     enabled: true
     dataHostCIDR: 10.0.2.0/24
     oidcIssuerCIDR: 164.152.53.29/32
+  encryption:
+    provider: vault
+    vaultAddress: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
+    kubernetesRole: uniplus-api
 
 uniplusApiIngresso:
   enabled: true
@@ -1017,6 +1028,10 @@ uniplusApiIngresso:
     enabled: true
     dataHostCIDR: 10.0.2.0/24
     oidcIssuerCIDR: 164.152.53.29/32
+  encryption:
+    provider: vault
+    vaultAddress: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
+    kubernetesRole: uniplus-api
 
 # ----------------------------------------------------------------------------
 # Frontends Uni+ (Angular SPAs servidas por nginx-unprivileged). 1 chart,

--- a/platform/vault-transit-bootstrap/README.md
+++ b/platform/vault-transit-bootstrap/README.md
@@ -58,7 +58,7 @@ sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml -n vault exec -i \
 | `vaultTransitBootstrap.key.allowPlaintextBackup` | bool | `false` | Snapshot inclui plaintext. |
 | `vaultTransitBootstrap.policy.name` | string | `uniplus-api-transit` | Nome da policy. |
 | `vaultTransitBootstrap.role.name` | string | `uniplus-api` | Nome da role K8s auth. |
-| `vaultTransitBootstrap.role.boundSa` | string | `uniplus-api` | ServiceAccount autorizada. |
+| `vaultTransitBootstrap.role.boundSa` | string | `uniplus-api-portal,uniplus-api-selecao,uniplus-api-ingresso` | ServiceAccounts autorizadas (CSV — Vault aceita múltiplas SAs na mesma role). |
 | `vaultTransitBootstrap.role.boundNs` | string | `uniplus` | Namespace da ServiceAccount. |
 | `vaultTransitBootstrap.role.ttl` | string | `1h` | TTL do token Vault emitido. |
 | `vaultTransitBootstrap.externalSecret.secretStoreName` | string | `vault-default` | ClusterSecretStore que materializa o token. |

--- a/platform/vault-transit-bootstrap/values.yaml
+++ b/platform/vault-transit-bootstrap/values.yaml
@@ -50,11 +50,16 @@ vaultTransitBootstrap:
   policy:
     name: uniplus-api-transit
 
-  # Role K8s auth que a uniplus-api usa para autenticar no Vault. boundSa
-  # e boundNs precisam corresponder à ServiceAccount real dos pods da API.
+  # Role K8s auth que as APIs uniplus-api-{portal,selecao,ingresso} usam para
+  # autenticar no Vault. boundSa é uma lista CSV (Vault aceita múltiplos
+  # bound_service_account_names em uma única role) — cada chart deployado
+  # cria sua própria ServiceAccount com nome FIXO `uniplus-api-<app>` para
+  # que esta role autorize as 3 SAs simultaneamente sem proliferar roles.
+  # boundNs continua único (uniplus) porque os 3 charts rodam no mesmo
+  # namespace conforme o ApplicationSet uniplus-apps.
   role:
     name: uniplus-api
-    boundSa: uniplus-api
+    boundSa: uniplus-api-portal,uniplus-api-selecao,uniplus-api-ingresso
     boundNs: uniplus
     # TTL do token Vault emitido pela role. 1h é compatível com o refresh
     # do JWT do K8s no volume projetado do ServiceAccount.

--- a/scripts/smoke-encryption-e2e.sh
+++ b/scripts/smoke-encryption-e2e.sh
@@ -47,6 +47,10 @@ fail() {
 : "${KEYCLOAK_CLIENT_SECRET:?KEYCLOAK_CLIENT_SECRET é obrigatório (apicurio-registry client_secret no realm uniplus)}"
 : "${KEYCLOAK_USERNAME:?KEYCLOAK_USERNAME é obrigatório (usuário no realm uniplus com directAccessGrants permitido)}"
 : "${KEYCLOAK_PASSWORD:?KEYCLOAK_PASSWORD é obrigatório}"
+# Token Vault necessário para listar audit devices (/sys/audit exige token
+# com `sudo` capability — root ou policy dedicada). Permanece em var
+# separada para que o operador rotacione independentemente do KEYCLOAK_*.
+: "${VAULT_TOKEN_FOR_AUDIT:?VAULT_TOKEN_FOR_AUDIT é obrigatório (Vault token com capability sudo em sys/audit; tipicamente root token em standalone). Exportar antes de rodar.}"
 
 command -v curl >/dev/null 2>&1 || fail "curl não encontrado"
 command -v jq >/dev/null 2>&1 || fail "jq não encontrado"
@@ -57,14 +61,18 @@ command -v ssh >/dev/null 2>&1 || fail "ssh não encontrado"
 
 log "Obtendo token OIDC para client=${KEYCLOAK_CLIENT_ID} user=${KEYCLOAK_USERNAME}"
 
+# `--data-urlencode` é obrigatório aqui: senhas/secrets podem conter `&`,
+# `=`, `+` ou `%` que `curl -d` envia literalmente, corrompendo o form e
+# gerando 401 enganoso. URL-encode garante que credenciais com caracteres
+# especiais sejam transmitidas íntegras.
 token_response=$(curl -sk -X POST \
     "${KEYCLOAK_BASE}/protocol/openid-connect/token" \
-    -d "grant_type=password" \
-    -d "client_id=${KEYCLOAK_CLIENT_ID}" \
-    -d "client_secret=${KEYCLOAK_CLIENT_SECRET}" \
-    -d "username=${KEYCLOAK_USERNAME}" \
-    -d "password=${KEYCLOAK_PASSWORD}" \
-    -d "scope=openid")
+    --data-urlencode "grant_type=password" \
+    --data-urlencode "client_id=${KEYCLOAK_CLIENT_ID}" \
+    --data-urlencode "client_secret=${KEYCLOAK_CLIENT_SECRET}" \
+    --data-urlencode "username=${KEYCLOAK_USERNAME}" \
+    --data-urlencode "password=${KEYCLOAK_PASSWORD}" \
+    --data-urlencode "scope=openid")
 
 access_token=$(echo "$token_response" | jq -r .access_token)
 
@@ -167,10 +175,13 @@ log "Procurando entrada transit/encrypt/${TRANSIT_KEY} no audit log desde epoch=
 
 # `set +e` localmente para distinguir erros de SSH/kubectl (rc!=0) de
 # "comando rodou mas devolveu vazio" (audit ausente).
+# VAULT_TOKEN_FOR_AUDIT é expandido AQUI (no shell local) — checado via `:?`
+# no topo do script. Sem esse expand a env var ficaria vazia dentro do
+# kubectl exec porque o shell remoto não tem a mesma var disponível.
 set +e
 audit_devices=$(ssh -i "$SSH_KEY" -o ConnectTimeout=10 "$SSH_HOST" "
 sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml -n ${VAULT_POD_NS} exec -i ${VAULT_POD_NAME} -- \
-  env VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=\${VAULT_TOKEN_FOR_AUDIT:-} \
+  env VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=${VAULT_TOKEN_FOR_AUDIT} \
   vault audit list -format=json
 " 2>&1)
 audit_rc=$?
@@ -179,7 +190,7 @@ set -e
 if [ "$audit_rc" -ne 0 ]; then
     log "ERRO: falha ao consultar Vault via SSH/kubectl (rc=${audit_rc}). Output:"
     echo "$audit_devices" | head -10 >&2
-    log "Definir VAULT_TOKEN_FOR_AUDIT no host remoto OU configurar SSH/kubectl. Não dá pra distinguir audit habilitado/desabilitado neste estado."
+    log "Verificar: (1) VAULT_TOKEN_FOR_AUDIT tem capability sudo em sys/audit; (2) SSH/kubectl funcionando; (3) Vault unsealed."
     fail "Comunicação com o Vault falhou"
 fi
 

--- a/scripts/smoke-encryption-e2e.sh
+++ b/scripts/smoke-encryption-e2e.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Smoke E2E para validar que a uniplus-api consome Vault Transit em standalone
+# (uniplus-infra#220). O script:
+#
+#   1. Obtém um token OIDC do realm `uniplus` via apicurio-registry client
+#      (directAccessGrantsEnabled=true documentado em
+#      configs/uniplus-standalone/11-uniplus-apis.md).
+#   2. Envia POST /api/v1/selecao/editais com header `Idempotency-Key`
+#      contendo um UUID v4 (mais portável que v7 em sh) — força a uniplus-api
+#      a invocar o `IdempotencyFilter`, que toca o `IUniPlusEncryptionService`.
+#   3. Espera HTTP 201 (criado) ou 422 (validation falhou pelo payload mínimo).
+#      Códigos 5xx indicam regressão (Provider mal configurado ou Vault down).
+#   4. Lê o audit log do Vault no Pod do standalone e procura por entradas
+#      `request.path=transit/encrypt/uniplus-idempotency-aesgcm` emitidas
+#      DEPOIS do timestamp registrado antes do POST — comprova que a request
+#      atual (não uma anterior) tocou o Vault.
+#
+# Idempotente: cada execução gera um Idempotency-Key novo e o filtro do Vault
+# pelos últimos 60s descarta runs anteriores.
+
+set -euo pipefail
+
+# Defaults — sobrescrevíveis via env vars
+API_HOST="${API_HOST:-api-selecao.standalone.portaluni.com.br}"
+API_PATH="${API_PATH:-/api/v1/selecao/editais}"
+KEYCLOAK_BASE="${KEYCLOAK_BASE:-https://standalone.portaluni.com.br/auth/realms/uniplus}"
+KEYCLOAK_CLIENT_ID="${KEYCLOAK_CLIENT_ID:-apicurio-registry}"
+SSH_HOST="${SSH_HOST:-ubuntu@164.152.53.29}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519}"
+VAULT_POD_NS="${VAULT_POD_NS:-vault}"
+VAULT_POD_NAME="${VAULT_POD_NAME:-platform-vault-uniplus-standalone-0}"
+TRANSIT_KEY="${TRANSIT_KEY:-uniplus-idempotency-aesgcm}"
+AUDIT_LOG_PATH="${AUDIT_LOG_PATH:-/vault/audit/audit.log}"
+
+log() {
+    printf '%s [smoke-encryption] %s\n' "$(date -u +%H:%M:%S)" "$1" >&2
+}
+
+fail() {
+    log "ERRO: $1"
+    exit 1
+}
+
+# Credenciais devem vir SEM hardcode — operador exporta antes de rodar.
+: "${KEYCLOAK_CLIENT_SECRET:?KEYCLOAK_CLIENT_SECRET é obrigatório (apicurio-registry client_secret no realm uniplus)}"
+: "${KEYCLOAK_USERNAME:?KEYCLOAK_USERNAME é obrigatório (usuário no realm uniplus com directAccessGrants permitido)}"
+: "${KEYCLOAK_PASSWORD:?KEYCLOAK_PASSWORD é obrigatório}"
+
+command -v curl >/dev/null 2>&1 || fail "curl não encontrado"
+command -v jq >/dev/null 2>&1 || fail "jq não encontrado"
+command -v uuidgen >/dev/null 2>&1 || fail "uuidgen não encontrado"
+command -v ssh >/dev/null 2>&1 || fail "ssh não encontrado"
+
+# --- 1. Obter token OIDC ---------------------------------------------------
+
+log "Obtendo token OIDC para client=${KEYCLOAK_CLIENT_ID} user=${KEYCLOAK_USERNAME}"
+
+token_response=$(curl -sk -X POST \
+    "${KEYCLOAK_BASE}/protocol/openid-connect/token" \
+    -d "grant_type=password" \
+    -d "client_id=${KEYCLOAK_CLIENT_ID}" \
+    -d "client_secret=${KEYCLOAK_CLIENT_SECRET}" \
+    -d "username=${KEYCLOAK_USERNAME}" \
+    -d "password=${KEYCLOAK_PASSWORD}" \
+    -d "scope=openid")
+
+access_token=$(echo "$token_response" | jq -r .access_token)
+
+if [ -z "$access_token" ] || [ "$access_token" = "null" ]; then
+    log "Falha ao obter token. Resposta do Keycloak:"
+    echo "$token_response" | jq . >&2 || echo "$token_response" >&2
+    fail "Sem access_token"
+fi
+
+# Validar audience inclui 'uniplus' (sem isso a API rejeita 401)
+audiences=$(echo "$access_token" | cut -d. -f2 | base64 -d 2>/dev/null | jq -r '.aud | if type=="array" then join(",") else . end')
+case ",$audiences," in
+    *,uniplus,*) ;;
+    *) fail "Token não tem audience 'uniplus' (audiences=$audiences). Verificar audience mapper no client ${KEYCLOAK_CLIENT_ID}." ;;
+esac
+
+log "Token OIDC obtido com audience=${audiences}"
+
+# --- 2. Marcar timestamp ANTES do POST -------------------------------------
+
+# O audit log é JSON-lines com campo `time` em RFC3339. Vamos buscar entradas
+# emitidas a partir desse momento para evitar pegar lixo de runs anteriores.
+since_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# --- 3. POST /api/v1/selecao/editais com Idempotency-Key -------------------
+
+idempotency_key=$(uuidgen)
+log "POST https://${API_HOST}${API_PATH} Idempotency-Key=${idempotency_key}"
+
+# Payload mínimo — a validação do payload pode falhar (422), o que ainda assim
+# exercita o IdempotencyFilter (cifragem). 5xx é regressão real.
+payload='{
+  "numero": "SMOKE-2026-001",
+  "ano": 2026,
+  "titulo": "Smoke encryption E2E (uniplus-infra#220)"
+}'
+
+http_status=$(curl -sk -o /tmp/smoke-api-response.json -w '%{http_code}' \
+    -X POST "https://${API_HOST}${API_PATH}" \
+    -H "Authorization: Bearer ${access_token}" \
+    -H "Content-Type: application/json" \
+    -H "Idempotency-Key: ${idempotency_key}" \
+    --data "$payload")
+
+case "$http_status" in
+    201|422)
+        log "POST retornou ${http_status} (esperado — pipeline de cifragem foi exercitado)"
+        ;;
+    401|403)
+        log "POST retornou ${http_status} (auth falhou — não dá pra validar cifragem). Body:"
+        cat /tmp/smoke-api-response.json >&2 || true
+        fail "Falha de auth não diagnostica este smoke"
+        ;;
+    5*)
+        log "POST retornou ${http_status} (provavelmente Provider mal configurado ou Vault down). Body:"
+        cat /tmp/smoke-api-response.json >&2 || true
+        fail "5xx na request — regressão"
+        ;;
+    *)
+        log "POST retornou ${http_status} inesperado. Body:"
+        cat /tmp/smoke-api-response.json >&2 || true
+        fail "HTTP status inesperado"
+        ;;
+esac
+
+# --- 4. Verificar audit log do Vault --------------------------------------
+#
+# Estratégia: chamar `vault audit list` para diferenciar "Vault inacessível"
+# de "audit device desabilitado". Em sucesso, ler audit log e filtrar por
+# entradas posteriores a $since_iso (lexicografic compare em RFC3339 funciona).
+
+log "Procurando entrada transit/encrypt/${TRANSIT_KEY} no audit log desde ${since_iso}"
+
+# `set +e` localmente para distinguir erros de SSH/kubectl (rc!=0) de
+# "comando rodou mas devolveu vazio" (audit ausente).
+set +e
+audit_devices=$(ssh -i "$SSH_KEY" -o ConnectTimeout=10 "$SSH_HOST" "
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml -n ${VAULT_POD_NS} exec -i ${VAULT_POD_NAME} -- \
+  env VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=\${VAULT_TOKEN_FOR_AUDIT:-} \
+  vault audit list -format=json
+" 2>&1)
+audit_rc=$?
+set -e
+
+if [ "$audit_rc" -ne 0 ]; then
+    log "ERRO: falha ao consultar Vault via SSH/kubectl (rc=${audit_rc}). Output:"
+    echo "$audit_devices" | head -10 >&2
+    log "Definir VAULT_TOKEN_FOR_AUDIT no host remoto OU configurar SSH/kubectl. Não dá pra distinguir audit habilitado/desabilitado neste estado."
+    fail "Comunicação com o Vault falhou"
+fi
+
+# Vault retorna `{}` (objeto vazio) ou `null` quando não há audit devices.
+if [ -z "$audit_devices" ] \
+    || echo "$audit_devices" | jq -e 'if type == "object" then (length == 0) else (. == null) end' >/dev/null 2>&1; then
+    log "WARN: Vault está acessível, mas não tem audit devices habilitados."
+    log "Para habilitar: kubectl exec -i ${VAULT_POD_NAME} -n ${VAULT_POD_NS} -- vault audit enable file file_path=${AUDIT_LOG_PATH}"
+    log "Pulando verificação do audit log — POST retornou ${http_status} mas não dá pra confirmar transit/encrypt sem audit."
+    log "RESULTADO: HTTP ${http_status} (OK); audit verification pulada (Vault sem audit device)."
+    exit 0
+fi
+
+# Audit habilitado — buscar entrada DEPOIS de $since_iso usando jq para
+# parsear JSON-lines e filtrar por time + path. tail -500 dá folga para
+# bursts de tráfego concorrente.
+set +e
+audit_hits=$(ssh -i "$SSH_KEY" -o ConnectTimeout=10 "$SSH_HOST" "
+sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml -n ${VAULT_POD_NS} exec -i ${VAULT_POD_NAME} -- \
+  sh -c 'tail -500 ${AUDIT_LOG_PATH}'
+" 2>/dev/null | jq -c --arg since "$since_iso" --arg path "transit/encrypt/${TRANSIT_KEY}" \
+    'select(.time > $since and .request.path == $path)')
+hits_rc=$?
+set -e
+
+if [ "$hits_rc" -ne 0 ] || [ -z "$audit_hits" ]; then
+    log "ERRO: nenhuma entrada transit/encrypt/${TRANSIT_KEY} no audit log emitida APÓS ${since_iso}"
+    log "Verificar:"
+    log "  - log do pod uniplus-api-selecao mostra Provider=vault"
+    log "  - role uniplus-api existe com bound_service_account_names contendo uniplus-api-selecao"
+    log "  - audit log file ${AUDIT_LOG_PATH} acessível e sendo gravado"
+    fail "Audit log sem evidência de transit/encrypt na janela atual"
+fi
+
+log "Audit log confirma uso do Vault Transit:"
+echo "$audit_hits" | jq -r '"  \(.time) \(.request.path) (op=\(.request.operation))"'
+
+log "OK — smoke E2E verde: HTTP ${http_status} + transit/encrypt no audit do Vault (após ${since_iso})"

--- a/scripts/smoke-encryption-e2e.sh
+++ b/scripts/smoke-encryption-e2e.sh
@@ -107,9 +107,14 @@ log "Token OIDC obtido com audience=${audiences}"
 
 # --- 2. Marcar timestamp ANTES do POST -------------------------------------
 
-# O audit log é JSON-lines com campo `time` em RFC3339. Vamos buscar entradas
-# emitidas a partir desse momento para evitar pegar lixo de runs anteriores.
-since_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+# O audit log é JSON-lines com campo `time` em RFC3339 com fração de segundo
+# (`2026-05-11T11:21:45.123Z`). Comparação lexicográfica falha porque `.`
+# < `Z` em ASCII — `.123Z` ordena ANTES de `Z` puro, então entradas válidas
+# emitidas no mesmo segundo do POST seriam descartadas. Usamos epoch numérico
+# (segundo inteiro, com 1s de slack para absorver clock drift entre o
+# host local e o pod do Vault) e o jq converte `.time` removendo fração
+# antes de `fromdate`.
+since_epoch_minus_1=$(( $(date -u +%s) - 1 ))
 
 # --- 3. POST /api/v1/selecao/editais com Idempotency-Key -------------------
 
@@ -158,7 +163,7 @@ esac
 # de "audit device desabilitado". Em sucesso, ler audit log e filtrar por
 # entradas posteriores a $since_iso (lexicografic compare em RFC3339 funciona).
 
-log "Procurando entrada transit/encrypt/${TRANSIT_KEY} no audit log desde ${since_iso}"
+log "Procurando entrada transit/encrypt/${TRANSIT_KEY} no audit log desde epoch=${since_epoch_minus_1}"
 
 # `set +e` localmente para distinguir erros de SSH/kubectl (rc!=0) de
 # "comando rodou mas devolveu vazio" (audit ausente).
@@ -188,20 +193,23 @@ if [ -z "$audit_devices" ] \
     exit 0
 fi
 
-# Audit habilitado — buscar entrada DEPOIS de $since_iso usando jq para
-# parsear JSON-lines e filtrar por time + path. tail -500 dá folga para
-# bursts de tráfego concorrente.
+# Audit habilitado — buscar entrada DEPOIS de $since_epoch_minus_1 usando
+# jq para parsear JSON-lines, converter `.time` (RFC3339 com fração) em
+# epoch removendo fração com sub() e comparar numericamente com >=.
+# tail -500 dá folga para bursts de tráfego concorrente.
 set +e
 audit_hits=$(ssh -i "$SSH_KEY" -o ConnectTimeout=10 "$SSH_HOST" "
 sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml -n ${VAULT_POD_NS} exec -i ${VAULT_POD_NAME} -- \
   sh -c 'tail -500 ${AUDIT_LOG_PATH}'
-" 2>/dev/null | jq -c --arg since "$since_iso" --arg path "transit/encrypt/${TRANSIT_KEY}" \
-    'select(.time > $since and .request.path == $path)')
+" 2>/dev/null | jq -c \
+    --argjson since "$since_epoch_minus_1" \
+    --arg path "transit/encrypt/${TRANSIT_KEY}" \
+    'select((.time | sub("\\.[0-9]+Z$"; "Z") | fromdate) >= $since and .request.path == $path)')
 hits_rc=$?
 set -e
 
 if [ "$hits_rc" -ne 0 ] || [ -z "$audit_hits" ]; then
-    log "ERRO: nenhuma entrada transit/encrypt/${TRANSIT_KEY} no audit log emitida APÓS ${since_iso}"
+    log "ERRO: nenhuma entrada transit/encrypt/${TRANSIT_KEY} no audit log emitida APÓS epoch=${since_epoch_minus_1}"
     log "Verificar:"
     log "  - log do pod uniplus-api-selecao mostra Provider=vault"
     log "  - role uniplus-api existe com bound_service_account_names contendo uniplus-api-selecao"
@@ -212,4 +220,4 @@ fi
 log "Audit log confirma uso do Vault Transit:"
 echo "$audit_hits" | jq -r '"  \(.time) \(.request.path) (op=\(.request.operation))"'
 
-log "OK — smoke E2E verde: HTTP ${http_status} + transit/encrypt no audit do Vault (após ${since_iso})"
+log "OK — smoke E2E verde: HTTP ${http_status} + transit/encrypt no audit do Vault (após epoch=${since_epoch_minus_1})"

--- a/scripts/smoke-encryption-e2e.sh
+++ b/scripts/smoke-encryption-e2e.sh
@@ -74,8 +74,30 @@ if [ -z "$access_token" ] || [ "$access_token" = "null" ]; then
     fail "Sem access_token"
 fi
 
-# Validar audience inclui 'uniplus' (sem isso a API rejeita 401)
-audiences=$(echo "$access_token" | cut -d. -f2 | base64 -d 2>/dev/null | jq -r '.aud | if type=="array" then join(",") else . end')
+# Validar audience inclui 'uniplus' (sem isso a API rejeita 401).
+# JWT segments são base64url (caracteres -/_ em vez de +/) e podem vir sem
+# padding. GNU base64 -d exige base64 standard e múltiplo de 4 bytes:
+# normalizamos antes de decodificar para evitar exit não-zero do `base64`
+# que sob `set -euo pipefail` abortaria o script.
+decode_jwt_segment() {
+    local seg="$1"
+    # base64url → base64 standard
+    seg=$(printf '%s' "$seg" | tr -- '-_' '+/')
+    # padding para múltiplo de 4
+    local mod=$(( ${#seg} % 4 ))
+    if [ "$mod" -ne 0 ]; then
+        seg="${seg}$(printf '%*s' $((4 - mod)) '' | tr ' ' '=')"
+    fi
+    printf '%s' "$seg" | base64 -d 2>/dev/null
+}
+
+jwt_payload=$(printf '%s' "$access_token" | cut -d. -f2)
+audiences=$(decode_jwt_segment "$jwt_payload" | jq -r '.aud | if type=="array" then join(",") else . end' 2>/dev/null || echo "")
+
+if [ -z "$audiences" ]; then
+    fail "Falha ao decodificar payload do JWT (segmento base64url do access_token). Token recebido começa com: ${access_token:0:30}..."
+fi
+
 case ",$audiences," in
     *,uniplus,*) ;;
     *) fail "Token não tem audience 'uniplus' (audiences=$audiences). Verificar audience mapper no client ${KEYCLOAK_CLIENT_ID}." ;;


### PR DESCRIPTION
Closes #220
Refs #45

## Contexto

Issue 3 de 3 do plano \"correção definitiva de cifragem\" no standalone Uni+. As duas anteriores estão merged:

- **uniplus-api fail-fast completa** ([#400](https://github.com/unifesspa-edu-br/uniplus-api/issues/400) PR [#401](https://github.com/unifesspa-edu-br/uniplus-api/pull/401), [#402](https://github.com/unifesspa-edu-br/uniplus-api/issues/402) PR [#403](https://github.com/unifesspa-edu-br/uniplus-api/pull/403), [#404](https://github.com/unifesspa-edu-br/uniplus-api/issues/404) PR [#406](https://github.com/unifesspa-edu-br/uniplus-api/pull/406), [#405](https://github.com/unifesspa-edu-br/uniplus-api/issues/405) PR [#407](https://github.com/unifesspa-edu-br/uniplus-api/pull/407)): Validator + warmup hosted service + auth method determinístico + guards split.
- **uniplus-infra Vault Transit standup** ([#219](https://github.com/unifesspa-edu-br/uniplus-infra/issues/219) PR [#223](https://github.com/unifesspa-edu-br/uniplus-infra/pull/223)): chart `platform/vault-transit-bootstrap/` criado; mount transit + key uniplus-idempotency-aesgcm + policy uniplus-api-transit + role K8s uniplus-api já reconciliados no Vault standalone.

Este PR pluga as 3 APIs `uniplus-api-{portal,selecao,ingresso}` em standalone para usar `Provider=vault` (em vez de `local`), consumindo a infra do #219.

## Mudanças

### Charts `apps/uniplus-api-{portal,selecao,ingresso}` — paralelas nos 3

- **`values.yaml`**: novo bloco `encryption` (provider/vaultAddress/kubernetesRole, default `local` para CI/dev). `serviceAccount.name` muda de `\"\"` para `uniplus-api-<app>` (FIXO) — pattern espelha `external-secrets` (line 31 do platform/external-secrets/values.yaml).
- **`templates/deployment.yaml`**: env vars `UniPlus__Encryption__{Provider,VaultAddress,KubernetesRole}` rendendo do values; **fail-on-render** se Provider=vault sem VaultAddress ou KubernetesRole; podSpec ganha `automountServiceAccountToken: true`.

### `platform/vault-transit-bootstrap/values.yaml`

`role.boundSa` muda de `\"uniplus-api\"` para CSV `\"uniplus-api-portal,uniplus-api-selecao,uniplus-api-ingresso\"`. Vault aceita múltiplos `bound_service_account_names` numa única role. 3 SAs distintas + 1 role compartilhada: preserva identidade por app no audit do Vault sem proliferar roles. README do chart atualizado.

### `environments/standalone/values.yaml`

Bloco `encryption: { provider: vault, vaultAddress: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200, kubernetesRole: uniplus-api }` em cada `uniplusApi{Portal,Selecao,Ingresso}`.

### `scripts/smoke-encryption-e2e.sh` (NOVO)

Smoke E2E que (1) obtém token OIDC, (2) POST com Idempotency-Key forçando o IdempotencyFilter da uniplus-api a tocar cifragem, (3) valida HTTP 201/422 (5xx = regressão), (4) procura no audit log do Vault entrada `transit/encrypt/uniplus-idempotency-aesgcm` **emitida após** o timestamp do POST (filtro temporal via jq, não pega entrada antiga).

### `docs/RUNBOOKS.md` §18

Cobre: topologia das 3 SAs, validação via smoke, inspeção do Pod, plano de rollback (com disclaimer honesto que rollback completo exige PR adicional), dependência da imagem.

## Validação ao vivo (Vault standalone)

Bootstrap script reaplicado com `ROLE_SA=\"uniplus-api-portal,uniplus-api-selecao,uniplus-api-ingresso\"`:

```
$ vault read auth/kubernetes/role/uniplus-api
bound_service_account_names      [uniplus-api-portal uniplus-api-selecao uniplus-api-ingresso]
bound_service_account_namespaces [uniplus]
policies                         [uniplus-api-transit]
token_ttl                        1h
ttl                              1h
```

`helm template` em cada um dos 3 charts confirma:

```
  name: uniplus-api-selecao              # SA criada pelo chart
      serviceAccountName: uniplus-api-selecao
      automountServiceAccountToken: true
            - name: UniPlus__Encryption__Provider
            - name: UniPlus__Encryption__VaultAddress
            - name: UniPlus__Encryption__KubernetesRole
```

`helm lint` em todos os 4 charts: 0 fail. `yamllint` clean. `bash -n` no smoke: OK.

## Codex CLI

1 rodada, 3 achados absorvidos:

- **P1**: smoke fazia `tail -200 | grep` sem filtro de tempo, podendo aprovar com entrada antiga do audit. Agora `jq` filtra por `.time > $since_iso` (RFC3339 lexicográfico bate).
- **P2**: smoke confundia falha SSH/kubectl com audit ausente. Agora `set +e` localmente + checagem de `rc` para distinguir comunicação quebrada de Vault sem audit device.
- **P2**: RUNBOOK rollback documentava trocar para Provider=local mas charts não têm wire-up de LocalKey. Reescrito para ser honesto: rollback completo exige PR adicional adicionando ExternalSecret + env var.

## Dependência da imagem

O fail-fast completo (Validator + Warmup do `EncryptionWarmupHostedService`) está nos PRs uniplus-api#401/#403/#406/#407 — mergeados nesta sessão. A imagem GHCR atual (`v0.2.0`) provavelmente ainda não tem os bits — pre-validação de fail-fast aguarda o próximo cut de release.

O **wire-up entregue por este PR funciona com qualquer imagem**; apenas a defesa em profundidade fica plena com a próxima imagem. Documentado no RUNBOOK §18.5.

## Test plan

- [x] `helm lint` nos 4 charts (portal/selecao/ingresso/bootstrap)
- [x] `helm template` valida env vars + SA + automount no Deployment renderizado
- [x] `yamllint` clean nos arquivos modificados
- [x] `bash -n` no smoke script
- [x] Vault role real reaplicada via script bootstrap, audit confirma CSV de 3 SAs
- [x] Codex CLI absorvido (3 achados P1/P2)
- [ ] CI verde (apenas `PR author is org member` é required; lint workflows são warning-only)
- [ ] Review humano (jf2s)
- [ ] Smoke E2E completo executável quando imagem com bits do fail-fast for publicada