### PR TITLE
fix(otel): corrige endpoint OTLP nos 3 charts api para o nome canonico do service

### DIFF
--- a/apps/uniplus-api-ingresso/templates/deployment.yaml
+++ b/apps/uniplus-api-ingresso/templates/deployment.yaml
@@ -23,7 +23,7 @@
   {{- end -}}
 {{- end -}}
 {{- if and .Values.uniplusApiIngresso.otel.enabled (not .Values.uniplusApiIngresso.otel.exporter.endpoint) -}}
-{{- fail "uniplusApiIngresso.otel.exporter.endpoint é obrigatório quando otel.enabled=true. Configurar em environments/<env>/values.yaml apontando para o Service do OTel Collector do cluster (ex.: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317). Sem isto, o SDK .NET cai no default localhost:4317 — drops silenciosos." -}}
+{{- fail "uniplusApiIngresso.otel.exporter.endpoint é obrigatório quando otel.enabled=true. Configurar em environments/<env>/values.yaml apontando para o Service do OTel Collector do cluster (ex.: http://otelcol.observability-otelcol.svc.cluster.local:4317). Sem isto, o SDK .NET cai no default localhost:4317 — drops silenciosos." -}}
 {{- end -}}
 {{- if and .Values.uniplusApiIngresso.schemaRegistry.url (eq .Values.uniplusApiIngresso.schemaRegistry.authType "OAuthBearer") -}}
   {{- if not .Values.uniplusApiIngresso.schemaRegistry.oauth.tokenEndpoint -}}

--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -163,7 +163,7 @@ uniplusApiIngresso:
   otel:
     enabled: true
     exporter:
-      endpoint: ""              # ex.: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
+      endpoint: ""              # ex.: http://otelcol.observability-otelcol.svc.cluster.local:4317
       protocol: grpc            # "grpc" (porta 4317) ou "http/protobuf" (porta 4318)
     resource:
       # Vazio por default — Program.cs do uniplus-api passa o nome canônico

--- a/apps/uniplus-api-portal/templates/deployment.yaml
+++ b/apps/uniplus-api-portal/templates/deployment.yaml
@@ -23,7 +23,7 @@
   {{- end -}}
 {{- end -}}
 {{- if and .Values.uniplusApiPortal.otel.enabled (not .Values.uniplusApiPortal.otel.exporter.endpoint) -}}
-{{- fail "uniplusApiPortal.otel.exporter.endpoint é obrigatório quando otel.enabled=true. Configurar em environments/<env>/values.yaml apontando para o Service do OTel Collector do cluster (ex.: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317). Sem isto, o SDK .NET cai no default localhost:4317 — drops silenciosos." -}}
+{{- fail "uniplusApiPortal.otel.exporter.endpoint é obrigatório quando otel.enabled=true. Configurar em environments/<env>/values.yaml apontando para o Service do OTel Collector do cluster (ex.: http://otelcol.observability-otelcol.svc.cluster.local:4317). Sem isto, o SDK .NET cai no default localhost:4317 — drops silenciosos." -}}
 {{- end -}}
 {{- if and .Values.uniplusApiPortal.schemaRegistry.url (eq .Values.uniplusApiPortal.schemaRegistry.authType "OAuthBearer") -}}
   {{- if not .Values.uniplusApiPortal.schemaRegistry.oauth.tokenEndpoint -}}

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -163,7 +163,7 @@ uniplusApiPortal:
   otel:
     enabled: true
     exporter:
-      endpoint: ""              # ex.: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
+      endpoint: ""              # ex.: http://otelcol.observability-otelcol.svc.cluster.local:4317
       protocol: grpc            # "grpc" (porta 4317) ou "http/protobuf" (porta 4318)
     resource:
       # Vazio por default — Program.cs do uniplus-api passa o nome canônico

--- a/apps/uniplus-api-selecao/templates/deployment.yaml
+++ b/apps/uniplus-api-selecao/templates/deployment.yaml
@@ -23,7 +23,7 @@
   {{- end -}}
 {{- end -}}
 {{- if and .Values.uniplusApiSelecao.otel.enabled (not .Values.uniplusApiSelecao.otel.exporter.endpoint) -}}
