### PR TITLE
fix(networkpolicy): adicionar egress 8200 para Vault Transit quando provider=vault

### DIFF
--- a/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-ingresso/templates/networkpolicy.yaml
@@ -145,4 +145,21 @@ spec:
         - protocol: TCP
           port: 4318
     {{- end }}
+    {{- if eq .Values.uniplusApiIngresso.encryption.provider "vault" }}
+    # Vault Transit (ADR-0027) — egress TCP 8200 para o pod do Vault quando
+    # encryption.provider=vault. Sem esta regra todo path que toca cifragem
+    # at-rest (idempotency_cache + chaves materializadas) falha com Connection
+    # refused. Padrão NamespaceSelector + PodSelector (mesmo do Keycloak)
+    # restringe ao Vault server e ignora pods auxiliares (agent-injector etc.).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiIngresso.networkPolicy.vaultNamespace }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vault
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uniplusApiIngresso.networkPolicy.vaultPort }}
+    {{- end }}
 {{- end }}

--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -194,6 +194,12 @@ uniplusApiIngresso:
     # platform/observability/otelcol/values.yaml ingressNamespaces).
     # Esta config libera o egress correspondente do lado da API.
     otelCollectorNamespace: observability-otelcol
+    # Vault Transit (ADR-0027) — namespace + port do servidor Vault.
+    # Regra de egress é renderizada apenas quando encryption.provider=vault.
+    # Em environments com Vault em outro cluster, manter encryption.provider=local
+    # ou expor o Vault via Service/Ingress in-cluster proxy.
+    vaultNamespace: vault
+    vaultPort: 8200
 
   metrics:
     enabled: false

--- a/apps/uniplus-api-portal/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-portal/templates/networkpolicy.yaml
@@ -145,4 +145,21 @@ spec:
         - protocol: TCP
           port: 4318
     {{- end }}
+    {{- if eq .Values.uniplusApiPortal.encryption.provider "vault" }}
+    # Vault Transit (ADR-0027) — egress TCP 8200 para o pod do Vault quando
+    # encryption.provider=vault. Sem esta regra todo path que toca cifragem
+    # at-rest (idempotency_cache + chaves materializadas) falha com Connection
+    # refused. Padrão NamespaceSelector + PodSelector (mesmo do Keycloak)
+    # restringe ao Vault server e ignora pods auxiliares (agent-injector etc.).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiPortal.networkPolicy.vaultNamespace }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vault
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uniplusApiPortal.networkPolicy.vaultPort }}
+    {{- end }}
 {{- end }}

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -194,6 +194,12 @@ uniplusApiPortal:
     # platform/observability/otelcol/values.yaml ingressNamespaces).
     # Esta config libera o egress correspondente do lado da API.
     otelCollectorNamespace: observability-otelcol
+    # Vault Transit (ADR-0027) — namespace + port do servidor Vault.
+    # Regra de egress é renderizada apenas quando encryption.provider=vault.
+    # Em environments com Vault em outro cluster, manter encryption.provider=local
+    # ou expor o Vault via Service/Ingress in-cluster proxy.
+    vaultNamespace: vault
+    vaultPort: 8200
 
   metrics:
     enabled: false

--- a/apps/uniplus-api-selecao/templates/networkpolicy.yaml
+++ b/apps/uniplus-api-selecao/templates/networkpolicy.yaml
@@ -145,4 +145,21 @@ spec:
         - protocol: TCP
           port: 4318
     {{- end }}
+    {{- if eq .Values.uniplusApiSelecao.encryption.provider "vault" }}
+    # Vault Transit (ADR-0027) — egress TCP 8200 para o pod do Vault quando
+    # encryption.provider=vault. Sem esta regra todo path que toca cifragem
+    # at-rest (idempotency_cache + chaves materializadas) falha com Connection
+    # refused. Padrão NamespaceSelector + PodSelector (mesmo do Keycloak)
+    # restringe ao Vault server e ignora pods auxiliares (agent-injector etc.).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.uniplusApiSelecao.networkPolicy.vaultNamespace }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vault
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uniplusApiSelecao.networkPolicy.vaultPort }}
+    {{- end }}
 {{- end }}

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -194,6 +194,12 @@ uniplusApiSelecao:
     # platform/observability/otelcol/values.yaml ingressNamespaces).
     # Esta config libera o egress correspondente do lado da API.
     otelCollectorNamespace: observability-otelcol
