### PR TITLE
fix(vault): permitir ingress 8200 de aplicacoes consumidoras (uniplus em standalone)

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -526,6 +526,10 @@ networkPolicy:
   enabled: true
   externalSecretsNamespace: external-secrets
   traefikNamespace: traefik
+  # Aplicações que consomem Vault via Transit/auth-kubernetes em standalone:
+  # uniplus-api-{selecao,portal,ingresso} no namespace `uniplus` (encryption.provider=vault).
+  appConsumerNamespaces:
+    - uniplus
   kubeApiCidrs:
     - 10.43.0.0/16
     - 10.0.1.0/24  # ajustar por cluster — ver bloco acima

--- a/platform/vault/templates/networkpolicy.yaml
+++ b/platform/vault/templates/networkpolicy.yaml
@@ -52,6 +52,20 @@ spec:
       ports:
         - protocol: TCP
           port: 8200
+    {{- range $ns := .Values.networkPolicy.appConsumerNamespaces }}
+    # Aplicações consumidoras (ex.: uniplus-api-* fazendo Transit
+    # encrypt/decrypt via auth/kubernetes/login + transit/{encrypt,decrypt}).
+    # Cada namespace listado em values.networkPolicy.appConsumerNamespaces
+    # ganha uma regra de ingress 8200. Restringe-se ao listener API (sem
+    # acesso ao listener interno 8201 reservado a Raft).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $ns | quote }}
+      ports:
+        - protocol: TCP
+          port: 8200
+    {{- end }}
   egress:
     # Auto-unseal cross-cluster: Vault chama o Transit em PA1.
     # IP e porta derivados de topology.{pa1HostIP,transitNodePort} — definidos

--- a/platform/vault/values.yaml
+++ b/platform/vault/values.yaml
@@ -123,6 +123,13 @@ networkPolicy:
   externalSecretsNamespace: external-secrets
   # Namespace do Traefik no mesmo cluster (acesso UI/API).
   traefikNamespace: traefik
+  # Namespaces de aplicações consumidoras do Vault (auth/kubernetes/login +
+  # transit/{encrypt,decrypt}). Cada entrada gera uma regra de ingress 8200.
+  # Vazio = sem regra; aplicações em namespaces fora desta lista não
+  # alcançarão o Vault server (mesmo com NetworkPolicy de egress permissiva
+  # do lado do consumidor). Em standalone, `uniplus` é o namespace dos pods
+  # uniplus-api-{selecao,portal,ingresso} (encryption.provider=vault).
+  appConsumerNamespaces: []
   # CIDRs restritos para egress ao Kubernetes API server (service registration).
   # Padrão: service CIDR do K3s (10.43.0.0/16) — cobre o ClusterIP do
   # serviço `kubernetes` em `default` sem permitir destinos externos em 443/6443.


### PR DESCRIPTION
## Contexto

Complementa PR #234. Pós-merge daquele PR, o pod `uniplus-api-selecao` ganhou a regra de **egress** 8200 → namespace `vault`. Re-rodei o smoke E2E e o erro persistiu:

```
curl http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200/v1/sys/health
→ exit code 7 (Connection refused)
```

DNS OK, regra de egress aplicada — mas o pod do Vault continua rejeitando. **Causa**: a NetworkPolicy do próprio chart `platform/vault` (`platform-vault-uniplus-standalone-vault` na ns `vault`) só aceita ingress 8200 de:

- ns `external-secrets`
- ns `traefik`
- pod `vault-agent-injector` (mesmo cluster)

A ns `uniplus` não está na lista de ingress, então o tráfego é bloqueado independente da regra de egress do lado consumidor.

## Mudanças

**`platform/vault/templates/networkpolicy.yaml`**: adiciona bloco `range` sobre `.Values.networkPolicy.appConsumerNamespaces`. Cada namespace listado gera uma regra de ingress 8200 (somente listener API; listener interno 8201 do Raft segue restrito).

**`platform/vault/values.yaml`**: novo campo `networkPolicy.appConsumerNamespaces` (default `[]`). Comentário documenta o uso e o impacto.

**`environments/standalone/values.yaml`**: override `networkPolicy.appConsumerNamespaces: [uniplus]` para liberar `uniplus-api-{selecao,portal,ingresso}` no standalone.

## Validação local

- `helm lint platform/vault -f environments/standalone/values.yaml` limpo.
- `helm template ... | grep uniplus` confirma a regra renderizada com `namespaceSelector: kubernetes.io/metadata.name: uniplus` + `port 8200`.

## Validação pós-merge (esperada)

1. ArgoCD reconcilia `platform-vault-uniplus-standalone` na ns `vault`.
2. `kubectl describe networkpolicy -n vault platform-vault-uniplus-standalone-vault` mostra a 4ª regra de ingress (`from ns uniplus, ports 8200/TCP`).
3. `kubectl exec` no pod selecao: `curl http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200/v1/sys/health` retorna 200.
4. Smoke E2E final: `POST /api/editais` com `Idempotency-Key` retorna 201; audit log do Vault registra `transit/encrypt/uniplus-idempotency-aesgcm`.

## Rollback

Reverter o commit; ArgoCD remove a regra; standalone volta ao estado pré-PR (POST com Idempotency-Key retorna 500 via Vault unreachable).

Closes #233
Refs unifesspa-edu-br/uniplus-api#416, unifesspa-edu-br/uniplus-api#421, #40, #234