-{{- fail "uniplusApiSelecao.otel.exporter.endpoint é obrigatório quando otel.enabled=true. Configurar em environments/<env>/values.yaml apontando para o Service do OTel Collector do cluster (ex.: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317). Sem isto, o SDK .NET cai no default localhost:4317 — drops silenciosos." -}}
+{{- fail "uniplusApiSelecao.otel.exporter.endpoint é obrigatório quando otel.enabled=true. Configurar em environments/<env>/values.yaml apontando para o Service do OTel Collector do cluster (ex.: http://otelcol.observability-otelcol.svc.cluster.local:4317). Sem isto, o SDK .NET cai no default localhost:4317 — drops silenciosos." -}}
 {{- end -}}
 {{- if and .Values.uniplusApiSelecao.schemaRegistry.url (eq .Values.uniplusApiSelecao.schemaRegistry.authType "OAuthBearer") -}}
   {{- if not .Values.uniplusApiSelecao.schemaRegistry.oauth.tokenEndpoint -}}

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -163,7 +163,7 @@ uniplusApiSelecao:
   otel:
     enabled: true
     exporter:
-      endpoint: ""              # ex.: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
+      endpoint: ""              # ex.: http://otelcol.observability-otelcol.svc.cluster.local:4317
       protocol: grpc            # "grpc" (porta 4317) ou "http/protobuf" (porta 4318)
     resource:
       # Vazio por default — Program.cs do uniplus-api passa o nome canônico

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -976,7 +976,7 @@ uniplusApiPortal:
   # PR uniplus-infra#224 — esta entrada destrava a issue #226.
   otel:
     exporter:
-      endpoint: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
+      endpoint: http://otelcol.observability-otelcol.svc.cluster.local:4317
       protocol: grpc
 
 uniplusApiSelecao:
@@ -1025,7 +1025,7 @@ uniplusApiSelecao:
   # Ver comentário em uniplusApiPortal.otel.
   otel:
     exporter:
-      endpoint: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
+      endpoint: http://otelcol.observability-otelcol.svc.cluster.local:4317
       protocol: grpc
 
 uniplusApiIngresso:
@@ -1074,7 +1074,7 @@ uniplusApiIngresso:
   # Ver comentário em uniplusApiPortal.otel.
   otel:
     exporter:
-      endpoint: http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
+      endpoint: http://otelcol.observability-otelcol.svc.cluster.local:4317
       protocol: grpc
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Contexto

Validação E2E pós-v0.3.2 expôs que o Tempo está **vazio** — nenhum trace chega — apesar do Loki receber logs com TraceId correlacionado e do app emitir spans via SDK OTel .NET.

## Diagnóstico

`environments/standalone/values.yaml` apontava nos 3 charts api para:

```
http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317
```

Mas o chart `platform/observability/otelcol` aplica `fullnameOverride: otelcol`, então o service real é apenas `otelcol`. DNS lookup do nome composto falha com exit code 6 (couldn't resolve host), e o SDK OTel sofre silenciosamente — não há erro perceptível no app porque o exporter agrupa retries em background.

Validação manual via `curl` do pod selecao:
- `getent hosts otelcol.observability-otelcol.svc.cluster.local` → resolve ✓
- `getent hosts platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local` → falha ✗
- `kubectl get svc -n observability-otelcol` → única entrada `otelcol`

## Mudanças

Substitui o endpoint nos 6 arquivos onde aparecia:

- `environments/standalone/values.yaml` (3 entradas)
- `apps/uniplus-api-{selecao,portal,ingresso}/values.yaml` (comentário do exemplo)
- `apps/uniplus-api-{selecao,portal,ingresso}/templates/deployment.yaml` (mensagem de fail quando endpoint vazio)

De `http://platform-observability-otelcol-uniplus-standalone.observability-otelcol.svc.cluster.local:4317` para `http://otelcol.observability-otelcol.svc.cluster.local:4317`.

## Validação local

- `helm lint -f environments/standalone/values.yaml` limpo nos 3 charts.
- `helm template` renderiza endpoint canônico.

## Validação pós-merge

1. ArgoCD reconcilia os 3 Applications standalone (`uniplus-api-*-uniplus-standalone`).
2. Pods uniplus-api fazem rollout com nova env `OTEL_EXPORTER_OTLP_ENDPOINT`.
3. Smoke E2E: criar edital, capturar TraceId.
4. Grafana Explore → Tempo → TraceQL `{resource.service.name=\"uniplus-selecao\"}` retorna spans.
5. Correlação log↔trace funciona (clicar "Ver trace no Tempo" a partir de log Loki).

Closes #237
Refs unifesspa-edu-br/uniplus-infra#40