+    # Vault Transit (ADR-0027) — namespace + port do servidor Vault.
+    # Regra de egress é renderizada apenas quando encryption.provider=vault.
+    # Em environments com Vault em outro cluster, manter encryption.provider=local
+    # ou expor o Vault via Service/Ingress in-cluster proxy.
+    vaultNamespace: vault
+    vaultPort: 8200
 
   metrics:
     enabled: false


### PR DESCRIPTION
## Contexto

Pós-merge do uniplus-api v0.3.1 (uniplus-infra#232 + uniplus-api#421), o smoke E2E `POST /api/editais` com header `Idempotency-Key` no standalone avançou da camada de banco (uniplus-api#416 resolvida) para a camada de cifragem at-rest, e parou em **500** com a mensagem:

```
Unifesspa.UniPlus.Infrastructure.Core.Cryptography.EncryptionFailureException:
  Falha na operação de criptografia para a chave 'idempotency'.
 ---> HttpRequestException: Connection refused
       (platform-vault-uniplus-standalone.vault.svc.cluster.local:8200)
```

## Causa raiz

A NetworkPolicy de egress dos 3 charts `uniplus-api-{selecao,portal,ingresso}` não tinha regra para o port 8200 do namespace `vault`. Verificado com `kubectl exec` no pod selecao:

- `getent hosts platform-vault-uniplus-standalone.vault.svc.cluster.local` → `10.43.53.18` (DNS OK)
- `curl http://...:8200/v1/sys/health` → exit code 7 (Connection refused)

Vault está `Running 1/1` em `vault` namespace, service `platform-vault-uniplus-standalone` com endpoints saudáveis (`10.42.0.96:8200`). NetworkPolicy bloqueia o egress no nível do pod uniplus.

Este gap existia desde antes do uniplus-api v0.3.1, mas estava mascarado pelo uniplus-api#416 (idempotency_cache ausente em runtime → 42P01 antes da camada de cifragem ser exercitada).

## Mudanças

Adiciona bloco condicional no template `networkpolicy.yaml` dos 3 charts:

```yaml
{{- if eq .Values.uniplusApiXxx.encryption.provider "vault" }}
- to:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: {{ .Values.uniplusApiXxx.networkPolicy.vaultNamespace }}
      podSelector:
        matchLabels:
          app.kubernetes.io/name: vault
  ports:
    - protocol: TCP
      port: {{ .Values.uniplusApiXxx.networkPolicy.vaultPort }}
{{- end }}
```

Novos campos em `values.yaml`:

- `networkPolicy.vaultNamespace` (default `vault`)
- `networkPolicy.vaultPort` (default `8200`)

Padrão idêntico ao da regra Keycloak: `namespaceSelector + podSelector` restringe ao Vault server e ignora pods auxiliares (`agent-injector` etc.). Condicional `encryption.provider=vault` garante zero impacto em environments com `provider=local` (dev/CI).

## Validação local

- `helm lint -f environments/standalone/values.yaml` limpo nos 3 charts.
- `yamllint` limpo.
- `helm template` renderiza a regra esperada com `vaultNamespace=vault`, `vaultPort=8200`.

## Validação pós-merge (esperada)

1. ArgoCD reconcilia 3 Applications `uniplus-api-*-uniplus-standalone`.
2. NetworkPolicy ganha a regra de egress 8200.
3. `kubectl exec` no pod selecao: `curl ...:8200/v1/sys/health` retorna 200.
4. Smoke E2E: `POST /api/editais` com `Idempotency-Key` retorna 201; audit log do Vault registra `transit/encrypt/uniplus-idempotency-aesgcm`.

## Rollback

Reverter o commit; ArgoCD remove a regra; standalone volta ao estado pré-PR (POST com Idempotency-Key retorna 500).

Closes #233
Refs unifesspa-edu-br/uniplus-api#416, unifesspa-edu-br/uniplus-api#421, #40