### PR TITLE
feat(observability): wire OTEL_EXPORTER_OTLP_ENDPOINT nas APIs Uni+ standalone (#226)

### DIFF
--- a/apps/uniplus-api-ingresso/templates/deployment.yaml
+++ b/apps/uniplus-api-ingresso/templates/deployment.yaml
@@ -22,6 +22,9 @@
   {{- fail "uniplusApiIngresso.encryption.kubernetesRole é obrigatório quando encryption.provider=vault. A role precisa existir no Vault (uniplus-infra#219) com bound_service_account_names incluindo a SA deste chart." -}}
   {{- end -}}
 {{- end -}}
+{{- if and .Values.uniplusApiIngresso.otel.enabled (not .Values.uniplusApiIngresso.otel.exporter.endpoint) -}}
+{{- fail "uniplusApiIngresso.otel.exporter.endpoint é obrigatório quando otel.enabled=true. Configurar em environments/<env>/values.yaml apontando para o Service do OTel Collector do cluster (ex.: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317). Sem isto, o SDK .NET cai no default localhost:4317 — drops silenciosos." -}}
+{{- end -}}
 {{- if and .Values.uniplusApiIngresso.schemaRegistry.url (eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer") -}}
   {{- if not .Values.uniplusApiIngresso.schemaRegistry.oauth.tokenEndpoint -}}
   {{- fail "uniplusApiIngresso.schemaRegistry.oauth.tokenEndpoint é obrigatório quando schemaRegistry.url está populado e authType=OAuthBearer. ADR-0051 exige endpoint /protocol/openid-connect/token do realm Keycloak para emissão do bearer token." -}}
@@ -191,6 +194,23 @@ spec:
             {{- end }}
             {{- end }}
 
+            {{- if .Values.uniplusApiIngresso.otel.enabled }}
+            # === OpenTelemetry (ADR-0018) ===
+            # SDK .NET lê estas envs no boot — `AddOtlpExporter()` em
+            # AdicionarObservabilidade (uniplus-api Infrastructure.Core/Observability)
+            # respeita OTEL_EXPORTER_OTLP_ENDPOINT/PROTOCOL. service.name canônico
+            # é setado por Program.cs via UniPlusServiceNames (ADR-0052); o
+            # OTEL_SERVICE_NAME aqui só é renderizado quando o environment
+            # sobrescrever explicitamente (raro — útil em integrações externas).
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.uniplusApiIngresso.otel.exporter.endpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.uniplusApiIngresso.otel.exporter.protocol | quote }}
+            {{- if .Values.uniplusApiIngresso.otel.resource.serviceName }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.uniplusApiIngresso.otel.resource.serviceName | quote }}
+            {{- end }}
+            {{- end }}
             {{- range $i, $origin := .Values.uniplusApiIngresso.cors.allowedOrigins }}
             - name: Cors__AllowedOrigins__{{ $i }}
               value: {{ $origin | quote }}

--- a/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
@@ -130,4 +130,19 @@ spec:
         - protocol: TCP
           port: {{ .Values.uniplusApiIngresso.networkPolicy.schemaRegistryPort }}
     {{- end }}
+    {{- if .Values.uniplusApiIngresso.otel.enabled }}
+    # OTel Collector DaemonSet (ADR-013) — egress OTLP gRPC (4317) e HTTP (4318)
+    # cross-namespace. O collector já tem o namespace `uniplus` na whitelist
+    # ingressNamespaces (platform/observability/otelcol/values.yaml), então
+    # esta regra fecha a simetria do lado do consumidor.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiIngresso.networkPolicy.otelCollectorNamespace }}
+      ports:
+        - protocol: TCP
+          port: 4317
+        - protocol: TCP
+          port: 4318
+    {{- end }}
 {{- end }}

--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -153,6 +153,24 @@ uniplusApiIngresso:
         enabled: false
         clusterIssuer: ""       # ex.: letsencrypt-prod
 
+  # === OpenTelemetry (ADR-0018 uniplus-api + ADR-013 uniplus-infra) ===
+  # Exporta traces + metrics + logs via OTLP para o OTel Collector DaemonSet
+  # do cluster (namespace observability-otelcol). Endpoint vazio + enabled=true
+  # é rejeitado pelo guard do template — pod só sobe quando o environment
+  # popular o endpoint real (release name do collector varia entre standalone
+  # e demais ambientes). Sem este wiring, o SDK .NET cai no default
+  # http://localhost:4317 e drops silenciosos para um sink inexistente.
+  otel:
+    enabled: true
+    exporter:
+      endpoint: ""              # ex.: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
+      protocol: grpc            # "grpc" (porta 4317) ou "http/protobuf" (porta 4318)
+    resource:
+      # Vazio por default — Program.cs do uniplus-api passa o nome canônico
+      # de UniPlusServiceNames diretamente para AdicionarObservabilidade (ADR-0052).
+      # Setar aqui só quando integração externa exigir override via env (raro).
+      serviceName: ""
+
   # === NetworkPolicy ===
   networkPolicy:
     enabled: true
@@ -171,6 +189,11 @@ uniplusApiIngresso:
     # distintos, definir aqui para liberar egress HTTPS separado.
     schemaRegistryCIDR: ""
     schemaRegistryPort: 443
+    # OTel Collector DaemonSet (ADR-013) — namespace whitelist no
+    # collector já inclui `uniplus` por default (ver
+    # platform/observability/otelcol/values.yaml ingressNamespaces).
+    # Esta config libera o egress correspondente do lado da API.
+    otelCollectorNamespace: observability-otelcol
 
   metrics:
     enabled: false

--- a/apps/uniplus-api-portal/templates/deployment.yaml
+++ b/apps/uniplus-api-portal/templates/deployment.yaml
@@ -22,6 +22,9 @@
   {{- fail "uniplusApiPortal.encryption.kubernetesRole é obrigatório quando encryption.provider=vault. A role precisa existir no Vault (uniplus-infra#219) com bound_service_account_names incluindo a SA deste chart." -}}
   {{- end -}}
 {{- end -}}
+{{- if and .Values.uniplusApiPortal.otel.enabled (not .Values.uniplusApiPortal.otel.exporter.endpoint) -}}
+{{- fail "uniplusApiPortal.otel.exporter.endpoint é obrigatório quando otel.enabled=true. Configurar em environments/<env>/values.yaml apontando para o Service do OTel Collector do cluster (ex.: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317). Sem isto, o SDK .NET cai no default localhost:4317 — drops silenciosos." -}}
+{{- end -}}
 {{- if and .Values.uniplusApiPortal.schemaRegistry.url (eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer") -}}
   {{- if not .Values.uniplusApiPortal.schemaRegistry.oauth.tokenEndpoint -}}
   {{- fail "uniplusApiPortal.schemaRegistry.oauth.tokenEndpoint é obrigatório quando schemaRegistry.url está populado e authType=OAuthBearer. ADR-0051 exige endpoint /protocol/openid-connect/token do realm Keycloak para emissão do bearer token." -}}
@@ -191,6 +194,23 @@ spec:
             {{- end }}
             {{- end }}
 
+            {{- if .Values.uniplusApiPortal.otel.enabled }}
+            # === OpenTelemetry (ADR-0018) ===
+            # SDK .NET lê estas envs no boot — `AddOtlpExporter()` em
+            # AdicionarObservabilidade (uniplus-api Infrastructure.Core/Observability)
+            # respeita OTEL_EXPORTER_OTLP_ENDPOINT/PROTOCOL. service.name canônico
+            # é setado por Program.cs via UniPlusServiceNames (ADR-0052); o
+            # OTEL_SERVICE_NAME aqui só é renderizado quando o environment
+            # sobrescrever explicitamente (raro — útil em integrações externas).
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.uniplusApiPortal.otel.exporter.endpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.uniplusApiPortal.otel.exporter.protocol | quote }}
+            {{- if .Values.uniplusApiPortal.otel.resource.serviceName }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.uniplusApiPortal.otel.resource.serviceName | quote }}
+            {{- end }}
+            {{- end }}
             {{- range $i, $origin := .Values.uniplusApiPortal.cors.allowedOrigins }}
             - name: Cors__AllowedOrigins__{{ $i }}
               value: {{ $origin | quote }}

--- a/apps/uniplus-api-portal/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-portal/templates/networkpolicy.yaml
@@ -130,4 +130,19 @@ spec:
         - protocol: TCP
           port: {{ .Values.uniplusApiPortal.networkPolicy.schemaRegistryPort }}
     {{- end }}
+    {{- if .Values.uniplusApiPortal.otel.enabled }}
+    # OTel Collector DaemonSet (ADR-013) — egress OTLP gRPC (4317) e HTTP (4318)
+    # cross-namespace. O collector já tem o namespace `uniplus` na whitelist
+    # ingressNamespaces (platform/observability/otelcol/values.yaml), então
+    # esta regra fecha a simetria do lado do consumidor.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiPortal.networkPolicy.otelCollectorNamespace }}
+      ports:
+        - protocol: TCP
+          port: 4317
+        - protocol: TCP
+          port: 4318
+    {{- end }}
 {{- end }}

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -153,6 +153,24 @@ uniplusApiPortal:
         enabled: false
         clusterIssuer: ""       # ex.: letsencrypt-prod
 
+  # === OpenTelemetry (ADR-0018 uniplus-api + ADR-013 uniplus-infra) ===
+  # Exporta traces + metrics + logs via OTLP para o OTel Collector DaemonSet
+  # do cluster (namespace observability-otelcol). Endpoint vazio + enabled=true
+  # é rejeitado pelo guard do template — pod só sobe quando o environment
+  # popular o endpoint real (release name do collector varia entre standalone
+  # e demais ambientes). Sem este wiring, o SDK .NET cai no default
+  # http://localhost:4317 e drops silenciosos para um sink inexistente.
+  otel:
+    enabled: true
+    exporter:
+      endpoint: ""              # ex.: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
+      protocol: grpc            # "grpc" (porta 4317) ou "http/protobuf" (porta 4318)
+    resource:
+      # Vazio por default — Program.cs do uniplus-api passa o nome canônico
+      # de UniPlusServiceNames diretamente para AdicionarObservabilidade (ADR-0052).
+      # Setar aqui só quando integração externa exigir override via env (raro).
+      serviceName: ""
+
   # === NetworkPolicy ===
   networkPolicy:
     enabled: true
@@ -171,6 +189,11 @@ uniplusApiPortal:
     # distintos, definir aqui para liberar egress HTTPS separado.
     schemaRegistryCIDR: ""
     schemaRegistryPort: 443
+    # OTel Collector DaemonSet (ADR-013) — namespace whitelist no
+    # collector já inclui `uniplus` por default (ver
+    # platform/observability/otelcol/values.yaml ingressNamespaces).
+    # Esta config libera o egress correspondente do lado da API.
+    otelCollectorNamespace: observability-otelcol
 
   metrics:
     enabled: false

--- a/apps/uniplus-api-selecao/templates/deployment.yaml
+++ b/apps/uniplus-api-selecao/templates/deployment.yaml
@@ -22,6 +22,9 @@
   {{- fail "uniplusApiSelecao.encryption.kubernetesRole é obrigatório quando encryption.provider=vault. A role precisa existir no Vault (uniplus-infra#219) com bound_service_account_names incluindo a SA deste chart." -}}
   {{- end -}}
 {{- end -}}
+{{- if and .Values.uniplusApiSelecao.otel.enabled (not .Values.uniplusApiSelecao.otel.exporter.endpoint) -}}
+{{- fail "uniplusApiSelecao.otel.exporter.endpoint é obrigatório quando otel.enabled=true. Configurar em environments/<env>/values.yaml apontando para o Service do OTel Collector do cluster (ex.: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317). Sem isto, o SDK .NET cai no default localhost:4317 — drops silenciosos." -}}
+{{- end -}}
 {{- if and .Values.uniplusApiSelecao.schemaRegistry.url (eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer") -}}
   {{- if not .Values.uniplusApiSelecao.schemaRegistry.oauth.tokenEndpoint -}}
   {{- fail "uniplusApiSelecao.schemaRegistry.oauth.tokenEndpoint é obrigatório quando schemaRegistry.url está populado e authType=OAuthBearer. ADR-0051 exige endpoint /protocol/openid-connect/token do realm Keycloak para emissão do bearer token." -}}
@@ -191,6 +194,23 @@ spec:
             {{- end }}
             {{- end }}
 
+            {{- if .Values.uniplusApiSelecao.otel.enabled }}
+            # === OpenTelemetry (ADR-0018) ===
+            # SDK .NET lê estas envs no boot — `AddOtlpExporter()` em
+            # AdicionarObservabilidade (uniplus-api Infrastructure.Core/Observability)
+            # respeita OTEL_EXPORTER_OTLP_ENDPOINT/PROTOCOL. service.name canônico
+            # é setado por Program.cs via UniPlusServiceNames (ADR-0052); o
+            # OTEL_SERVICE_NAME aqui só é renderizado quando o environment
+            # sobrescrever explicitamente (raro — útil em integrações externas).
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.uniplusApiSelecao.otel.exporter.endpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.uniplusApiSelecao.otel.exporter.protocol | quote }}
+            {{- if .Values.uniplusApiSelecao.otel.resource.serviceName }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.uniplusApiSelecao.otel.resource.serviceName | quote }}
+            {{- end }}
+            {{- end }}
             {{- range $i, $origin := .Values.uniplusApiSelecao.cors.allowedOrigins }}
             - name: Cors__AllowedOrigins__{{ $i }}
               value: {{ $origin | quote }}

--- a/apps/uniplus-api-selecao/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-selecao/templates/networkpolicy.yaml
@@ -130,4 +130,19 @@ spec:
         - protocol: TCP
           port: {{ .Values.uniplusApiSelecao.networkPolicy.schemaRegistryPort }}
     {{- end }}
+    {{- if .Values.uniplusApiSelecao.otel.enabled }}
+    # OTel Collector DaemonSet (ADR-013) — egress OTLP gRPC (4317) e HTTP (4318)
+    # cross-namespace. O collector já tem o namespace `uniplus` na whitelist
+    # ingressNamespaces (platform/observability/otelcol/values.yaml), então
+    # esta regra fecha a simetria do lado do consumidor.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiSelecao.networkPolicy.otelCollectorNamespace }}
+      ports:
+        - protocol: TCP
+          port: 4317
+        - protocol: TCP
+          port: 4318
+    {{- end }}
 {{- end }}

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -153,6 +153,24 @@ uniplusApiSelecao:
         enabled: false
         clusterIssuer: ""       # ex.: letsencrypt-prod
 
+  # === OpenTelemetry (ADR-0018 uniplus-api + ADR-013 uniplus-infra) ===
+  # Exporta traces + metrics + logs via OTLP para o OTel Collector DaemonSet
+  # do cluster (namespace observability-otelcol). Endpoint vazio + enabled=true
+  # é rejeitado pelo guard do template — pod só sobe quando o environment
+  # popular o endpoint real (release name do collector varia entre standalone
+  # e demais ambientes). Sem este wiring, o SDK .NET cai no default
+  # http://localhost:4317 e drops silenciosos para um sink inexistente.
+  otel:
+    enabled: true
+    exporter:
+      endpoint: ""              # ex.: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
+      protocol: grpc            # "grpc" (porta 4317) ou "http/protobuf" (porta 4318)
+    resource:
+      # Vazio por default — Program.cs do uniplus-api passa o nome canônico
+      # de UniPlusServiceNames diretamente para AdicionarObservabilidade (ADR-0052).
+      # Setar aqui só quando integração externa exigir override via env (raro).
+      serviceName: ""
+
   # === NetworkPolicy ===
   networkPolicy:
     enabled: true
@@ -171,6 +189,11 @@ uniplusApiSelecao:
     # distintos, definir aqui para liberar egress HTTPS separado.
     schemaRegistryCIDR: ""
     schemaRegistryPort: 443
+    # OTel Collector DaemonSet (ADR-013) — namespace whitelist no
+    # collector já inclui `uniplus` por default (ver
+    # platform/observability/otelcol/values.yaml ingressNamespaces).
+    # Esta config libera o egress correspondente do lado da API.
+    otelCollectorNamespace: observability-otelcol
 
   metrics:
     enabled: false

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -965,6 +965,15 @@ uniplusApiPortal:
     oauth:
       tokenEndpoint: https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/token
       clientId: uniplus-api-portal
+  # OpenTelemetry — destino OTLP gRPC do collector DaemonSet do cluster.
+  # Service ClusterIP `<release>.<ns>.svc.cluster.local:4317`; o release name
+  # `platform-observability-otelcol-uniplus-standalone` é gerado pelo
+  # ApplicationSet (platform/observability/otelcol). Endpoint vivo desde
+  # PR uniplus-infra#224 — esta entrada destrava a issue #226.
+  otel:
+    exporter:
+      endpoint: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
+      protocol: grpc
 
 uniplusApiSelecao:
   enabled: true
@@ -1009,6 +1018,11 @@ uniplusApiSelecao:
     oauth:
       tokenEndpoint: https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/token
       clientId: uniplus-api-selecao
+  # Ver comentário em uniplusApiPortal.otel.
+  otel:
+    exporter:
+      endpoint: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
+      protocol: grpc
 
 uniplusApiIngresso:
   enabled: true
@@ -1053,6 +1067,11 @@ uniplusApiIngresso:
     oauth:
       tokenEndpoint: https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/token
       clientId: uniplus-api-ingresso
+  # Ver comentário em uniplusApiPortal.otel.
+  otel:
+    exporter:
+      endpoint: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
+      protocol: grpc
 
 # ----------------------------------------------------------------------------
 # Frontends Uni+ (Angular SPAs servidas por nginx-unprivileged). 1 chart,


### PR DESCRIPTION
## Resumo

Wire `OTEL_EXPORTER_OTLP_ENDPOINT` (e correlatas) nas 3 APIs Uni+ via chart wrappers — destrava a "última milha" do pipeline observability já implantado pelos PRs #221/#222/#224/#225. Sem isto, o SDK .NET cai no default `http://localhost:4317` em todo pod e traces/métricas/logs OTLP são silenciosamente dropados; logs ainda chegam ao Loki via filelog do collector mas sem correlação `traceId`. Smoke direto no standalone (2026-05-11) confirmou Tempo vazio apesar de Loki recebendo logs do namespace `uniplus`.

## Estrutura

| Arquivo | Função |
|---|---|
| `apps/uniplus-api-{portal,selecao,ingresso}/values.yaml` | Adiciona bloco `otel:` (enabled/exporter.endpoint/protocol/resource.serviceName) + `networkPolicy.otelCollectorNamespace`. |
| `apps/uniplus-api-*/templates/deployment.yaml` | Guard `fail` quando `otel.enabled=true && endpoint=""` + render dos envs `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL` e (opcional) `OTEL_SERVICE_NAME`. |
| `apps/uniplus-api-*/templates/networkpolicy.yaml` | Regra `egress` por `namespaceSelector` para `observability-otelcol` (gRPC 4317 + HTTP 4318). |
| `environments/standalone/values.yaml` | Override `otel.exporter.endpoint` apontando para o Service do collector standalone. |

## Decisões binding

1. **`enabled: true` no default + endpoint vazio + guard fail** — pod só sobe quando o environment popula. Release name do collector varia entre standalone/lab/prod, então hardcoded no chart seria errado. Mesma postura de `oidc.issuerUri`, `kafka.bootstrapServers`.
2. **`OTEL_SERVICE_NAME` opcional** — Program.cs do uniplus-api já passa `UniPlusServiceNames.*` direto via `AdicionarObservabilidade` (ADR-0052). Env var seria redundante; mantemos override por env para integrações externas raras.
3. **NetworkPolicy egress via `namespaceSelector`** (não `ipBlock`) — robusto a re-IP do Service. Collector já tem `uniplus` na whitelist `ingressNamespaces` (platform/observability/otelcol/values.yaml ingressNamespaces).

## Critérios de aceite

- [x] Chart wrapper de cada uma das 3 APIs com bloco `otel:` e env vars renderizadas no Deployment.
- [x] `environments/standalone/values.yaml` popula override.
- [x] NetworkPolicy permite egress para `observability-otelcol:4317/4318`.
- [x] `helm lint` passa nos 3 charts; `helm template` emite Deployment + NetworkPolicy com env e regra esperadas.
- [ ] kubeconform (CI) — pendente
- [ ] Pós-deploy: Tempo recebe traces, Loki contém `TraceId` populado, drill-down clicável — pendente Argo sync + uniplus-api#417 mergeada + restart pods.

## Dependência consumidora

`uniplus-api#417` (`TraceContextEnricher` + `outputTemplate` Console com `TraceId={TraceId}`) ✅ **MERGED** em 2026-05-12. Esta PR sozinha exporta traces para o Tempo, mas sem `TraceId` no body do log o `derivedFields` do Loki não casa. Ambas mergeadas + Argo sync no standalone fecham o pré-requisito do smoke E2E visual (uniplus-infra#227).

## Validação local

```
helm lint apps/uniplus-api-portal -f environments/standalone/values.yaml    → 1 chart(s) linted, 0 failed
helm lint apps/uniplus-api-selecao -f environments/standalone/values.yaml   → 1 chart(s) linted, 0 failed
helm lint apps/uniplus-api-ingresso -f environments/standalone/values.yaml  → 1 chart(s) linted, 0 failed

helm template apps/uniplus-api-{portal,selecao,ingresso} -f environments/standalone/values.yaml
→ Deployment env contém OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_PROTOCOL
→ NetworkPolicy egress regra para observability-otelcol porta 4317 + 4318

Teste de guard (endpoint vazio + enabled=true) → fail com mensagem orientativa  ✓
```

## Test plan

- [ ] `helm lint` verde no CI
- [ ] `helm template` + kubeconform verde no CI
- [ ] PR author org member check verde
- [ ] Codex AI review sem findings P1
- [ ] Argo sync no standalone (post-merge): pods das 3 APIs restart + collector recebe spans
- [ ] Smoke manual: forçar request rastreável, validar trace aparece em `https://standalone.portaluni.com.br/grafana/explore` (datasource Tempo) com `service.name=uniplus-api-{portal,selecao,ingresso}`

## Referências

- ADR-0018 (`uniplus-api`) — OpenTelemetry para instrumentação do backend
- ADR-013 (este repo) — OTel Collector DaemonSet standalone
- ADR-0052 (`uniplus-api`) — rastreabilidade cross-service via `traceparent` + `ServiceNameEnricher`
- PR `uniplus-api#411` (MERGED) — ServiceNameEnricher + CorrelationId via Wolverine envelope
- PR `uniplus-api#418` (MERGED) — `TraceId`/`SpanId` no outputTemplate do Console
- PR #221 (Loki), #222 (Tempo), #224 (Collector), #225 (Datasources) — pipeline observability deste repo
- Runbook: `/home/jeferson/configs/uniplus-standalone/13-observability.md`
