### PR TITLE
fix(grafana): remove StripPrefix do IngressRoute (conflito com serve_from_sub_path causa loop redirect)

### DIFF
--- a/platform/observability/grafana/templates/ingressroute.yaml
+++ b/platform/observability/grafana/templates/ingressroute.yaml
@@ -9,33 +9,21 @@
   Grafana IngressRoute Traefik. Suporta dois patterns:
 
   1) Subpath (host raiz com PathPrefix):
-     standalone.portaluni.com.br/grafana/* — exige serve_from_sub_path: true
-     no grafana.ini.server e root_url terminando em /grafana/.
-     Render adiciona Middleware StripPrefix /grafana — Grafana recebe paths
-     sem o prefix, que é a forma esperada quando serve_from_sub_path=true.
+     standalone.portaluni.com.br/grafana/* — exige `serve_from_sub_path: true`
+     no `grafana.ini.server` e `root_url` terminando em `/grafana/`.
+     Traefik NÃO faz StripPrefix — Grafana com `serve_from_sub_path=true`
+     espera receber URLs com o sub-path preservado (caso contrário emite
+     301 redirect para o root_url, gerando loop infinito ERR_TOO_MANY_REDIRECTS).
+     Ver issue uniplus-infra#261 e https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#root_url.
 
   2) Subdomain (host dedicado):
-     grafana.standalone.portaluni.com.br/* — root_url sem subpath,
-     serve_from_sub_path=false. Pattern de outros admin UIs Uni+
+     grafana.standalone.portaluni.com.br/* — `root_url` sem subpath,
+     `serve_from_sub_path: false`. Pattern de outros admin UIs Uni+
      (kafka-ui, schema-registry, redis-ui).
 
   ingressRoute.pathPrefix vazio → caminho 2 (subdomain).
   ingressRoute.pathPrefix preenchido (ex.: "/grafana") → caminho 1.
 */}}
-{{- if $ing.pathPrefix -}}
-apiVersion: traefik.io/v1alpha1
-kind: Middleware
-metadata:
-  name: {{ printf "%s-strip-prefix" (include "grafana.fullname" .) }}
-  labels:
-    app.kubernetes.io/part-of: uniplus
-    app.kubernetes.io/component: grafana
-spec:
-  stripPrefix:
-    prefixes:
-      - {{ $ing.pathPrefix | quote }}
----
-{{- end }}
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
@@ -50,8 +38,6 @@ spec:
     {{- if $ing.pathPrefix }}
     - match: Host(`{{ $ing.host }}`) && PathPrefix(`{{ $ing.pathPrefix }}`)
       kind: Rule
-      middlewares:
-        - name: {{ printf "%s-strip-prefix" (include "grafana.fullname" .) }}
       services:
         - name: {{ $svcName }}
           port: {{ $svcPort }}


### PR DESCRIPTION
## Contexto

UI Grafana retorna `ERR_TOO_MANY_REDIRECTS` no browser. `curl -I https://standalone.portaluni.com.br/grafana/`:

```
HTTP/2 301
location: https://standalone.portaluni.com.br/grafana/   ← redireciona para o mesmo URL
```

## Causa raiz

Template `platform/observability/grafana/templates/ingressroute.yaml` emitia automaticamente um Middleware Traefik `StripPrefix /grafana` antes de enviar para o pod, **mas** `environments/standalone/values.yaml` configura `serve_from_sub_path: true` no Grafana.

Quando `serve_from_sub_path=true`, Grafana **espera receber o path com o sub-path preservado**. O StripPrefix removia, então:

1. Browser → `https://standalone.portaluni.com.br/grafana/`
2. Traefik StripPrefix → pod recebe `/`
3. Grafana espera `/grafana/` → constrói redirect 301 com Location `https://standalone.portaluni.com.br/grafana/` (do `root_url`)
4. Browser segue → volta ao passo 2 → loop

[Documentação oficial Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#root_url):

> "By enabling this setting and using a value for `root_url` containing a sub path, Grafana can be made to **serve Grafana from a sub path**."

Reverse proxy não deve fazer rewrite/strip — Grafana lida nativamente. Pattern idêntico em ArgoCD, Prometheus, AlertManager.

## Mudança

Remove o bloco Middleware StripPrefix do template. Atualiza comentário inline citando a doc oficial e a issue #261 para evitar regressão.

Caminho 2 (subdomain, ex.: `grafana.staging.portaluni.com.br/*`) não é afetado — sempre passou paths direto sem middleware.

## Validação local

- `helm lint` limpo
- `helm template -f environments/standalone/values.yaml`: IngressRoute renderizado **sem** middleware, route correto `Host(...) && PathPrefix(/grafana)`

## Validação pós-merge esperada

```bash
curl -ksI https://standalone.portaluni.com.br/grafana/
→ HTTP/2 200 (HTML do login Grafana, sem 301)

curl -ksL https://standalone.portaluni.com.br/grafana/login | head -3
→ HTML do form de login
```

UI no browser: abre normalmente, sem erro de redirect.

Closes #261
Refs unifesspa-edu-br/uniplus-infra#240, unifesspa-edu-br/uniplus-infra#259, unifesspa-edu-br/uniplus-infra#260