### PR TITLE
chore(images): promove uniplus-api v0.3.1 -> v0.3.2 (keyName Vault canonica)

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.1"
+    tag: "v0.3.2"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.1"
+    tag: "v0.3.2"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.1"
+    tag: "v0.3.2"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
## Resumo

Promove os 3 charts `uniplus-api-{selecao,ingresso,portal}` para a tag **v0.3.2** publicada hoje em GHCR. Encerra a cascata de bugs de cifragem at-rest no standalone.

## Cascata pós-v0.3.0

1. **v0.3.0** — Cifragem at-rest via Vault Transit ativada (ADR-0027).
2. **v0.3.1 (PR #232)** — Migration EF Core `InitialCreate` em runtime. Fix `42P01 idempotency_cache does not exist`.
3. **PR #234** — NetworkPolicy do uniplus-api: egress 8200 → Vault. Fix `Connection refused (lado consumidor)`.
4. **PR #235** — NetworkPolicy do Vault: ingress 8200 ← ns uniplus. Fix `Connection refused (lado server)`.
5. **v0.3.2 (este PR)** — Alinha `IdempotencyOptions.EncryptionKeyName` e `CursorEncoder.KeyName` com a key canônica `uniplus-idempotency-aesgcm` provisionada por `platform/vault-transit-bootstrap`. Fix `permission denied`.

## Validação pós-merge

1. ArgoCD reconcilia 3 Applications standalone.
2. `kubectl rollout status deploy/uniplus-api-selecao-...` retorna sucesso com imagem `v0.3.2`.
3. Smoke E2E final:
   ```bash
   curl -X POST .../api/editais \
     -H "Idempotency-Key: $(uuidgen)" \
     -H "Authorization: Bearer ..." \
     -d '...'
   # Esperado: 201, audit log Vault registra transit/encrypt/uniplus-idempotency-aesgcm
   ```

## Rollback

```bash
sed -i 's/tag: "v0.3.2"/tag: "v0.3.1"/' apps/uniplus-api-{selecao,ingresso,portal}/values.yaml
```

Volta ao estado v0.3.1: cifragem desalinhada com a key Vault → 403 em todo POST com Idempotency-Key.

## Refs

- uniplus-api v0.3.2 release: https://github.com/unifesspa-edu-br/uniplus-api/releases/tag/v0.3.2
- uniplus-api#422, uniplus-api#423
- uniplus-infra#40, uniplus-infra#234, uniplus-infra#235