### PR TITLE
chore(images): promove uniplus-api v0.3.3 -> v0.3.4 (cascade handler logging)

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.3"
+    tag: "v0.3.4"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.3"
+    tag: "v0.3.4"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.3"
+    tag: "v0.3.4"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
Bump v0.3.3 -> v0.3.4 nos 3 charts api standalone. v0.3.4 entrega logging estruturado no EditalPublicadoToKafkaCascadeHandler (uniplus-api#427) — sinal LogProjetandoParaKafkaCascade(EventId, EditalId, NumeroEdital) emitido pelo handler antes do roteamento Wolverine→Kafka, consultável via LogQL no Grafana Loki. Alimenta sinais do Epic uniplus-infra#240 (observability). Refs uniplus-api#427.