### PR TITLE
chore(images): promove uniplus-api v0.3.2 -> v0.3.3 (CORS Idempotency-Key)

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.2"
+    tag: "v0.3.3"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.2"
+    tag: "v0.3.3"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.2"
+    tag: "v0.3.3"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
Bump v0.3.2 -> v0.3.3 nos 3 charts api. v0.3.3 destrava UI: Idempotency-Key + If-Match/If-None-Match no Access-Control-Allow-Headers. Closes-out a cascata pós-v0.3.0. Validação via Playwright: createEdital POST no SPA estava em 'Não foi possível conectar ao servidor' por preflight CORS. Refs uniplus-api#424, uniplus-api#425.