### PR TITLE
fix(api): wire Schema Registry (ADR-0051) nos 3 charts uniplus-api

### DIFF
--- a/apps/uniplus-api-ingresso/templates/deployment.yaml
+++ b/apps/uniplus-api-ingresso/templates/deployment.yaml
@@ -159,7 +159,30 @@ spec:
             - name: UniPlus__Encryption__KubernetesRole
               value: {{ .Values.uniplusApiIngresso.encryption.kubernetesRole | quote }}
             {{- end }}
-            
+            # === Schema Registry (ADR-0051) — Apicurio Confluent-compat ===
+            # url vazio = feature off; em Production com Kafka habilitado, o
+            # Program.cs aborta o boot se url estiver vazio. AuthType OAuthBearer
+            # exige tokenEndpoint+clientId; client_secret é injetado via
+            # secretKeyRef do mesmo ESO 5 (oidcSecretName) já existente,
+            # alinhado ao Vault path secret/<env>/keycloak/clients/uniplus-api-<app>.
+            {{- if .Values.uniplusApiIngresso.schemaRegistry.url }}
+            - name: SchemaRegistry__Url
+              value: {{ .Values.uniplusApiIngresso.schemaRegistry.url | quote }}
+            - name: SchemaRegistry__AuthType
+              value: {{ .Values.uniplusApiIngresso.schemaRegistry.authType | quote }}
+            {{- if eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer" }}
+            - name: SchemaRegistry__OAuth__TokenEndpoint
+              value: {{ .Values.uniplusApiIngresso.schemaRegistry.oauth.tokenEndpoint | quote }}
+            - name: SchemaRegistry__OAuth__ClientId
+              value: {{ .Values.uniplusApiIngresso.schemaRegistry.oauth.clientId | quote }}
+            - name: SchemaRegistry__OAuth__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiIngresso.oidcSecretName" . }}
+                  key: OIDC_CLIENT_SECRET
+            {{- end }}
+            {{- end }}
+
             {{- range $i, $origin := .Values.uniplusApiIngresso.cors.allowedOrigins }}
             - name: Cors__AllowedOrigins__{{ $i }}
               value: {{ $origin | quote }}

--- a/apps/uniplus-api-ingresso/templates/deployment.yaml
+++ b/apps/uniplus-api-ingresso/templates/deployment.yaml
@@ -22,6 +22,14 @@
   {{- fail "uniplusApiIngresso.encryption.kubernetesRole é obrigatório quando encryption.provider=vault. A role precisa existir no Vault (uniplus-infra#219) com bound_service_account_names incluindo a SA deste chart." -}}
   {{- end -}}
 {{- end -}}
+{{- if and .Values.uniplusApiIngresso.schemaRegistry.url (eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer") -}}
+  {{- if not .Values.uniplusApiIngresso.schemaRegistry.oauth.tokenEndpoint -}}
+  {{- fail "uniplusApiIngresso.schemaRegistry.oauth.tokenEndpoint é obrigatório quando schemaRegistry.url está populado e authType=OAuthBearer. ADR-0051 exige endpoint /protocol/openid-connect/token do realm Keycloak para emissão do bearer token." -}}
+  {{- end -}}
+  {{- if not .Values.uniplusApiIngresso.schemaRegistry.oauth.clientId -}}
+  {{- fail "uniplusApiIngresso.schemaRegistry.oauth.clientId é obrigatório quando schemaRegistry.url está populado e authType=OAuthBearer. Tipicamente uniplus-api-<app>; client_secret correspondente custodiado no Vault em secret/<env>/keycloak/clients/<clientId>." -}}
+  {{- end -}}
+{{- end -}}
 {{- if not .Values.uniplusApiIngresso.externalSecrets.enabled -}}
 {{- fail "uniplusApiIngresso.enabled=true requer externalSecrets.enabled=true. Deployment depende dos Secrets sintetizados pelo ESO (Postgres password, Redis, MinIO, Kafka, OIDC)." -}}
 {{- end -}}

--- a/apps/uniplus-api-ingresso/templates/externalsecret.yaml
+++ b/apps/uniplus-api-ingresso/templates/externalsecret.yaml
@@ -100,13 +100,18 @@ spec:
         key: {{ $es.kafkaAdmin.vaultPath }}
         property: {{ $es.kafkaAdmin.caCertKey }}
 {{- end }}
-{{- if .Values.uniplusApiIngresso.oidc.enabled }}
+{{- if or .Values.uniplusApiIngresso.oidc.enabled (eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer") }}
 ---
-# ESO 5: OIDC client_secret reservado para machine-to-machine (m2m)
-# FUTURO. Resource server bearer-only NÃO consome este Secret em runtime
-# — não há env var nem envFrom no Deployment referenciando-o. ESO antecipa
-# o cenário em que a API se autentica como service account contra outras
-# APIs (client_credentials grant). Mantido para parity com kafka-ui/apicurio-registry.
+# ESO 5: client_secret OIDC do realm uniplus. Materializa o Secret K8s
+# `<release>-oidc-client` consumido por:
+#   - Deployment quando schemaRegistry.authType=OAuthBearer (env
+#     SchemaRegistry__OAuth__ClientSecret via secretKeyRef — ADR-0051).
+#   - Cenário m2m futuro: API se autentica como service account contra
+#     outras APIs via client_credentials grant.
+# A guarda inclui ambos os predicados porque cada um é uma necessidade
+# independente — desligar oidc.enabled (bearer validation no resource
+# server) não deveria desligar o cliente OAuth que o Schema Registry
+# precisa para publicar schemas.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/apps/uniplus-api-ingresso/templates/externalsecret.yaml
+++ b/apps/uniplus-api-ingresso/templates/externalsecret.yaml
@@ -100,7 +100,7 @@ spec:
         key: {{ $es.kafkaAdmin.vaultPath }}
         property: {{ $es.kafkaAdmin.caCertKey }}
 {{- end }}
-{{- if or .Values.uniplusApiIngresso.oidc.enabled (eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer") }}
+{{- if or .Values.uniplusApiIngresso.oidc.enabled (and (ne .Values.uniplusApiIngresso.schemaRegistry.url "") (eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer")) }}
 ---
 # ESO 5: client_secret OIDC do realm uniplus. Materializa o Secret K8s
 # `<release>-oidc-client` consumido por:

--- a/apps/uniplus-api-ingresso/templates/externalsecret.yaml
+++ b/apps/uniplus-api-ingresso/templates/externalsecret.yaml
@@ -100,7 +100,11 @@ spec:
         key: {{ $es.kafkaAdmin.vaultPath }}
         property: {{ $es.kafkaAdmin.caCertKey }}
 {{- end }}
-{{- if or .Values.uniplusApiIngresso.oidc.enabled (and (ne .Values.uniplusApiIngresso.schemaRegistry.url "") (eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer")) }}
+{{/* ESO 5 só é necessário quando consumimos OIDC m2m OU Schema Registry com OAuthBearer
+     (basic/none não consumem este Secret). url vazio = feature off, mesma guarda do
+     Deployment para evitar criar Secret órfão. */}}
+{{- $srOAuthActive := and (ne .Values.uniplusApiIngresso.schemaRegistry.url "") (eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer") -}}
+{{- if or .Values.uniplusApiIngresso.oidc.enabled $srOAuthActive }}
 ---
 # ESO 5: client_secret OIDC do realm uniplus. Materializa o Secret K8s
 # `<release>-oidc-client` consumido por:

--- a/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
@@ -3,14 +3,14 @@
 {{- fail "uniplusApiIngresso.networkPolicy.dataHostCIDR é obrigatório (egress para Postgres + Redis + Kafka + MinIO no data-host)." -}}
 {{- end -}}
 {{- /*
-  $srOAuth combina url não-vazia (feature off quando url=="") com authType=OAuthBearer.
-  Mesma guarda usada no deployment.yaml (env vars Schema Registry só renderizam
-  quando url está populado) — mantém consistência entre os templates: se a
-  feature está off no Deployment, o NetworkPolicy também ignora.
+  $srEnabled: feature flag real do Schema Registry — url não-vazia (mesma
+  guarda do deployment.yaml, que só renderiza envs SchemaRegistry__* quando
+  url está populado). Independente do authType (None/Basic/OAuthBearer), a
+  API precisa alcançar o registry HTTPS quando a feature está on.
 */}}
-{{- $srOAuth := and (ne .Values.uniplusApiIngresso.schemaRegistry.url "") (eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer") -}}
-{{- if and (or .Values.uniplusApiIngresso.oidc.enabled $srOAuth) (not .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR) -}}
-{{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU (schemaRegistry.url populado E schemaRegistry.authType=OAuthBearer) — egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host." -}}
+{{- $srEnabled := ne .Values.uniplusApiIngresso.schemaRegistry.url "" -}}
+{{- if and (or .Values.uniplusApiIngresso.oidc.enabled $srEnabled) (not .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU schemaRegistry.url populado — egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host (em standalone os 2 subdomínios resolvem para o mesmo IP)." -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -80,15 +80,17 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiIngresso.networkPolicy.keycloakPort }}
-    {{- if or .Values.uniplusApiIngresso.oidc.enabled $srOAuth }}
+    {{- if or .Values.uniplusApiIngresso.oidc.enabled $srEnabled }}
     # Egress HTTPS para o IP público do k8s-host (Traefik), necessário para:
     #   - JWT validation chama jwks endpoint do Keycloak quando oidc.enabled
     #     (resource server bearer validation).
-    #   - Token endpoint OAuth + Apicurio Registry (Confluent-compat) quando
-    #     schemaRegistry.authType=OAuthBearer (publishing de schemas, ADR-0051).
-    # Em standalone os dois subdomínios (auth + schema-registry) resolvem para
+    #   - Schema Registry (Apicurio Confluent-compat) quando schemaRegistry.url
+    #     está populado — independente do authType. Token endpoint OAuth
+    #     adicional quando authType=OAuthBearer também roteia pelo mesmo IP.
+    # Em standalone os subdomínios (auth + schema-registry) resolvem para
     # o mesmo IP público do k8s-host (Traefik termina TLS), então uma regra
-    # única cobre ambos consumidores.
+    # única cobre ambos consumidores. Em environments com IPs distintos,
+    # adicionar regra extra via override de networkPolicy.
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR }}

--- a/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
@@ -73,8 +73,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiIngresso.networkPolicy.keycloakPort }}
-    {{- if .Values.uniplusApiIngresso.oidc.enabled }}
-    # OIDC issuer público — JWT validation chama jwks endpoint (HTTPS).
+    {{- if or .Values.uniplusApiIngresso.oidc.enabled (eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer") }}
+    # Egress HTTPS para o IP público do k8s-host (Traefik), necessário para:
+    #   - JWT validation chama jwks endpoint do Keycloak quando oidc.enabled
+    #     (resource server bearer validation).
+    #   - Token endpoint OAuth + Apicurio Registry (Confluent-compat) quando
+    #     schemaRegistry.authType=OAuthBearer (publishing de schemas, ADR-0051).
+    # Em standalone os dois subdomínios (auth + schema-registry) resolvem para
+    # o mesmo IP público do k8s-host (Traefik termina TLS), então uma regra
+    # única cobre ambos consumidores.
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR }}

--- a/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
@@ -5,17 +5,31 @@
 {{- /*
   $srEnabled: feature flag real do Schema Registry — url não-vazia (mesma
   guarda do deployment.yaml, que só renderiza envs SchemaRegistry__* quando
-  url está populado). Independente do authType (None/Basic/OAuthBearer), a
-  API precisa alcançar o registry HTTPS quando a feature está on.
+  url está populado). Independente do authType, a API precisa alcançar o
+  registry HTTPS quando a feature está on.
 
   $hasSrCIDR: CIDR dedicado do Schema Registry está configurado. Quando
   vazio, assumimos co-locação com o OIDC issuer e usamos oidcIssuerCIDR
   como fallback (default standalone via Traefik no k8s-host).
+
+  $srNeedsIssuerCIDR: a regra ipBlock=oidcIssuerCIDR ainda é necessária
+  para Schema Registry em 2 casos:
+    1. Co-locação (hasSrCIDR=false) — registry alcançável pelo IP do issuer.
+    2. authType=OAuthBearer — o oauth.tokenEndpoint tipicamente fica no
+       Keycloak (mesmo IP do issuer), independente do CIDR dedicado do
+       registry para chamadas Confluent-compat.
+  Só dispensamos oidcIssuerCIDR quando SR usa Basic/None E tem CIDR
+  dedicado (rota Confluent-compat 100% no registry, sem token endpoint).
 */}}
 {{- $srEnabled := ne .Values.uniplusApiIngresso.schemaRegistry.url "" -}}
 {{- $hasSrCIDR := ne .Values.uniplusApiIngresso.networkPolicy.schemaRegistryCIDR "" -}}
+{{- $srOAuth := eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer" -}}
+{{- $srNeedsIssuerCIDR := and $srEnabled (or (not $hasSrCIDR) $srOAuth) -}}
 {{- if and .Values.uniplusApiIngresso.oidc.enabled (not .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR) -}}
 {{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (egress HTTPS para o issuer Keycloak / JWKS validation)." -}}
+{{- end -}}
+{{- if and $srNeedsIssuerCIDR (not .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR é obrigatório quando schemaRegistry.url está populado E (schemaRegistryCIDR vazio OU authType=OAuthBearer) — o egress 443 do registry co-localizado OU do oauth.tokenEndpoint precisa alcançar o IP do issuer." -}}
 {{- end -}}
 {{- if and $srEnabled (not .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR) (not $hasSrCIDR) -}}
 {{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR OU schemaRegistryCIDR é obrigatório quando schemaRegistry.url está populado (egress HTTPS para o Apicurio Registry). Em standalone os 2 subdomínios resolvem para o mesmo IP — basta oidcIssuerCIDR; em environments com IPs distintos, definir schemaRegistryCIDR." -}}
@@ -88,15 +102,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiIngresso.networkPolicy.keycloakPort }}
-    {{- if or .Values.uniplusApiIngresso.oidc.enabled (and $srEnabled (not $hasSrCIDR)) }}
+    {{- if or .Values.uniplusApiIngresso.oidc.enabled $srNeedsIssuerCIDR }}
     # Egress HTTPS para o IP do OIDC issuer (Keycloak via Traefik). Cobre:
     #   - JWT validation chama jwks endpoint quando oidc.enabled (bearer
     #     validation no resource server).
-    #   - Schema Registry quando schemaRegistry.url está populado E
-    #     schemaRegistryCIDR vazio (co-locação default do standalone — auth
-    #     e schema-registry subdomínios resolvem para o mesmo IP do k8s-host).
-    # Quando OIDC está desligado E schemaRegistryCIDR está populado, esta
-    # regra não é renderizada (caminho dedicado abaixo cobre).
+    #   - Schema Registry co-localizado (schemaRegistryCIDR vazio — default
+    #     standalone, auth e schema-registry subdomínios no mesmo IP).
+    #   - oauth.tokenEndpoint quando schemaRegistry.authType=OAuthBearer —
+    #     tipicamente fica no Keycloak, mesmo CIDR do issuer, independente
+    #     do CIDR dedicado do registry para chamadas Confluent-compat.
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR }}

--- a/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
@@ -2,8 +2,9 @@
 {{- if not .Values.uniplusApiIngresso.networkPolicy.dataHostCIDR -}}
 {{- fail "uniplusApiIngresso.networkPolicy.dataHostCIDR é obrigatório (egress para Postgres + Redis + Kafka + MinIO no data-host)." -}}
 {{- end -}}
-{{- if and .Values.uniplusApiIngresso.oidc.enabled (not .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR) -}}
-{{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (issuer público resolvido via Traefik no IP do k8s-host)." -}}
+{{- $srOAuth := eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer" -}}
+{{- if and (or .Values.uniplusApiIngresso.oidc.enabled $srOAuth) (not .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU schemaRegistry.authType=OAuthBearer (egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host)." -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
@@ -98,4 +98,16 @@ spec:
         - protocol: TCP
           port: {{ .Values.uniplusApiIngresso.networkPolicy.oidcIssuerPort }}
     {{- end }}
+    {{- if and $srEnabled .Values.uniplusApiIngresso.networkPolicy.schemaRegistryCIDR }}
+    # Regra adicional para Schema Registry em IP público distinto do OIDC
+    # issuer (lab/prod-* podem ter Apicurio em outro host/cluster). Quando
+    # schemaRegistryCIDR está vazio assumimos co-locação com oidcIssuerCIDR
+    # (cobertura via regra acima) — caso default do standalone.
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.uniplusApiIngresso.networkPolicy.schemaRegistryCIDR }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uniplusApiIngresso.networkPolicy.schemaRegistryPort }}
+    {{- end }}
 {{- end }}

--- a/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
@@ -7,10 +7,18 @@
   guarda do deployment.yaml, que só renderiza envs SchemaRegistry__* quando
   url está populado). Independente do authType (None/Basic/OAuthBearer), a
   API precisa alcançar o registry HTTPS quando a feature está on.
+
+  $hasSrCIDR: CIDR dedicado do Schema Registry está configurado. Quando
+  vazio, assumimos co-locação com o OIDC issuer e usamos oidcIssuerCIDR
+  como fallback (default standalone via Traefik no k8s-host).
 */}}
 {{- $srEnabled := ne .Values.uniplusApiIngresso.schemaRegistry.url "" -}}
-{{- if and (or .Values.uniplusApiIngresso.oidc.enabled $srEnabled) (not .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR) -}}
-{{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU schemaRegistry.url populado — egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host (em standalone os 2 subdomínios resolvem para o mesmo IP)." -}}
+{{- $hasSrCIDR := ne .Values.uniplusApiIngresso.networkPolicy.schemaRegistryCIDR "" -}}
+{{- if and .Values.uniplusApiIngresso.oidc.enabled (not .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (egress HTTPS para o issuer Keycloak / JWKS validation)." -}}
+{{- end -}}
+{{- if and $srEnabled (not .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR) (not $hasSrCIDR) -}}
+{{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR OU schemaRegistryCIDR é obrigatório quando schemaRegistry.url está populado (egress HTTPS para o Apicurio Registry). Em standalone os 2 subdomínios resolvem para o mesmo IP — basta oidcIssuerCIDR; em environments com IPs distintos, definir schemaRegistryCIDR." -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -80,17 +88,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiIngresso.networkPolicy.keycloakPort }}
-    {{- if or .Values.uniplusApiIngresso.oidc.enabled $srEnabled }}
-    # Egress HTTPS para o IP público do k8s-host (Traefik), necessário para:
-    #   - JWT validation chama jwks endpoint do Keycloak quando oidc.enabled
-    #     (resource server bearer validation).
-    #   - Schema Registry (Apicurio Confluent-compat) quando schemaRegistry.url
-    #     está populado — independente do authType. Token endpoint OAuth
-    #     adicional quando authType=OAuthBearer também roteia pelo mesmo IP.
-    # Em standalone os subdomínios (auth + schema-registry) resolvem para
-    # o mesmo IP público do k8s-host (Traefik termina TLS), então uma regra
-    # única cobre ambos consumidores. Em environments com IPs distintos,
-    # adicionar regra extra via override de networkPolicy.
+    {{- if or .Values.uniplusApiIngresso.oidc.enabled (and $srEnabled (not $hasSrCIDR)) }}
+    # Egress HTTPS para o IP do OIDC issuer (Keycloak via Traefik). Cobre:
+    #   - JWT validation chama jwks endpoint quando oidc.enabled (bearer
+    #     validation no resource server).
+    #   - Schema Registry quando schemaRegistry.url está populado E
+    #     schemaRegistryCIDR vazio (co-locação default do standalone — auth
+    #     e schema-registry subdomínios resolvem para o mesmo IP do k8s-host).
+    # Quando OIDC está desligado E schemaRegistryCIDR está populado, esta
+    # regra não é renderizada (caminho dedicado abaixo cobre).
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR }}
@@ -98,11 +104,11 @@ spec:
         - protocol: TCP
           port: {{ .Values.uniplusApiIngresso.networkPolicy.oidcIssuerPort }}
     {{- end }}
-    {{- if and $srEnabled .Values.uniplusApiIngresso.networkPolicy.schemaRegistryCIDR }}
-    # Regra adicional para Schema Registry em IP público distinto do OIDC
-    # issuer (lab/prod-* podem ter Apicurio em outro host/cluster). Quando
-    # schemaRegistryCIDR está vazio assumimos co-locação com oidcIssuerCIDR
-    # (cobertura via regra acima) — caso default do standalone.
+    {{- if and $srEnabled $hasSrCIDR }}
+    # Regra dedicada para Schema Registry em IP público distinto do OIDC
+    # issuer (lab/prod-* podem ter Apicurio em outro host/cluster). Esta
+    # regra é independente da regra OIDC acima — em standalone
+    # (schemaRegistryCIDR vazio) o egress do registry cai na regra OIDC.
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiIngresso.networkPolicy.schemaRegistryCIDR }}

--- a/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
@@ -2,9 +2,15 @@
 {{- if not .Values.uniplusApiIngresso.networkPolicy.dataHostCIDR -}}
 {{- fail "uniplusApiIngresso.networkPolicy.dataHostCIDR é obrigatório (egress para Postgres + Redis + Kafka + MinIO no data-host)." -}}
 {{- end -}}
-{{- $srOAuth := eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer" -}}
+{{- /*
+  $srOAuth combina url não-vazia (feature off quando url=="") com authType=OAuthBearer.
+  Mesma guarda usada no deployment.yaml (env vars Schema Registry só renderizam
+  quando url está populado) — mantém consistência entre os templates: se a
+  feature está off no Deployment, o NetworkPolicy também ignora.
+*/}}
+{{- $srOAuth := and (ne .Values.uniplusApiIngresso.schemaRegistry.url "") (eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer") -}}
 {{- if and (or .Values.uniplusApiIngresso.oidc.enabled $srOAuth) (not .Values.uniplusApiIngresso.networkPolicy.oidcIssuerCIDR) -}}
-{{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU schemaRegistry.authType=OAuthBearer (egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host)." -}}
+{{- fail "uniplusApiIngresso.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU (schemaRegistry.url populado E schemaRegistry.authType=OAuthBearer) — egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host." -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -74,7 +80,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiIngresso.networkPolicy.keycloakPort }}
-    {{- if or .Values.uniplusApiIngresso.oidc.enabled (eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer") }}
+    {{- if or .Values.uniplusApiIngresso.oidc.enabled $srOAuth }}
     # Egress HTTPS para o IP público do k8s-host (Traefik), necessário para:
     #   - JWT validation chama jwks endpoint do Keycloak quando oidc.enabled
     #     (resource server bearer validation).

--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -49,6 +49,18 @@ uniplusApiIngresso:
     vaultAddress: ""
     kubernetesRole: ""
 
+  # Schema Registry (ADR-0051) — feature off quando url está vazio. Em
+  # ambientes de produção com Kafka habilitado, Program.cs aborta o boot
+  # se url estiver vazio (publishing cross-módulo exige schema validation).
+  # Auth OAuthBearer: client_secret vem do Secret K8s sintetizado pelo
+  # ESO 5 (oidcSecretName) — mesmo Vault path do OIDC client da API.
+  schemaRegistry:
+    url: ""
+    authType: None
+    oauth:
+      tokenEndpoint: ""
+      clientId: ""
+
   aspnet:
     environment: Production
     urls: "http://+:8080"

--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -164,6 +164,13 @@ uniplusApiIngresso:
     keycloakPort: 8080
     oidcIssuerCIDR: ""          # ex.: 164.152.53.29/32
     oidcIssuerPort: 443
+    # CIDR adicional para Schema Registry (ADR-0051) quando o Apicurio
+    # estiver em IP público distinto do OIDC issuer. Vazio = assume
+    # co-locação com oidcIssuerCIDR (default standalone — ambos subdomínios
+    # resolvem via Traefik no mesmo k8s-host). Em environments com IPs
+    # distintos, definir aqui para liberar egress HTTPS separado.
+    schemaRegistryCIDR: ""
+    schemaRegistryPort: 443
 
   metrics:
     enabled: false

--- a/apps/uniplus-api-portal/templates/deployment.yaml
+++ b/apps/uniplus-api-portal/templates/deployment.yaml
@@ -159,7 +159,30 @@ spec:
             - name: UniPlus__Encryption__KubernetesRole
               value: {{ .Values.uniplusApiPortal.encryption.kubernetesRole | quote }}
             {{- end }}
-            
+            # === Schema Registry (ADR-0051) — Apicurio Confluent-compat ===
+            # url vazio = feature off; em Production com Kafka habilitado, o
+            # Program.cs aborta o boot se url estiver vazio. AuthType OAuthBearer
+            # exige tokenEndpoint+clientId; client_secret é injetado via
+            # secretKeyRef do mesmo ESO 5 (oidcSecretName) já existente,
+            # alinhado ao Vault path secret/<env>/keycloak/clients/uniplus-api-<app>.
+            {{- if .Values.uniplusApiPortal.schemaRegistry.url }}
+            - name: SchemaRegistry__Url
+              value: {{ .Values.uniplusApiPortal.schemaRegistry.url | quote }}
+            - name: SchemaRegistry__AuthType
+              value: {{ .Values.uniplusApiPortal.schemaRegistry.authType | quote }}
+            {{- if eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer" }}
+            - name: SchemaRegistry__OAuth__TokenEndpoint
+              value: {{ .Values.uniplusApiPortal.schemaRegistry.oauth.tokenEndpoint | quote }}
+            - name: SchemaRegistry__OAuth__ClientId
+              value: {{ .Values.uniplusApiPortal.schemaRegistry.oauth.clientId | quote }}
+            - name: SchemaRegistry__OAuth__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiPortal.oidcSecretName" . }}
+                  key: OIDC_CLIENT_SECRET
+            {{- end }}
+            {{- end }}
+
             {{- range $i, $origin := .Values.uniplusApiPortal.cors.allowedOrigins }}
             - name: Cors__AllowedOrigins__{{ $i }}
               value: {{ $origin | quote }}

--- a/apps/uniplus-api-portal/templates/deployment.yaml
+++ b/apps/uniplus-api-portal/templates/deployment.yaml
@@ -22,6 +22,14 @@
   {{- fail "uniplusApiPortal.encryption.kubernetesRole é obrigatório quando encryption.provider=vault. A role precisa existir no Vault (uniplus-infra#219) com bound_service_account_names incluindo a SA deste chart." -}}
   {{- end -}}
 {{- end -}}
+{{- if and .Values.uniplusApiPortal.schemaRegistry.url (eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer") -}}
+  {{- if not .Values.uniplusApiPortal.schemaRegistry.oauth.tokenEndpoint -}}
+  {{- fail "uniplusApiPortal.schemaRegistry.oauth.tokenEndpoint é obrigatório quando schemaRegistry.url está populado e authType=OAuthBearer. ADR-0051 exige endpoint /protocol/openid-connect/token do realm Keycloak para emissão do bearer token." -}}
+  {{- end -}}
+  {{- if not .Values.uniplusApiPortal.schemaRegistry.oauth.clientId -}}
+  {{- fail "uniplusApiPortal.schemaRegistry.oauth.clientId é obrigatório quando schemaRegistry.url está populado e authType=OAuthBearer. Tipicamente uniplus-api-<app>; client_secret correspondente custodiado no Vault em secret/<env>/keycloak/clients/<clientId>." -}}
+  {{- end -}}
+{{- end -}}
 {{- if not .Values.uniplusApiPortal.externalSecrets.enabled -}}
 {{- fail "uniplusApiPortal.enabled=true requer externalSecrets.enabled=true. Deployment depende dos Secrets sintetizados pelo ESO (Postgres password, Redis, MinIO, Kafka, OIDC)." -}}
 {{- end -}}

--- a/apps/uniplus-api-portal/templates/externalsecret.yaml
+++ b/apps/uniplus-api-portal/templates/externalsecret.yaml
@@ -100,7 +100,7 @@ spec:
         key: {{ $es.kafkaAdmin.vaultPath }}
         property: {{ $es.kafkaAdmin.caCertKey }}
 {{- end }}
-{{- if or .Values.uniplusApiPortal.oidc.enabled (eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer") }}
+{{- if or .Values.uniplusApiPortal.oidc.enabled (and (ne .Values.uniplusApiPortal.schemaRegistry.url "") (eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer")) }}
 ---
 # ESO 5: client_secret OIDC do realm uniplus. Materializa o Secret K8s
 # `<release>-oidc-client` consumido por:

--- a/apps/uniplus-api-portal/templates/externalsecret.yaml
+++ b/apps/uniplus-api-portal/templates/externalsecret.yaml
@@ -100,13 +100,18 @@ spec:
         key: {{ $es.kafkaAdmin.vaultPath }}
         property: {{ $es.kafkaAdmin.caCertKey }}
 {{- end }}
-{{- if .Values.uniplusApiPortal.oidc.enabled }}
+{{- if or .Values.uniplusApiPortal.oidc.enabled (eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer") }}
 ---
-# ESO 5: OIDC client_secret reservado para machine-to-machine (m2m)
-# FUTURO. Resource server bearer-only NÃO consome este Secret em runtime
-# — não há env var nem envFrom no Deployment referenciando-o. ESO antecipa
-# o cenário em que a API se autentica como service account contra outras
-# APIs (client_credentials grant). Mantido para parity com kafka-ui/apicurio-registry.
+# ESO 5: client_secret OIDC do realm uniplus. Materializa o Secret K8s
+# `<release>-oidc-client` consumido por:
+#   - Deployment quando schemaRegistry.authType=OAuthBearer (env
+#     SchemaRegistry__OAuth__ClientSecret via secretKeyRef — ADR-0051).
+#   - Cenário m2m futuro: API se autentica como service account contra
+#     outras APIs via client_credentials grant.
+# A guarda inclui ambos os predicados porque cada um é uma necessidade
+# independente — desligar oidc.enabled (bearer validation no resource
+# server) não deveria desligar o cliente OAuth que o Schema Registry
+# precisa para publicar schemas.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/apps/uniplus-api-portal/templates/externalsecret.yaml
+++ b/apps/uniplus-api-portal/templates/externalsecret.yaml
@@ -100,7 +100,11 @@ spec:
         key: {{ $es.kafkaAdmin.vaultPath }}
         property: {{ $es.kafkaAdmin.caCertKey }}
 {{- end }}
-{{- if or .Values.uniplusApiPortal.oidc.enabled (and (ne .Values.uniplusApiPortal.schemaRegistry.url "") (eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer")) }}
+{{/* ESO 5 só é necessário quando consumimos OIDC m2m OU Schema Registry com OAuthBearer
+     (basic/none não consumem este Secret). url vazio = feature off, mesma guarda do
+     Deployment para evitar criar Secret órfão. */}}
+{{- $srOAuthActive := and (ne .Values.uniplusApiPortal.schemaRegistry.url "") (eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer") -}}
+{{- if or .Values.uniplusApiPortal.oidc.enabled $srOAuthActive }}
 ---
 # ESO 5: client_secret OIDC do realm uniplus. Materializa o Secret K8s
 # `<release>-oidc-client` consumido por:

--- a/apps/uniplus-api-portal/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-portal/templates/networkpolicy.yaml
@@ -2,8 +2,9 @@
 {{- if not .Values.uniplusApiPortal.networkPolicy.dataHostCIDR -}}
 {{- fail "uniplusApiPortal.networkPolicy.dataHostCIDR é obrigatório (egress para Postgres + Redis + Kafka + MinIO no data-host)." -}}
 {{- end -}}
-{{- if and .Values.uniplusApiPortal.oidc.enabled (not .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR) -}}
-{{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (issuer público resolvido via Traefik no IP do k8s-host)." -}}
+{{- $srOAuth := eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer" -}}
+{{- if and (or .Values.uniplusApiPortal.oidc.enabled $srOAuth) (not .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU schemaRegistry.authType=OAuthBearer (egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host)." -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/apps/uniplus-api-portal/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-portal/templates/networkpolicy.yaml
@@ -73,8 +73,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiPortal.networkPolicy.keycloakPort }}
-    {{- if .Values.uniplusApiPortal.oidc.enabled }}
-    # OIDC issuer público — JWT validation chama jwks endpoint (HTTPS).
+    {{- if or .Values.uniplusApiPortal.oidc.enabled (eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer") }}
+    # Egress HTTPS para o IP público do k8s-host (Traefik), necessário para:
+    #   - JWT validation chama jwks endpoint do Keycloak quando oidc.enabled
+    #     (resource server bearer validation).
+    #   - Token endpoint OAuth + Apicurio Registry (Confluent-compat) quando
+    #     schemaRegistry.authType=OAuthBearer (publishing de schemas, ADR-0051).
+    # Em standalone os dois subdomínios (auth + schema-registry) resolvem para
+    # o mesmo IP público do k8s-host (Traefik termina TLS), então uma regra
+    # única cobre ambos consumidores.
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR }}

--- a/apps/uniplus-api-portal/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-portal/templates/networkpolicy.yaml
@@ -98,4 +98,16 @@ spec:
         - protocol: TCP
           port: {{ .Values.uniplusApiPortal.networkPolicy.oidcIssuerPort }}
     {{- end }}
+    {{- if and $srEnabled .Values.uniplusApiPortal.networkPolicy.schemaRegistryCIDR }}
+    # Regra adicional para Schema Registry em IP público distinto do OIDC
+    # issuer (lab/prod-* podem ter Apicurio em outro host/cluster). Quando
+    # schemaRegistryCIDR está vazio assumimos co-locação com oidcIssuerCIDR
+    # (cobertura via regra acima) — caso default do standalone.
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.uniplusApiPortal.networkPolicy.schemaRegistryCIDR }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uniplusApiPortal.networkPolicy.schemaRegistryPort }}
+    {{- end }}
 {{- end }}

--- a/apps/uniplus-api-portal/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-portal/templates/networkpolicy.yaml
@@ -7,10 +7,18 @@
   guarda do deployment.yaml, que só renderiza envs SchemaRegistry__* quando
   url está populado). Independente do authType (None/Basic/OAuthBearer), a
   API precisa alcançar o registry HTTPS quando a feature está on.
+
+  $hasSrCIDR: CIDR dedicado do Schema Registry está configurado. Quando
+  vazio, assumimos co-locação com o OIDC issuer e usamos oidcIssuerCIDR
+  como fallback (default standalone via Traefik no k8s-host).
 */}}
 {{- $srEnabled := ne .Values.uniplusApiPortal.schemaRegistry.url "" -}}
-{{- if and (or .Values.uniplusApiPortal.oidc.enabled $srEnabled) (not .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR) -}}
-{{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU schemaRegistry.url populado — egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host (em standalone os 2 subdomínios resolvem para o mesmo IP)." -}}
+{{- $hasSrCIDR := ne .Values.uniplusApiPortal.networkPolicy.schemaRegistryCIDR "" -}}
+{{- if and .Values.uniplusApiPortal.oidc.enabled (not .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (egress HTTPS para o issuer Keycloak / JWKS validation)." -}}
+{{- end -}}
+{{- if and $srEnabled (not .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR) (not $hasSrCIDR) -}}
+{{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR OU schemaRegistryCIDR é obrigatório quando schemaRegistry.url está populado (egress HTTPS para o Apicurio Registry). Em standalone os 2 subdomínios resolvem para o mesmo IP — basta oidcIssuerCIDR; em environments com IPs distintos, definir schemaRegistryCIDR." -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -80,17 +88,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiPortal.networkPolicy.keycloakPort }}
-    {{- if or .Values.uniplusApiPortal.oidc.enabled $srEnabled }}
-    # Egress HTTPS para o IP público do k8s-host (Traefik), necessário para:
-    #   - JWT validation chama jwks endpoint do Keycloak quando oidc.enabled
-    #     (resource server bearer validation).
-    #   - Schema Registry (Apicurio Confluent-compat) quando schemaRegistry.url
-    #     está populado — independente do authType. Token endpoint OAuth
-    #     adicional quando authType=OAuthBearer também roteia pelo mesmo IP.
-    # Em standalone os subdomínios (auth + schema-registry) resolvem para
-    # o mesmo IP público do k8s-host (Traefik termina TLS), então uma regra
-    # única cobre ambos consumidores. Em environments com IPs distintos,
-    # adicionar regra extra via override de networkPolicy.
+    {{- if or .Values.uniplusApiPortal.oidc.enabled (and $srEnabled (not $hasSrCIDR)) }}
+    # Egress HTTPS para o IP do OIDC issuer (Keycloak via Traefik). Cobre:
+    #   - JWT validation chama jwks endpoint quando oidc.enabled (bearer
+    #     validation no resource server).
+    #   - Schema Registry quando schemaRegistry.url está populado E
+    #     schemaRegistryCIDR vazio (co-locação default do standalone — auth
+    #     e schema-registry subdomínios resolvem para o mesmo IP do k8s-host).
+    # Quando OIDC está desligado E schemaRegistryCIDR está populado, esta
+    # regra não é renderizada (caminho dedicado abaixo cobre).
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR }}
@@ -98,11 +104,11 @@ spec:
         - protocol: TCP
           port: {{ .Values.uniplusApiPortal.networkPolicy.oidcIssuerPort }}
     {{- end }}
-    {{- if and $srEnabled .Values.uniplusApiPortal.networkPolicy.schemaRegistryCIDR }}
-    # Regra adicional para Schema Registry em IP público distinto do OIDC
-    # issuer (lab/prod-* podem ter Apicurio em outro host/cluster). Quando
-    # schemaRegistryCIDR está vazio assumimos co-locação com oidcIssuerCIDR
-    # (cobertura via regra acima) — caso default do standalone.
+    {{- if and $srEnabled $hasSrCIDR }}
+    # Regra dedicada para Schema Registry em IP público distinto do OIDC
+    # issuer (lab/prod-* podem ter Apicurio em outro host/cluster). Esta
+    # regra é independente da regra OIDC acima — em standalone
+    # (schemaRegistryCIDR vazio) o egress do registry cai na regra OIDC.
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiPortal.networkPolicy.schemaRegistryCIDR }}

--- a/apps/uniplus-api-portal/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-portal/templates/networkpolicy.yaml
@@ -5,17 +5,31 @@
 {{- /*
   $srEnabled: feature flag real do Schema Registry — url não-vazia (mesma
   guarda do deployment.yaml, que só renderiza envs SchemaRegistry__* quando
-  url está populado). Independente do authType (None/Basic/OAuthBearer), a
-  API precisa alcançar o registry HTTPS quando a feature está on.
+  url está populado). Independente do authType, a API precisa alcançar o
+  registry HTTPS quando a feature está on.
 
   $hasSrCIDR: CIDR dedicado do Schema Registry está configurado. Quando
   vazio, assumimos co-locação com o OIDC issuer e usamos oidcIssuerCIDR
   como fallback (default standalone via Traefik no k8s-host).
+
+  $srNeedsIssuerCIDR: a regra ipBlock=oidcIssuerCIDR ainda é necessária
+  para Schema Registry em 2 casos:
+    1. Co-locação (hasSrCIDR=false) — registry alcançável pelo IP do issuer.
+    2. authType=OAuthBearer — o oauth.tokenEndpoint tipicamente fica no
+       Keycloak (mesmo IP do issuer), independente do CIDR dedicado do
+       registry para chamadas Confluent-compat.
+  Só dispensamos oidcIssuerCIDR quando SR usa Basic/None E tem CIDR
+  dedicado (rota Confluent-compat 100% no registry, sem token endpoint).
 */}}
 {{- $srEnabled := ne .Values.uniplusApiPortal.schemaRegistry.url "" -}}
 {{- $hasSrCIDR := ne .Values.uniplusApiPortal.networkPolicy.schemaRegistryCIDR "" -}}
+{{- $srOAuth := eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer" -}}
+{{- $srNeedsIssuerCIDR := and $srEnabled (or (not $hasSrCIDR) $srOAuth) -}}
 {{- if and .Values.uniplusApiPortal.oidc.enabled (not .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR) -}}
 {{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (egress HTTPS para o issuer Keycloak / JWKS validation)." -}}
+{{- end -}}
+{{- if and $srNeedsIssuerCIDR (not .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR é obrigatório quando schemaRegistry.url está populado E (schemaRegistryCIDR vazio OU authType=OAuthBearer) — o egress 443 do registry co-localizado OU do oauth.tokenEndpoint precisa alcançar o IP do issuer." -}}
 {{- end -}}
 {{- if and $srEnabled (not .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR) (not $hasSrCIDR) -}}
 {{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR OU schemaRegistryCIDR é obrigatório quando schemaRegistry.url está populado (egress HTTPS para o Apicurio Registry). Em standalone os 2 subdomínios resolvem para o mesmo IP — basta oidcIssuerCIDR; em environments com IPs distintos, definir schemaRegistryCIDR." -}}
@@ -88,15 +102,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiPortal.networkPolicy.keycloakPort }}
-    {{- if or .Values.uniplusApiPortal.oidc.enabled (and $srEnabled (not $hasSrCIDR)) }}
+    {{- if or .Values.uniplusApiPortal.oidc.enabled $srNeedsIssuerCIDR }}
     # Egress HTTPS para o IP do OIDC issuer (Keycloak via Traefik). Cobre:
     #   - JWT validation chama jwks endpoint quando oidc.enabled (bearer
     #     validation no resource server).
-    #   - Schema Registry quando schemaRegistry.url está populado E
-    #     schemaRegistryCIDR vazio (co-locação default do standalone — auth
-    #     e schema-registry subdomínios resolvem para o mesmo IP do k8s-host).
-    # Quando OIDC está desligado E schemaRegistryCIDR está populado, esta
-    # regra não é renderizada (caminho dedicado abaixo cobre).
+    #   - Schema Registry co-localizado (schemaRegistryCIDR vazio — default
+    #     standalone, auth e schema-registry subdomínios no mesmo IP).
+    #   - oauth.tokenEndpoint quando schemaRegistry.authType=OAuthBearer —
+    #     tipicamente fica no Keycloak, mesmo CIDR do issuer, independente
+    #     do CIDR dedicado do registry para chamadas Confluent-compat.
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR }}

--- a/apps/uniplus-api-portal/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-portal/templates/networkpolicy.yaml
@@ -2,9 +2,15 @@
 {{- if not .Values.uniplusApiPortal.networkPolicy.dataHostCIDR -}}
 {{- fail "uniplusApiPortal.networkPolicy.dataHostCIDR é obrigatório (egress para Postgres + Redis + Kafka + MinIO no data-host)." -}}
 {{- end -}}
-{{- $srOAuth := eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer" -}}
+{{- /*
+  $srOAuth combina url não-vazia (feature off quando url=="") com authType=OAuthBearer.
+  Mesma guarda usada no deployment.yaml (env vars Schema Registry só renderizam
+  quando url está populado) — mantém consistência entre os templates: se a
+  feature está off no Deployment, o NetworkPolicy também ignora.
+*/}}
+{{- $srOAuth := and (ne .Values.uniplusApiPortal.schemaRegistry.url "") (eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer") -}}
 {{- if and (or .Values.uniplusApiPortal.oidc.enabled $srOAuth) (not .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR) -}}
-{{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU schemaRegistry.authType=OAuthBearer (egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host)." -}}
+{{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU (schemaRegistry.url populado E schemaRegistry.authType=OAuthBearer) — egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host." -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -74,7 +80,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiPortal.networkPolicy.keycloakPort }}
-    {{- if or .Values.uniplusApiPortal.oidc.enabled (eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer") }}
+    {{- if or .Values.uniplusApiPortal.oidc.enabled $srOAuth }}
     # Egress HTTPS para o IP público do k8s-host (Traefik), necessário para:
     #   - JWT validation chama jwks endpoint do Keycloak quando oidc.enabled
     #     (resource server bearer validation).

--- a/apps/uniplus-api-portal/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-portal/templates/networkpolicy.yaml
@@ -3,14 +3,14 @@
 {{- fail "uniplusApiPortal.networkPolicy.dataHostCIDR é obrigatório (egress para Postgres + Redis + Kafka + MinIO no data-host)." -}}
 {{- end -}}
 {{- /*
-  $srOAuth combina url não-vazia (feature off quando url=="") com authType=OAuthBearer.
-  Mesma guarda usada no deployment.yaml (env vars Schema Registry só renderizam
-  quando url está populado) — mantém consistência entre os templates: se a
-  feature está off no Deployment, o NetworkPolicy também ignora.
+  $srEnabled: feature flag real do Schema Registry — url não-vazia (mesma
+  guarda do deployment.yaml, que só renderiza envs SchemaRegistry__* quando
+  url está populado). Independente do authType (None/Basic/OAuthBearer), a
+  API precisa alcançar o registry HTTPS quando a feature está on.
 */}}
-{{- $srOAuth := and (ne .Values.uniplusApiPortal.schemaRegistry.url "") (eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer") -}}
-{{- if and (or .Values.uniplusApiPortal.oidc.enabled $srOAuth) (not .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR) -}}
-{{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU (schemaRegistry.url populado E schemaRegistry.authType=OAuthBearer) — egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host." -}}
+{{- $srEnabled := ne .Values.uniplusApiPortal.schemaRegistry.url "" -}}
+{{- if and (or .Values.uniplusApiPortal.oidc.enabled $srEnabled) (not .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiPortal.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU schemaRegistry.url populado — egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host (em standalone os 2 subdomínios resolvem para o mesmo IP)." -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -80,15 +80,17 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiPortal.networkPolicy.keycloakPort }}
-    {{- if or .Values.uniplusApiPortal.oidc.enabled $srOAuth }}
+    {{- if or .Values.uniplusApiPortal.oidc.enabled $srEnabled }}
     # Egress HTTPS para o IP público do k8s-host (Traefik), necessário para:
     #   - JWT validation chama jwks endpoint do Keycloak quando oidc.enabled
     #     (resource server bearer validation).
-    #   - Token endpoint OAuth + Apicurio Registry (Confluent-compat) quando
-    #     schemaRegistry.authType=OAuthBearer (publishing de schemas, ADR-0051).
-    # Em standalone os dois subdomínios (auth + schema-registry) resolvem para
+    #   - Schema Registry (Apicurio Confluent-compat) quando schemaRegistry.url
+    #     está populado — independente do authType. Token endpoint OAuth
+    #     adicional quando authType=OAuthBearer também roteia pelo mesmo IP.
+    # Em standalone os subdomínios (auth + schema-registry) resolvem para
     # o mesmo IP público do k8s-host (Traefik termina TLS), então uma regra
-    # única cobre ambos consumidores.
+    # única cobre ambos consumidores. Em environments com IPs distintos,
+    # adicionar regra extra via override de networkPolicy.
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiPortal.networkPolicy.oidcIssuerCIDR }}

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -49,6 +49,18 @@ uniplusApiPortal:
     vaultAddress: ""
     kubernetesRole: ""
 
+  # Schema Registry (ADR-0051) — feature off quando url está vazio. Em
+  # ambientes de produção com Kafka habilitado, Program.cs aborta o boot
+  # se url estiver vazio (publishing cross-módulo exige schema validation).
+  # Auth OAuthBearer: client_secret vem do Secret K8s sintetizado pelo
+  # ESO 5 (oidcSecretName) — mesmo Vault path do OIDC client da API.
+  schemaRegistry:
+    url: ""
+    authType: None
+    oauth:
+      tokenEndpoint: ""
+      clientId: ""
+
   aspnet:
     environment: Production
     urls: "http://+:8080"

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -164,6 +164,13 @@ uniplusApiPortal:
     keycloakPort: 8080
     oidcIssuerCIDR: ""          # ex.: 164.152.53.29/32
     oidcIssuerPort: 443
+    # CIDR adicional para Schema Registry (ADR-0051) quando o Apicurio
+    # estiver em IP público distinto do OIDC issuer. Vazio = assume
+    # co-locação com oidcIssuerCIDR (default standalone — ambos subdomínios
+    # resolvem via Traefik no mesmo k8s-host). Em environments com IPs
+    # distintos, definir aqui para liberar egress HTTPS separado.
+    schemaRegistryCIDR: ""
+    schemaRegistryPort: 443
 
   metrics:
     enabled: false

--- a/apps/uniplus-api-selecao/templates/deployment.yaml
+++ b/apps/uniplus-api-selecao/templates/deployment.yaml
@@ -22,6 +22,14 @@
   {{- fail "uniplusApiSelecao.encryption.kubernetesRole é obrigatório quando encryption.provider=vault. A role precisa existir no Vault (uniplus-infra#219) com bound_service_account_names incluindo a SA deste chart." -}}
   {{- end -}}
 {{- end -}}
+{{- if and .Values.uniplusApiSelecao.schemaRegistry.url (eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer") -}}
+  {{- if not .Values.uniplusApiSelecao.schemaRegistry.oauth.tokenEndpoint -}}
+  {{- fail "uniplusApiSelecao.schemaRegistry.oauth.tokenEndpoint é obrigatório quando schemaRegistry.url está populado e authType=OAuthBearer. ADR-0051 exige endpoint /protocol/openid-connect/token do realm Keycloak para emissão do bearer token." -}}
+  {{- end -}}
+  {{- if not .Values.uniplusApiSelecao.schemaRegistry.oauth.clientId -}}
+  {{- fail "uniplusApiSelecao.schemaRegistry.oauth.clientId é obrigatório quando schemaRegistry.url está populado e authType=OAuthBearer. Tipicamente uniplus-api-<app>; client_secret correspondente custodiado no Vault em secret/<env>/keycloak/clients/<clientId>." -}}
+  {{- end -}}
+{{- end -}}
 {{- if not .Values.uniplusApiSelecao.externalSecrets.enabled -}}
 {{- fail "uniplusApiSelecao.enabled=true requer externalSecrets.enabled=true. Deployment depende dos Secrets sintetizados pelo ESO (Postgres password, Redis, MinIO, Kafka, OIDC)." -}}
 {{- end -}}

--- a/apps/uniplus-api-selecao/templates/deployment.yaml
+++ b/apps/uniplus-api-selecao/templates/deployment.yaml
@@ -159,7 +159,30 @@ spec:
             - name: UniPlus__Encryption__KubernetesRole
               value: {{ .Values.uniplusApiSelecao.encryption.kubernetesRole | quote }}
             {{- end }}
-            
+            # === Schema Registry (ADR-0051) — Apicurio Confluent-compat ===
+            # url vazio = feature off; em Production com Kafka habilitado, o
+            # Program.cs aborta o boot se url estiver vazio. AuthType OAuthBearer
+            # exige tokenEndpoint+clientId; client_secret é injetado via
+            # secretKeyRef do mesmo ESO 5 (oidcSecretName) já existente,
+            # alinhado ao Vault path secret/<env>/keycloak/clients/uniplus-api-<app>.
+            {{- if .Values.uniplusApiSelecao.schemaRegistry.url }}
+            - name: SchemaRegistry__Url
+              value: {{ .Values.uniplusApiSelecao.schemaRegistry.url | quote }}
+            - name: SchemaRegistry__AuthType
+              value: {{ .Values.uniplusApiSelecao.schemaRegistry.authType | quote }}
+            {{- if eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer" }}
+            - name: SchemaRegistry__OAuth__TokenEndpoint
+              value: {{ .Values.uniplusApiSelecao.schemaRegistry.oauth.tokenEndpoint | quote }}
+            - name: SchemaRegistry__OAuth__ClientId
+              value: {{ .Values.uniplusApiSelecao.schemaRegistry.oauth.clientId | quote }}
+            - name: SchemaRegistry__OAuth__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "uniplusApiSelecao.oidcSecretName" . }}
+                  key: OIDC_CLIENT_SECRET
+            {{- end }}
+            {{- end }}
+
             {{- range $i, $origin := .Values.uniplusApiSelecao.cors.allowedOrigins }}
             - name: Cors__AllowedOrigins__{{ $i }}
               value: {{ $origin | quote }}

--- a/apps/uniplus-api-selecao/templates/externalsecret.yaml
+++ b/apps/uniplus-api-selecao/templates/externalsecret.yaml
@@ -100,7 +100,11 @@ spec:
         key: {{ $es.kafkaAdmin.vaultPath }}
         property: {{ $es.kafkaAdmin.caCertKey }}
 {{- end }}
-{{- if or .Values.uniplusApiSelecao.oidc.enabled (and (ne .Values.uniplusApiSelecao.schemaRegistry.url "") (eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer")) }}
+{{/* ESO 5 só é necessário quando consumimos OIDC m2m OU Schema Registry com OAuthBearer
+     (basic/none não consumem este Secret). url vazio = feature off, mesma guarda do
+     Deployment para evitar criar Secret órfão. */}}
+{{- $srOAuthActive := and (ne .Values.uniplusApiSelecao.schemaRegistry.url "") (eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer") -}}
+{{- if or .Values.uniplusApiSelecao.oidc.enabled $srOAuthActive }}
 ---
 # ESO 5: client_secret OIDC do realm uniplus. Materializa o Secret K8s
 # `<release>-oidc-client` consumido por:

--- a/apps/uniplus-api-selecao/templates/externalsecret.yaml
+++ b/apps/uniplus-api-selecao/templates/externalsecret.yaml
@@ -100,13 +100,18 @@ spec:
         key: {{ $es.kafkaAdmin.vaultPath }}
         property: {{ $es.kafkaAdmin.caCertKey }}
 {{- end }}
-{{- if .Values.uniplusApiSelecao.oidc.enabled }}
+{{- if or .Values.uniplusApiSelecao.oidc.enabled (eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer") }}
 ---
-# ESO 5: OIDC client_secret reservado para machine-to-machine (m2m)
-# FUTURO. Resource server bearer-only NÃO consome este Secret em runtime
-# — não há env var nem envFrom no Deployment referenciando-o. ESO antecipa
-# o cenário em que a API se autentica como service account contra outras
-# APIs (client_credentials grant). Mantido para parity com kafka-ui/apicurio-registry.
+# ESO 5: client_secret OIDC do realm uniplus. Materializa o Secret K8s
+# `<release>-oidc-client` consumido por:
+#   - Deployment quando schemaRegistry.authType=OAuthBearer (env
+#     SchemaRegistry__OAuth__ClientSecret via secretKeyRef — ADR-0051).
+#   - Cenário m2m futuro: API se autentica como service account contra
+#     outras APIs via client_credentials grant.
+# A guarda inclui ambos os predicados porque cada um é uma necessidade
+# independente — desligar oidc.enabled (bearer validation no resource
+# server) não deveria desligar o cliente OAuth que o Schema Registry
+# precisa para publicar schemas.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/apps/uniplus-api-selecao/templates/externalsecret.yaml
+++ b/apps/uniplus-api-selecao/templates/externalsecret.yaml
@@ -100,7 +100,7 @@ spec:
         key: {{ $es.kafkaAdmin.vaultPath }}
         property: {{ $es.kafkaAdmin.caCertKey }}
 {{- end }}
-{{- if or .Values.uniplusApiSelecao.oidc.enabled (eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer") }}
+{{- if or .Values.uniplusApiSelecao.oidc.enabled (and (ne .Values.uniplusApiSelecao.schemaRegistry.url "") (eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer")) }}
 ---
 # ESO 5: client_secret OIDC do realm uniplus. Materializa o Secret K8s
 # `<release>-oidc-client` consumido por:

--- a/apps/uniplus-api-selecao/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-selecao/templates/networkpolicy.yaml
@@ -3,14 +3,14 @@
 {{- fail "uniplusApiSelecao.networkPolicy.dataHostCIDR é obrigatório (egress para Postgres + Redis + Kafka + MinIO no data-host)." -}}
 {{- end -}}
 {{- /*
-  $srOAuth combina url não-vazia (feature off quando url=="") com authType=OAuthBearer.
-  Mesma guarda usada no deployment.yaml (env vars Schema Registry só renderizam
-  quando url está populado) — mantém consistência entre os templates: se a
-  feature está off no Deployment, o NetworkPolicy também ignora.
+  $srEnabled: feature flag real do Schema Registry — url não-vazia (mesma
+  guarda do deployment.yaml, que só renderiza envs SchemaRegistry__* quando
+  url está populado). Independente do authType (None/Basic/OAuthBearer), a
+  API precisa alcançar o registry HTTPS quando a feature está on.
 */}}
-{{- $srOAuth := and (ne .Values.uniplusApiSelecao.schemaRegistry.url "") (eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer") -}}
-{{- if and (or .Values.uniplusApiSelecao.oidc.enabled $srOAuth) (not .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR) -}}
-{{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU (schemaRegistry.url populado E schemaRegistry.authType=OAuthBearer) — egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host." -}}
+{{- $srEnabled := ne .Values.uniplusApiSelecao.schemaRegistry.url "" -}}
+{{- if and (or .Values.uniplusApiSelecao.oidc.enabled $srEnabled) (not .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU schemaRegistry.url populado — egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host (em standalone os 2 subdomínios resolvem para o mesmo IP)." -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -80,15 +80,17 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiSelecao.networkPolicy.keycloakPort }}
-    {{- if or .Values.uniplusApiSelecao.oidc.enabled $srOAuth }}
+    {{- if or .Values.uniplusApiSelecao.oidc.enabled $srEnabled }}
     # Egress HTTPS para o IP público do k8s-host (Traefik), necessário para:
     #   - JWT validation chama jwks endpoint do Keycloak quando oidc.enabled
     #     (resource server bearer validation).
-    #   - Token endpoint OAuth + Apicurio Registry (Confluent-compat) quando
-    #     schemaRegistry.authType=OAuthBearer (publishing de schemas, ADR-0051).
-    # Em standalone os dois subdomínios (auth + schema-registry) resolvem para
+    #   - Schema Registry (Apicurio Confluent-compat) quando schemaRegistry.url
+    #     está populado — independente do authType. Token endpoint OAuth
+    #     adicional quando authType=OAuthBearer também roteia pelo mesmo IP.
+    # Em standalone os subdomínios (auth + schema-registry) resolvem para
     # o mesmo IP público do k8s-host (Traefik termina TLS), então uma regra
-    # única cobre ambos consumidores.
+    # única cobre ambos consumidores. Em environments com IPs distintos,
+    # adicionar regra extra via override de networkPolicy.
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR }}

--- a/apps/uniplus-api-selecao/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-selecao/templates/networkpolicy.yaml
@@ -98,4 +98,16 @@ spec:
         - protocol: TCP
           port: {{ .Values.uniplusApiSelecao.networkPolicy.oidcIssuerPort }}
     {{- end }}
+    {{- if and $srEnabled .Values.uniplusApiSelecao.networkPolicy.schemaRegistryCIDR }}
+    # Regra adicional para Schema Registry em IP público distinto do OIDC
+    # issuer (lab/prod-* podem ter Apicurio em outro host/cluster). Quando
+    # schemaRegistryCIDR está vazio assumimos co-locação com oidcIssuerCIDR
+    # (cobertura via regra acima) — caso default do standalone.
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.uniplusApiSelecao.networkPolicy.schemaRegistryCIDR }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uniplusApiSelecao.networkPolicy.schemaRegistryPort }}
+    {{- end }}
 {{- end }}

--- a/apps/uniplus-api-selecao/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-selecao/templates/networkpolicy.yaml
@@ -7,10 +7,18 @@
   guarda do deployment.yaml, que só renderiza envs SchemaRegistry__* quando
   url está populado). Independente do authType (None/Basic/OAuthBearer), a
   API precisa alcançar o registry HTTPS quando a feature está on.
+
+  $hasSrCIDR: CIDR dedicado do Schema Registry está configurado. Quando
+  vazio, assumimos co-locação com o OIDC issuer e usamos oidcIssuerCIDR
+  como fallback (default standalone via Traefik no k8s-host).
 */}}
 {{- $srEnabled := ne .Values.uniplusApiSelecao.schemaRegistry.url "" -}}
-{{- if and (or .Values.uniplusApiSelecao.oidc.enabled $srEnabled) (not .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR) -}}
-{{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU schemaRegistry.url populado — egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host (em standalone os 2 subdomínios resolvem para o mesmo IP)." -}}
+{{- $hasSrCIDR := ne .Values.uniplusApiSelecao.networkPolicy.schemaRegistryCIDR "" -}}
+{{- if and .Values.uniplusApiSelecao.oidc.enabled (not .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (egress HTTPS para o issuer Keycloak / JWKS validation)." -}}
+{{- end -}}
+{{- if and $srEnabled (not .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR) (not $hasSrCIDR) -}}
+{{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR OU schemaRegistryCIDR é obrigatório quando schemaRegistry.url está populado (egress HTTPS para o Apicurio Registry). Em standalone os 2 subdomínios resolvem para o mesmo IP — basta oidcIssuerCIDR; em environments com IPs distintos, definir schemaRegistryCIDR." -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -80,17 +88,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiSelecao.networkPolicy.keycloakPort }}
-    {{- if or .Values.uniplusApiSelecao.oidc.enabled $srEnabled }}
-    # Egress HTTPS para o IP público do k8s-host (Traefik), necessário para:
-    #   - JWT validation chama jwks endpoint do Keycloak quando oidc.enabled
-    #     (resource server bearer validation).
-    #   - Schema Registry (Apicurio Confluent-compat) quando schemaRegistry.url
-    #     está populado — independente do authType. Token endpoint OAuth
-    #     adicional quando authType=OAuthBearer também roteia pelo mesmo IP.
-    # Em standalone os subdomínios (auth + schema-registry) resolvem para
-    # o mesmo IP público do k8s-host (Traefik termina TLS), então uma regra
-    # única cobre ambos consumidores. Em environments com IPs distintos,
-    # adicionar regra extra via override de networkPolicy.
+    {{- if or .Values.uniplusApiSelecao.oidc.enabled (and $srEnabled (not $hasSrCIDR)) }}
+    # Egress HTTPS para o IP do OIDC issuer (Keycloak via Traefik). Cobre:
+    #   - JWT validation chama jwks endpoint quando oidc.enabled (bearer
+    #     validation no resource server).
+    #   - Schema Registry quando schemaRegistry.url está populado E
+    #     schemaRegistryCIDR vazio (co-locação default do standalone — auth
+    #     e schema-registry subdomínios resolvem para o mesmo IP do k8s-host).
+    # Quando OIDC está desligado E schemaRegistryCIDR está populado, esta
+    # regra não é renderizada (caminho dedicado abaixo cobre).
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR }}
@@ -98,11 +104,11 @@ spec:
         - protocol: TCP
           port: {{ .Values.uniplusApiSelecao.networkPolicy.oidcIssuerPort }}
     {{- end }}
-    {{- if and $srEnabled .Values.uniplusApiSelecao.networkPolicy.schemaRegistryCIDR }}
-    # Regra adicional para Schema Registry em IP público distinto do OIDC
-    # issuer (lab/prod-* podem ter Apicurio em outro host/cluster). Quando
-    # schemaRegistryCIDR está vazio assumimos co-locação com oidcIssuerCIDR
-    # (cobertura via regra acima) — caso default do standalone.
+    {{- if and $srEnabled $hasSrCIDR }}
+    # Regra dedicada para Schema Registry em IP público distinto do OIDC
+    # issuer (lab/prod-* podem ter Apicurio em outro host/cluster). Esta
+    # regra é independente da regra OIDC acima — em standalone
+    # (schemaRegistryCIDR vazio) o egress do registry cai na regra OIDC.
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiSelecao.networkPolicy.schemaRegistryCIDR }}

--- a/apps/uniplus-api-selecao/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-selecao/templates/networkpolicy.yaml
@@ -73,8 +73,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiSelecao.networkPolicy.keycloakPort }}
-    {{- if .Values.uniplusApiSelecao.oidc.enabled }}
-    # OIDC issuer público — JWT validation chama jwks endpoint (HTTPS).
+    {{- if or .Values.uniplusApiSelecao.oidc.enabled (eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer") }}
+    # Egress HTTPS para o IP público do k8s-host (Traefik), necessário para:
+    #   - JWT validation chama jwks endpoint do Keycloak quando oidc.enabled
+    #     (resource server bearer validation).
+    #   - Token endpoint OAuth + Apicurio Registry (Confluent-compat) quando
+    #     schemaRegistry.authType=OAuthBearer (publishing de schemas, ADR-0051).
+    # Em standalone os dois subdomínios (auth + schema-registry) resolvem para
+    # o mesmo IP público do k8s-host (Traefik termina TLS), então uma regra
+    # única cobre ambos consumidores.
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR }}

--- a/apps/uniplus-api-selecao/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-selecao/templates/networkpolicy.yaml
@@ -2,8 +2,9 @@
 {{- if not .Values.uniplusApiSelecao.networkPolicy.dataHostCIDR -}}
 {{- fail "uniplusApiSelecao.networkPolicy.dataHostCIDR é obrigatório (egress para Postgres + Redis + Kafka + MinIO no data-host)." -}}
 {{- end -}}
-{{- if and .Values.uniplusApiSelecao.oidc.enabled (not .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR) -}}
-{{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (issuer público resolvido via Traefik no IP do k8s-host)." -}}
+{{- $srOAuth := eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer" -}}
+{{- if and (or .Values.uniplusApiSelecao.oidc.enabled $srOAuth) (not .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU schemaRegistry.authType=OAuthBearer (egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host)." -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/apps/uniplus-api-selecao/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-selecao/templates/networkpolicy.yaml
@@ -2,9 +2,15 @@
 {{- if not .Values.uniplusApiSelecao.networkPolicy.dataHostCIDR -}}
 {{- fail "uniplusApiSelecao.networkPolicy.dataHostCIDR é obrigatório (egress para Postgres + Redis + Kafka + MinIO no data-host)." -}}
 {{- end -}}
-{{- $srOAuth := eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer" -}}
+{{- /*
+  $srOAuth combina url não-vazia (feature off quando url=="") com authType=OAuthBearer.
+  Mesma guarda usada no deployment.yaml (env vars Schema Registry só renderizam
+  quando url está populado) — mantém consistência entre os templates: se a
+  feature está off no Deployment, o NetworkPolicy também ignora.
+*/}}
+{{- $srOAuth := and (ne .Values.uniplusApiSelecao.schemaRegistry.url "") (eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer") -}}
 {{- if and (or .Values.uniplusApiSelecao.oidc.enabled $srOAuth) (not .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR) -}}
-{{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU schemaRegistry.authType=OAuthBearer (egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host)." -}}
+{{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true OU (schemaRegistry.url populado E schemaRegistry.authType=OAuthBearer) — egress HTTPS via Traefik para Keycloak/Apicurio no IP do k8s-host." -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -74,7 +80,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiSelecao.networkPolicy.keycloakPort }}
-    {{- if or .Values.uniplusApiSelecao.oidc.enabled (eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer") }}
+    {{- if or .Values.uniplusApiSelecao.oidc.enabled $srOAuth }}
     # Egress HTTPS para o IP público do k8s-host (Traefik), necessário para:
     #   - JWT validation chama jwks endpoint do Keycloak quando oidc.enabled
     #     (resource server bearer validation).

--- a/apps/uniplus-api-selecao/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-selecao/templates/networkpolicy.yaml
@@ -5,17 +5,31 @@
 {{- /*
   $srEnabled: feature flag real do Schema Registry — url não-vazia (mesma
   guarda do deployment.yaml, que só renderiza envs SchemaRegistry__* quando
-  url está populado). Independente do authType (None/Basic/OAuthBearer), a
-  API precisa alcançar o registry HTTPS quando a feature está on.
+  url está populado). Independente do authType, a API precisa alcançar o
+  registry HTTPS quando a feature está on.
 
   $hasSrCIDR: CIDR dedicado do Schema Registry está configurado. Quando
   vazio, assumimos co-locação com o OIDC issuer e usamos oidcIssuerCIDR
   como fallback (default standalone via Traefik no k8s-host).
+
+  $srNeedsIssuerCIDR: a regra ipBlock=oidcIssuerCIDR ainda é necessária
+  para Schema Registry em 2 casos:
+    1. Co-locação (hasSrCIDR=false) — registry alcançável pelo IP do issuer.
+    2. authType=OAuthBearer — o oauth.tokenEndpoint tipicamente fica no
+       Keycloak (mesmo IP do issuer), independente do CIDR dedicado do
+       registry para chamadas Confluent-compat.
+  Só dispensamos oidcIssuerCIDR quando SR usa Basic/None E tem CIDR
+  dedicado (rota Confluent-compat 100% no registry, sem token endpoint).
 */}}
 {{- $srEnabled := ne .Values.uniplusApiSelecao.schemaRegistry.url "" -}}
 {{- $hasSrCIDR := ne .Values.uniplusApiSelecao.networkPolicy.schemaRegistryCIDR "" -}}
+{{- $srOAuth := eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer" -}}
+{{- $srNeedsIssuerCIDR := and $srEnabled (or (not $hasSrCIDR) $srOAuth) -}}
 {{- if and .Values.uniplusApiSelecao.oidc.enabled (not .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR) -}}
 {{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR é obrigatório quando oidc.enabled=true (egress HTTPS para o issuer Keycloak / JWKS validation)." -}}
+{{- end -}}
+{{- if and $srNeedsIssuerCIDR (not .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR) -}}
+{{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR é obrigatório quando schemaRegistry.url está populado E (schemaRegistryCIDR vazio OU authType=OAuthBearer) — o egress 443 do registry co-localizado OU do oauth.tokenEndpoint precisa alcançar o IP do issuer." -}}
 {{- end -}}
 {{- if and $srEnabled (not .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR) (not $hasSrCIDR) -}}
 {{- fail "uniplusApiSelecao.networkPolicy.oidcIssuerCIDR OU schemaRegistryCIDR é obrigatório quando schemaRegistry.url está populado (egress HTTPS para o Apicurio Registry). Em standalone os 2 subdomínios resolvem para o mesmo IP — basta oidcIssuerCIDR; em environments com IPs distintos, definir schemaRegistryCIDR." -}}
@@ -88,15 +102,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.uniplusApiSelecao.networkPolicy.keycloakPort }}
-    {{- if or .Values.uniplusApiSelecao.oidc.enabled (and $srEnabled (not $hasSrCIDR)) }}
+    {{- if or .Values.uniplusApiSelecao.oidc.enabled $srNeedsIssuerCIDR }}
     # Egress HTTPS para o IP do OIDC issuer (Keycloak via Traefik). Cobre:
     #   - JWT validation chama jwks endpoint quando oidc.enabled (bearer
     #     validation no resource server).
-    #   - Schema Registry quando schemaRegistry.url está populado E
-    #     schemaRegistryCIDR vazio (co-locação default do standalone — auth
-    #     e schema-registry subdomínios resolvem para o mesmo IP do k8s-host).
-    # Quando OIDC está desligado E schemaRegistryCIDR está populado, esta
-    # regra não é renderizada (caminho dedicado abaixo cobre).
+    #   - Schema Registry co-localizado (schemaRegistryCIDR vazio — default
+    #     standalone, auth e schema-registry subdomínios no mesmo IP).
+    #   - oauth.tokenEndpoint quando schemaRegistry.authType=OAuthBearer —
+    #     tipicamente fica no Keycloak, mesmo CIDR do issuer, independente
+    #     do CIDR dedicado do registry para chamadas Confluent-compat.
     - to:
         - ipBlock:
             cidr: {{ .Values.uniplusApiSelecao.networkPolicy.oidcIssuerCIDR }}

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -164,6 +164,13 @@ uniplusApiSelecao:
     keycloakPort: 8080
     oidcIssuerCIDR: ""          # ex.: 164.152.53.29/32
     oidcIssuerPort: 443
+    # CIDR adicional para Schema Registry (ADR-0051) quando o Apicurio
+    # estiver em IP público distinto do OIDC issuer. Vazio = assume
+    # co-locação com oidcIssuerCIDR (default standalone — ambos subdomínios
+    # resolvem via Traefik no mesmo k8s-host). Em environments com IPs
+    # distintos, definir aqui para liberar egress HTTPS separado.
+    schemaRegistryCIDR: ""
+    schemaRegistryPort: 443
 
   metrics:
     enabled: false

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -49,6 +49,18 @@ uniplusApiSelecao:
     vaultAddress: ""
     kubernetesRole: ""
 
+  # Schema Registry (ADR-0051) — feature off quando url está vazio. Em
+  # ambientes de produção com Kafka habilitado, Program.cs aborta o boot
+  # se url estiver vazio (publishing cross-módulo exige schema validation).
+  # Auth OAuthBearer: client_secret vem do Secret K8s sintetizado pelo
+  # ESO 5 (oidcSecretName) — mesmo Vault path do OIDC client da API.
+  schemaRegistry:
+    url: ""
+    authType: None
+    oauth:
+      tokenEndpoint: ""
+      clientId: ""
+
   aspnet:
     environment: Production
     urls: "http://+:8080"

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -956,6 +956,15 @@ uniplusApiPortal:
     provider: vault
     vaultAddress: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
     kubernetesRole: uniplus-api
+  # Schema Registry (ADR-0051) — Apicurio Confluent-compat. Auth OAuthBearer
+  # consumindo client_secret materializado pelo ESO 5 a partir do Vault path
+  # secret/standalone/keycloak/clients/uniplus-api-portal.
+  schemaRegistry:
+    url: https://schema-registry.standalone.portaluni.com.br/apis/ccompat/v7
+    authType: OAuthBearer
+    oauth:
+      tokenEndpoint: https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/token
+      clientId: uniplus-api-portal
 
 uniplusApiSelecao:
   enabled: true
@@ -994,6 +1003,12 @@ uniplusApiSelecao:
     provider: vault
     vaultAddress: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
     kubernetesRole: uniplus-api
+  schemaRegistry:
+    url: https://schema-registry.standalone.portaluni.com.br/apis/ccompat/v7
+    authType: OAuthBearer
+    oauth:
+      tokenEndpoint: https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/token
+      clientId: uniplus-api-selecao
 
 uniplusApiIngresso:
   enabled: true
@@ -1032,6 +1047,12 @@ uniplusApiIngresso:
     provider: vault
     vaultAddress: http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
     kubernetesRole: uniplus-api
+  schemaRegistry:
+    url: https://schema-registry.standalone.portaluni.com.br/apis/ccompat/v7
+    authType: OAuthBearer
+    oauth:
+      tokenEndpoint: https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/token
+      clientId: uniplus-api-ingresso
 
 # ----------------------------------------------------------------------------
 # Frontends Uni+ (Angular SPAs servidas por nginx-unprivileged). 1 chart,


### PR DESCRIPTION
## Contexto

Após o bump para `uniplus-api v0.3.0` (PR [#229](https://github.com/unifesspa-edu-br/uniplus-infra/pull/229)), o pod **uniplus-api-selecao** entrou em \`CrashLoopBackOff\` no boot:

\`\`\`
Unhandled exception. System.InvalidOperationException:
Configuração inválida: Kafka:BootstrapServers populado mas
SchemaRegistry:Url vazio em ASPNETCORE_ENVIRONMENT=Production.
ADR-0051 exige Schema Registry para todo publishing cross-módulo
em ambientes produtivos.
   at Program.<Main>$(String[] args) in Selecao.API/Program.cs:line 126
\`\`\`

A v0.3.0 adicionou um validator de boot ligado à ADR-0051 (Schema Registry). RollingUpdate do K8s manteve o pod antigo de v0.2.0 servindo tráfego, então não houve downtime — apenas o ArgoCD ficou \`Progressing\`. Portal e Ingresso não têm o mesmo enforce hoje, mas o caminho é wire-up nos 3 charts para evitar regression futura.

## O que muda

### Charts `apps/uniplus-api-{portal,selecao,ingresso}` (paralelas)

- **`values.yaml`**: novo bloco \`schemaRegistry\` (url + authType + oauth) com defaults vazios (feature off por design — mesmo pattern do bloco \`encryption\`).
- **`templates/deployment.yaml`**: env vars novos só renderizados quando \`schemaRegistry.url\` está populado. Suporta \`authType\` ∈ \`{None, Basic, OAuthBearer}\` (default \`None\`). Quando \`OAuthBearer\`, \`ClientSecret\` é injetado via \`secretKeyRef\` do Secret K8s sintetizado pelo **ESO 5** (\`oidcSecretName\`) **já existente** — sem novos ExternalSecret.

### Reuso do ESO 5

O \`ExternalSecret\` do OIDC client_secret já estava plumbed nos charts desde antes deste PR, com comentário inline: \"Resource server bearer-only NÃO consome este Secret em runtime — ESO antecipa cenário m2m FUTURO\". **O cenário futuro chegou**: cliente Schema Registry usa client_credentials grant. Reutilização total, sem novo path no Vault.

### Override `environments/standalone/values.yaml`

\`\`\`yaml
schemaRegistry:
  url: https://schema-registry.standalone.portaluni.com.br/apis/ccompat/v7
  authType: OAuthBearer
  oauth:
    tokenEndpoint: https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/token
    clientId: uniplus-api-{portal,selecao,ingresso}     # client por app
\`\`\`

Sufixo `/apis/ccompat/v7` obrigatório para Apicurio em modo Confluent-compat.

### NetworkPolicy

Apicurio externo resolve para `164.152.53.29:443` (Traefik no mesmo k8s-host). Já permitido pela regra `oidcIssuerCIDR` existente — sem nova regra necessária.

## Pré-requisitos já satisfeitos

- OIDC clients M2M `uniplus-api-{portal,selecao,ingresso}` no realm `uniplus` (uniplus-infra#163).
- Secrets custodiados em \`secret/standalone/keycloak/clients/uniplus-api-{portal,selecao,ingresso}\` (validado via \`vault kv list\`).
- Apicurio Registry rodando + ingress \`https://schema-registry.standalone.portaluni.com.br\` com cert LE prod (audit do cluster confirma).

## Validação local

- \`helm lint\` nos 3 charts: **0 chart(s) failed**.
- \`helm template selecao -f overrides.yaml\`: renderiza 5 env vars \`SchemaRegistry__*\` + \`secretKeyRef\` apontando para o Secret OIDC.

## Rollback

Reverter este commit volta os 3 charts a v0.2.0-compatíveis. Selecao pod novo volta a CrashLoopBackOff, pod antigo de v0.2.0 segue servindo via RollingUpdate (sem downtime).

## Test plan

- [x] \`helm lint\` 3/3 charts
- [x] \`helm template\` confirma env vars + secretKeyRef
- [x] OIDC client secrets já no Vault (validado via \`vault kv list secret/standalone/keycloak/clients\`)
- [ ] CI 7/7 verde
- [ ] Codex AI sem findings
- [ ] Review humano
- [ ] ArgoCD sync — pod uniplus-api-selecao novo (v0.3.0) sai de CrashLoopBackOff e fica Ready