### PR TITLE
fix(grafana): corrige URL do datasource Prometheus para o service real (fullnameOverride mismatch)

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -161,7 +161,13 @@ grafana:
           type: prometheus
           uid: prometheus
           access: proxy
-          url: http://platform-observability-prometheus-uniplus-standalone-prometheus.observability-prometheus.svc.cluster.local:9090
+          # Chart kube-prometheus-stack aplica fullnameOverride=platform-observability-pro,
+          # então o service real do Prometheus API (porta 9090) é
+          # platform-observability-pro-prometheus.observability-prometheus.svc.cluster.local:9090,
+          # não o nome composto com -uniplus-standalone-prometheus (esse último service
+          # existe mas expõe porta 9100 + endpoint diferente). Mesma origem da correção
+          # OTel em uniplus-infra#237/#238. Antes deste fix, HTTP 502 via Grafana proxy.
+          url: http://platform-observability-pro-prometheus.observability-prometheus.svc.cluster.local:9090
           isDefault: true
           jsonData:
             timeInterval: 30s


### PR DESCRIPTION
## Contexto

Validação E2E durante reabertura da story uniplus-api#427 revelou que **toda query do datasource Prometheus no Grafana retorna HTTP 502**:

```bash
curl -sk -u admin:uniplus 'https://standalone.portaluni.com.br/grafana/api/datasources/proxy/uid/prometheus/api/v1/query?query=up'
→ HTTP 502 size=0
```

## Diagnóstico

`environments/standalone/values.yaml:164` configurava:

```yaml
url: http://platform-observability-prometheus-uniplus-standalone-prometheus.observability-prometheus.svc.cluster.local:9090
```

Mas no cluster:

```
kubectl get svc -n observability-prometheus
platform-observability-pro-prometheus                             9090/TCP    ← API Prometheus
platform-observability-prometheus-uniplus-standalone-prometheus   9100/TCP    ← service diferente, porta 9100
```

DNS do hostname errado resolve para um service que **existe** mas escuta **na porta errada** — daí HTTP 502 ao tentar 9090.

O service correto (`platform-observability-pro-prometheus`) tem fullnameOverride aplicado pelo chart `kube-prometheus-stack` (`fullnameOverride: "platform-observability-pro"`).

Mesma origem do bug do OTel collector resolvido em uniplus-infra#237/#238.

## Validação local

```bash
kubectl run prom-q -n observability-prometheus --image=curlimages/curl --rm -i --command -- \
  curl -sG http://platform-observability-pro-prometheus.observability-prometheus.svc.cluster.local:9090/api/v1/label/__name__/values
→ HTTP 200, 1616 metric names retornados
```

`helm lint` limpo no chart `platform/observability/grafana`.

## Mudança

Single-line URL fix em `environments/standalone/values.yaml`. Adiciona comentário in-line explicando a origem do mismatch (fullnameOverride) e referenciando os PRs #237/#238 que resolveram o pattern análogo no OTel.

## Validação pós-merge esperada

1. ArgoCD reconcilia o chart Grafana, rolling deployment restart do pod
2. Após pod ready:
   ```bash
   curl -sk -u admin:uniplus 'https://standalone.portaluni.com.br/grafana/api/datasources/proxy/uid/prometheus/api/v1/query?query=up' | jq
   → HTTP 200, dados de targets
   ```
3. UI Grafana Explore → Prometheus → query `up` retorna data

## Não escopo

- **Métricas Wolverine/messaging não aparecem mesmo após este fix** — 0 de 1616 metric names contém `wolverine`/`messaging.*`. Causa: pipeline `otelcol → prometheusremotewrite` ainda não implementado. Endereçado pela Feature #242 (Stories #244/#245/#247) — independente deste PR.

## Achados secundários

Vale fazer varredura geral em todos os values configurando hostnames de charts da observability stack — esse pattern de fullnameOverride mismatch já apareceu 2 vezes (OTel + agora Prometheus); podem existir outros (Tempo? Loki? AlertManager?). Mas é trabalho separado.

Closes #259
Refs unifesspa-edu-br/uniplus-infra#237, unifesspa-edu-br/uniplus-infra#238, unifesspa-edu-br/uniplus-infra#240, unifesspa-edu-br/uniplus-infra#242