### PR TITLE
chore(images): bump uniplus-api v0.3.0 -> v0.3.1 (hotfix idempotency_cache)

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.0"
+    tag: "v0.3.1"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.0"
+    tag: "v0.3.1"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.0"
+    tag: "v0.3.1"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
## Resumo

Promove os 3 charts `uniplus-api-{selecao,ingresso,portal}` para a tag **v0.3.1** publicada hoje em GHCR. Hotfix crítico que destrava o runtime do standalone.

## Contexto

A v0.3.0 introduzia cifragem at-rest via Vault Transit no path Idempotency-Key (ADR-0027), mas a tabela `idempotency_cache` não existia no Postgres do standalone — não havia migration EF Core registrada para criá-la. Resultado: todo `POST` com header `Idempotency-Key` retornava 500 (Postgres 42P01: `relation "idempotency_cache" does not exist`), bloqueando smoke E2E pós-v0.3.0.

A v0.3.1 entrega a migration `InitialCreate` com `Up()` idempotente (`CREATE TABLE IF NOT EXISTS`) e `Down()` proibido (LGPD), aplicada pelo `MigrationHostedService` no startup do pod.

## Rollback

Reverter a tag para `v0.3.0`:

```bash
sed -i 's/tag: "v0.3.1"/tag: "v0.3.0"/' apps/uniplus-api-{selecao,ingresso,portal}/values.yaml
git commit -am "revert: rollback uniplus-api para v0.3.0"
```

ArgoCD reconcilia a versão anterior — pod volta a 1/1 ready, mas POST com Idempotency-Key volta a 500 (estado pré-correção).

## Validação pós-merge

1. ArgoCD `Application` `uniplus-api-selecao` (standalone) deve passar a `Synced`/`Healthy` automaticamente após merge.
2. `kubectl logs -n uniplus deployment/uniplus-api-selecao | grep -E "Aplicando|migrations"` — deve mostrar `Aplicando 1 migration(s) EF Core para SelecaoDbContext: 20260512010258_InitialCreate`.
3. `kubectl exec -n uniplus-data <pg-pod> -- psql -U ... -d selecao -c "\dt idempotency_cache"` — tabela presente.
4. Smoke E2E:
   ```bash
   curl -X POST .../api/v1/selecao/editais \
     -H "Idempotency-Key: $(uuidgen)" \
     -H "Authorization: Bearer ..." \
     -d '...'
   # Esperado: 201, log da API mostra Provider=vault, audit log Vault registra transit/encrypt/uniplus-idempotency-aesgcm
   ```

## Referências

- uniplus-api#416 — issue raiz
- uniplus-api#421 — PR da migration
- uniplus-api release v0.3.1: https://github.com/unifesspa-edu-br/uniplus-api/releases/tag/v0.3.1
- uniplus-infra#40 — Epic standalone

Refs unifesspa-edu-br/uniplus-api#416, unifesspa-edu-br/uniplus-api#421, #40