### PR TITLE
chore(images): bump uniplus-api v0.3.0 + uniplus-web v0.2.0

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.2.0"
+    tag: "v0.3.0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.2.0"
+    tag: "v0.3.0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.2.0"
+    tag: "v0.3.0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-web/values.yaml
+++ b/apps/uniplus-web/values.yaml
@@ -68,7 +68,7 @@ uniplusWeb:
       # prefixo `web-`) e os demais (com `web-`). Verificar tags em
       # https://github.com/unifesspa-edu-br/packages.
       image: uniplus-portal
-      tag: v0.1.2  # tag publicada em GHCR (override per-app possível)
+      tag: v0.2.0  # tag publicada em GHCR (override per-app possível)
       host: ""  # ex.: portal.standalone.portaluni.com.br
       # Conteúdo escrito em /assets/runtime-config.json via ConfigMap.
       # Schema é a interface AppConfig em libs/shared-data/lib/config/
@@ -91,7 +91,7 @@ uniplusWeb:
       enabled: false  # ativar em environments/<env>/values.yaml
       replicas: 2
       image: uniplus-web-selecao
-      tag: v0.1.2
+      tag: v0.2.0
       host: ""
       runtimeConfig:
         apiUrl: ""
@@ -111,7 +111,7 @@ uniplusWeb:
       enabled: false  # ativar em environments/<env>/values.yaml
       replicas: 2
       image: uniplus-web-ingresso
-      tag: v0.1.2
+      tag: v0.2.0
       host: ""
       runtimeConfig:
         apiUrl: ""


### PR DESCRIPTION
## Contexto

Atualiza `image.tag` nos charts `apps/uniplus-api-{portal,selecao,ingresso}` e `apps/uniplus-web` para as novas releases publicadas no GHCR.

## Mudanças

| Chart | De | Para |
|---|---|---|
| `apps/uniplus-api-portal` | `v0.2.0` | `v0.3.0` |
| `apps/uniplus-api-selecao` | `v0.2.0` | `v0.3.0` |
| `apps/uniplus-api-ingresso` | `v0.2.0` | `v0.3.0` |
| `apps/uniplus-web` (3 apps) | `v0.1.2` | `v0.2.0` |

Diff isolado: 4 arquivos, 6 linhas modificadas. Apenas `image.tag` (nenhuma mudança de comportamento dos charts).

## Releases incluídas

### uniplus-api v0.3.0

Notes: https://github.com/unifesspa-edu-br/uniplus-api/releases/tag/v0.3.0

- **Cifragem fail-fast no boot** (PRs #401/#403/#406/#407): `EncryptionOptionsValidator` + `EncryptionWarmupHostedService` + auth method determinístico no Vault Transit. Encerra o trabalho de \"correção definitiva de cifragem\" iniciado em uniplus-api#400 + uniplus-infra#219/#220.
- **OpenTelemetry** wired nos 3 `Program.cs` + integration test ponta-a-ponta.
- **Audit fields** (`CreatedBy`/`UpdatedBy`) via `AuditableInterceptor` + `IAuditableEntity` opt-in. `SoftDeleteInterceptor` consome `IUserContext`.
- **EF Core value converters** para Value Objects.
- CodeQL SAST + Trivy scanning + Dependabot.

### uniplus-web v0.2.0

Notes: https://github.com/unifesspa-edu-br/uniplus-web/releases/tag/v0.2.0

- **`NotificationHost`** standalone-friendly + **`DataTable`** com retry/aria-busy/traceId em 5xx (Closes #171).
- CodeQL SAST TypeScript/JavaScript.

## Impacto operacional

### Cifragem (fail-fast)

Com a imagem `v0.3.0`, a uniplus-api derruba o pod no boot (`CrashLoopBackOff`) se a config `UniPlus:Encryption:*` estiver inconsistente, em vez de servir `500 Internal Server Error` na primeira request cifrada. Em standalone (uniplus-infra#220 mergeada em [#228](https://github.com/unifesspa-edu-br/uniplus-infra/pull/228)), `Provider=vault` já está plumbed e a role Vault `uniplus-api` aceita as 3 SAs `uniplus-api-{portal,selecao,ingresso}`. Smoke E2E `scripts/smoke-encryption-e2e.sh` fica executável ponta-a-ponta após o ArgoCD reconciliar este bump.

### Frontend notification

`NotificationHost` é registrado no `app.config.ts` de cada SPA na release v0.2.0 — sem mudança necessária no runtime-config. Toasts user-friendly em 5xx do backend; DataTable indica `aria-busy` para screen readers e propaga `X-Trace-Id` para correlação com logs de backend.

## Compatibilidade

- Sem breaking change nos contratos REST nem no `runtime-config.json` do web.
- `automountServiceAccountToken=true` no podSpec já está nas charts (uniplus-infra#220).
- Pre-flight para deploy em produção: confirmar `UniPlus:Encryption:*` por environment **antes** do upgrade — configs inconsistentes agora bloqueiam o pod ao boot.

## Validação local

- `helm lint` nos 4 charts: 0 chart(s) failed.
- Diff: apenas `image.tag` em 4 arquivos.
- Workflows `publish-images.yml` em uniplus-api e uniplus-web já completaram com sucesso para as tags v0.3.0 e v0.2.0 respectivamente (confirmação manual via `gh run list`).

## Rollback

Reverter este commit (single commit, single concern). ArgoCD reconcilia automaticamente para as tags v0.2.0/v0.1.2 anteriores.

## Test plan

- [x] `helm lint` 4/4
- [x] Releases v0.3.0 + v0.2.0 publicadas no GHCR
- [ ] CI 7/7 verde
- [ ] Review jf2s
- [ ] ArgoCD sync após merge — verificar pods em Running com nova tag (logs mostram Provider=vault na uniplus-api)