### PR TITLE
feat(grafana): habilita SSO via Keycloak OIDC do realm uniplus

### DIFF
--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -114,6 +114,48 @@
       ]
     },
     {
+      "clientId": "grafana",
+      "name": "Grafana — Observability Dashboards (admin/editor/viewer)",
+      "description": "Cliente OIDC do Grafana (platform/observability/grafana). Confidential — secret substituido via ${GRAFANA_CLIENT_SECRET} (IMPORT_VARSUBSTITUTION) e custodiado em secret/standalone/keycloak/clients/grafana. Roles mapeadas via groupsClaim em role_attribute_path do auth.generic_oauth: /admins/grafana=Admin, /editors/grafana=Editor, default=Viewer. RUNBOOKS §16.1.",
+      "secret": "${GRAFANA_CLIENT_SECRET}",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "frontchannelLogout": true,
+      "redirectUris": ["https://standalone.portaluni.com.br/grafana/login/generic_oauth"],
+      "webOrigins": ["https://standalone.portaluni.com.br"],
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "defaultClientScopes": [
+        "basic",
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "groups"
+          }
+        }
+      ]
+    },
+    {
       "clientId": "apicurio-registry",
       "name": "Apicurio Registry — Schema Registry (Confluent SR API)",
       "description": "Cliente OIDC do Apicurio Registry (apps/apicurio-registry). Confidential — secret em secret/standalone/keycloak/clients/apicurio-registry via kcadm pós-import. directAccessGrantsEnabled=true para smoke (revisar em prod). RUNBOOKS §15.1.",
@@ -335,7 +377,14 @@
     {
       "name": "admins",
       "subGroups": [
-        { "name": "kafka", "path": "/admins/kafka" }
+        { "name": "kafka", "path": "/admins/kafka" },
+        { "name": "grafana", "path": "/admins/grafana" }
+      ]
+    },
+    {
+      "name": "editors",
+      "subGroups": [
+        { "name": "grafana", "path": "/editors/grafana" }
       ]
     },
     {

--- a/apps/keycloak-replica/templates/_helpers.tpl
+++ b/apps/keycloak-replica/templates/_helpers.tpl
@@ -76,3 +76,7 @@ Mesmo nome serve para os outros (admin, client) com sufixo distinto.
 {{- define "keycloak-replica.realmConfigMapName" -}}
 {{- printf "%s-realm-uniplus" (include "keycloak-replica.fullname" .) }}
 {{- end }}
+
+{{- define "keycloak-replica.oidcClientSecretsName" -}}
+{{- printf "%s-oidc-client-secrets" (include "keycloak-replica.fullname" .) }}
+{{- end }}

--- a/apps/keycloak-replica/templates/deployment.yaml
+++ b/apps/keycloak-replica/templates/deployment.yaml
@@ -111,6 +111,13 @@ spec:
             # Bootstrap admin (KC_BOOTSTRAP_ADMIN_USERNAME, _PASSWORD).
             - secretRef:
                 name: {{ include "keycloak-replica.adminSecretName" . }}
+            {{- if .Values.keycloak.oidcClientSecrets.enabled }}
+            # Client secrets de aplicações OIDC do realm (ex.: GRAFANA_CLIENT_SECRET).
+            # Referenciados via ${envName} no realm.json e substituídos no
+            # --import-realm inicial via IMPORT_VARSUBSTITUTION_ENABLED=true.
+            - secretRef:
+                name: {{ include "keycloak-replica.oidcClientSecretsName" . }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ $kc.http.httpPort }}

--- a/apps/keycloak-replica/templates/realm-reconcile-job.yaml
+++ b/apps/keycloak-replica/templates/realm-reconcile-job.yaml
@@ -152,6 +152,15 @@ spec:
               value: "{{ .Values.keycloak.realmReconcile.logLevel | default "INFO" }}"
             - name: LOGGING_LEVEL_DE_ADORSYS_KEYCLOAK_CONFIG
               value: "{{ .Values.keycloak.realmReconcile.logLevel | default "INFO" }}"
+          {{- if .Values.keycloak.oidcClientSecrets.enabled }}
+          envFrom:
+            # Client secrets OIDC consumidos pelas substituições ${envName}
+            # no realm.json (IMPORT_VARSUBSTITUTION_ENABLED=true). Sem isso,
+            # clients confidential ficam com secret literal "${GRAFANA_CLIENT_SECRET}",
+            # quebrando o handshake OIDC do consumidor.
+            - secretRef:
+                name: {{ include "keycloak-replica.oidcClientSecretsName" . }}
+          {{- end }}
           volumeMounts:
             - name: realm-config
               mountPath: /realm

--- a/apps/keycloak-replica/values.yaml
+++ b/apps/keycloak-replica/values.yaml
@@ -240,3 +240,23 @@ keycloak:
 
   # Env vars adicionais (lista de `{name, value}` ou `{name, valueFrom}`).
   extraEnv: []
+
+  # ExternalSecret consolidado de client_secrets de aplicações OIDC do realm.
+  # Cada entrada de `clients` vira uma key remota → key local consumida via
+  # ${ENV_NAME} no realm.json (IMPORT_VARSUBSTITUTION_ENABLED=true). Permite
+  # que o realm-reconcile-job e o pod KC inicial materializem `secret`
+  # automaticamente para clients confidential como `grafana`, sem precisar de
+  # kcadm pós-import. O Secret K8s resultante é montado via envFrom no
+  # deployment do KC e no Job realm-reconcile.
+  oidcClientSecrets:
+    enabled: false
+    refreshInterval: "1h"
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: vault-default
+    # Lista de clientes OIDC a sincronizar do Vault.
+    # Cada item: { envName, vaultPath, vaultKey }
+    #   envName  — variável injetada no Pod (referenciada como ${envName} no realm.json)
+    #   vaultPath — path no Vault (ex.: secret/standalone/keycloak/clients/grafana)
+    #   vaultKey — propriedade dentro do segredo (ex.: client_secret)
+    clients: []

--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -132,11 +132,53 @@ grafana:
 
   persistence:
     storageClassName: standalone-local-nvme
+
+  # === SSO OIDC via Keycloak realm uniplus ===
+  # Habilita o ExternalSecret + envValueFrom + bloco auth.generic_oauth do
+  # subchart Grafana. Client `grafana` no realm provisionado pelo
+  # apps/keycloak-replica via realm-reconcile-job + IMPORT_VARSUBSTITUTION
+  # (uniplus-infra#263).
+  oidc:
+    enabled: true
+    issuerBaseUrl: https://standalone.portaluni.com.br/auth/realms/uniplus
+  externalSecrets:
+    enabled: true
+    oidcClient:
+      vaultPath: secret/standalone/keycloak/clients/grafana
+
   grafana.ini:
     server:
       root_url: https://standalone.portaluni.com.br/grafana/
       # subpath ativo — Grafana reescreve URLs internas com /grafana/.
       serve_from_sub_path: true
+    auth.generic_oauth:
+      enabled: true
+      name: "Uni+ Keycloak"
+      client_id: grafana
+      client_secret: "${OIDC_CLIENT_SECRET}"
+      scopes: "openid profile email groups"
+      auth_url: https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/auth
+      token_url: https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/token
+      api_url: https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/userinfo
+      signout_redirect_url: https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/logout
+      role_attribute_path: contains(groups[*], '/admins/grafana') && 'Admin' || contains(groups[*], '/editors/grafana') && 'Editor' || 'Viewer'
+      role_attribute_strict: false
+      allow_assign_grafana_admin: true
+      use_pkce: true
+    auth:
+      # Mantém form local admin/* visível como fallback de incidente Keycloak.
+      disable_login_form: false
+      oauth_auto_login: false
+
+  # Injeta env OIDC_CLIENT_SECRET no Pod via Secret K8s sintetizado pelo
+  # ExternalSecret. Consumido no template do auth.generic_oauth acima como
+  # ${OIDC_CLIENT_SECRET}. Nome do Secret bate com o materializado por
+  # platform/observability/grafana/templates/externalsecret.yaml.
+  envValueFrom:
+    OIDC_CLIENT_SECRET:
+      secretKeyRef:
+        name: platform-observability-grafana-uniplus-standalone-grafana-oidc-client-secret
+        key: client_secret
   # IngressRoute Traefik via subpath /grafana/* no FQDN raiz (consistente
   # com Keycloak em /auth/*). Middleware StripPrefix /grafana é emitido
   # automaticamente pelo template do wrapper — Grafana recebe paths sem
@@ -747,6 +789,17 @@ keycloak:
   # ServiceMonitor desligado até platform/observability/prometheus/ subir.
   serviceMonitor:
     enabled: false
+
+  # ExternalSecret consolidado de client_secrets OIDC do realm. Cada entrada
+  # vira chave do Secret K8s consumido via envFrom em deployment.yaml e
+  # realm-reconcile-job.yaml — referenciada como ${envName} no realm.json
+  # via IMPORT_VARSUBSTITUTION_ENABLED=true. Pattern uniplus-infra#263.
+  oidcClientSecrets:
+    enabled: true
+    clients:
+      - envName: GRAFANA_CLIENT_SECRET
+        vaultPath: secret/standalone/keycloak/clients/grafana
+        vaultKey: client_secret
 
 # ----------------------------------------------------------------------------
 # kafka-ui (AKHQ) — Web UI de gerenciamento do cluster Kafka SASL_SSL.

--- a/platform/observability/grafana/templates/externalsecret.yaml
+++ b/platform/observability/grafana/templates/externalsecret.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.grafana.enabled .Values.grafana.externalSecrets.enabled -}}
+{{- $es := .Values.grafana.externalSecrets -}}
+{{- if not $es.oidcClient.vaultPath -}}
+{{- fail "grafana.externalSecrets.enabled=true exige grafana.externalSecrets.oidcClient.vaultPath não-vazio (ex.: secret/standalone/keycloak/clients/grafana). Override em environments/<env>/values.yaml." -}}
+{{- end -}}
+# ExternalSecret que sintetiza o Secret K8s contendo client_secret do client
+# OIDC `grafana` do realm Uni+. Vault path custodiado em
+# `secret/standalone/keycloak/clients/grafana` (gerado pelo realm-reconcile-job
+# do apps/keycloak-replica via IMPORT_VARSUBSTITUTION + escrito no Vault pelo
+# operador no setup one-time — ver RUNBOOKS §16.1).
+#
+# Consumido via envValueFrom no subchart Grafana, exposto como env
+# OIDC_CLIENT_SECRET e referenciado no grafana.ini.auth.generic_oauth como
+# ${OIDC_CLIENT_SECRET}.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "grafana.fullname" . }}-oidc-client-secret
+  labels:
+    app.kubernetes.io/part-of: uniplus
+    app.kubernetes.io/component: grafana
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ $es.secretStoreRef.kind }}
+    name: {{ $es.secretStoreRef.name }}
+  target:
+    name: {{ include "grafana.fullname" . }}-oidc-client-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: client_secret
+      remoteRef:
+        key: {{ $es.oidcClient.vaultPath | quote }}
+        property: {{ $es.oidcClient.clientSecretKey | quote }}
+{{- end }}

--- a/platform/observability/grafana/values.yaml
+++ b/platform/observability/grafana/values.yaml
@@ -133,9 +133,44 @@ grafana:
       labelValue: "1"
       searchNamespace: ALL
 
-  # SSO via OIDC (Keycloak — ADR-003) — placeholder. Habilitar em env values
-  # apontando pro realm Uni+ depois que Keycloak (apps/keycloak-replica)
-  # tiver o client `grafana` configurado.
+  # SSO via OIDC (Keycloak — ADR-003). Em environments com Keycloak local
+  # (ex.: standalone) habilitar setando `oidc.enabled: true` + URLs reais
+  # + ExternalSecret materializando client_secret no Secret K8s referenciado.
+  # O bloco grafana.grafana.ini.auth.generic_oauth abaixo só deve ser ativado
+  # quando oidc.enabled=true. Login local admin/* permanece como fallback.
+  oidc:
+    enabled: false
+    # Identificação humana exibida no botão de login (auth.generic_oauth.name).
+    providerName: "Uni+ Keycloak"
+    clientId: grafana
+    # URLs Keycloak realm `uniplus`. Override em environments/<env>/values.yaml.
+    issuerBaseUrl: ""  # ex.: https://standalone.portaluni.com.br/auth/realms/uniplus
+    # JMESPath para mapear claim `groups` → role Grafana. Default canônico
+    # alinhado com pattern AKHQ (grupos /admins/<app> + /editors/<app>).
+    roleAttributePath: |
+      contains(groups[*], '/admins/grafana') && 'Admin' || contains(groups[*], '/editors/grafana') && 'Editor' || 'Viewer'
+    # Permite assignment como Server Admin via grupo (cuidado: ServerAdmin
+    # tem permissão total cross-org). Default true para alinhar com o
+    # mapping de `/admins/grafana` → Admin no role_attribute_path.
+    allowAssignGrafanaAdmin: true
+    # Auto-login redireciona direto para Keycloak sem mostrar o form local.
+    # Default false para preservar fallback admin local em incidente.
+    autoLogin: false
+
+  # ExternalSecret que materializa o client_secret do client OIDC `grafana`
+  # do realm uniplus no namespace observability-grafana. Consumido via env
+  # OIDC_CLIENT_SECRET pelo Pod Grafana e referenciado em
+  # `grafana.ini.auth.generic_oauth.client_secret` como ${OIDC_CLIENT_SECRET}.
+  externalSecrets:
+    enabled: false
+    refreshInterval: "1h"
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: vault-default
+    oidcClient:
+      vaultPath: ""  # ex.: secret/standalone/keycloak/clients/grafana
+      clientSecretKey: client_secret
+
   grafana.ini:
     server:
       root_url: ""  # override por env (ex.: https://standalone.portaluni.com.br/grafana/)


### PR DESCRIPTION
## Contexto

Pedido durante validação UI Grafana (issue #263). Pattern de admin UIs Uni+ já usa OIDC do realm `uniplus` (AKHQ, Schema Registry); aplicar o mesmo a Grafana destrava SSO + auditoria + RBAC granular.

## Mudanças (tudo IaC, zero kubectl além do bootstrap one-time do secret no Vault)

### `apps/keycloak-replica/files/uniplus-realm.json`

- Novo client confidential `grafana`:
  - `secret: ${GRAFANA_CLIENT_SECRET}` (substituído via `IMPORT_VARSUBSTITUTION_ENABLED=true` no startup + reconcile)
  - redirect URI: `https://standalone.portaluni.com.br/grafana/login/generic_oauth`
  - protocolMapper `groups` (`oidc-group-membership-mapper`, `full.path=true`)
  - scopes default + audience implícita
- Novos subgroups: `/admins/grafana` (sob `admins`) e `/editors/grafana` (sob novo `editors`)

### `apps/keycloak-replica` (chart)

- `values.yaml`: novo bloco `keycloak.oidcClientSecrets` (enabled, refreshInterval, secretStoreRef, lista de `clients: [{envName, vaultPath, vaultKey}]`)
- `_helpers.tpl`: helper `oidcClientSecretsName`
- `templates/externalsecret-oidc-client-secrets.yaml` (novo): consolida client secrets do Vault → Secret K8s com keys nomeadas pelo `envName` declarado
- `templates/deployment.yaml`: `envFrom` adicional (condicional) referenciando o Secret consolidado — KC `--import-realm` inicial vê `${GRAFANA_CLIENT_SECRET}` no ambiente
- `templates/realm-reconcile-job.yaml`: idem (mesmo Secret) — keycloak-config-cli reaplicar reconcile com os secrets substituídos

### `platform/observability/grafana` (chart)

- `values.yaml`: novos blocos `grafana.oidc` (enabled, providerName, clientId, issuerBaseUrl, roleAttributePath, allowAssignGrafanaAdmin, autoLogin) e `grafana.externalSecrets` (oidcClient.vaultPath)
- `templates/externalsecret.yaml` (novo): condicional `oidc.enabled` — sintetiza Secret K8s `<release>-grafana-oidc-client-secret` com key `client_secret` puxada do Vault

### `environments/standalone/values.yaml`

- `grafana.oidc.enabled: true` + `issuerBaseUrl` real do realm
- `grafana.externalSecrets.enabled: true` + `oidcClient.vaultPath: secret/standalone/keycloak/clients/grafana`
- `grafana.grafana.ini.auth.generic_oauth`: enabled + URLs do realm + `role_attribute_path` JMESPath canônico (Admin/Editor/Viewer) + `use_pkce: true` + `allow_assign_grafana_admin: true`
- `grafana.grafana.ini.auth.disable_login_form: false` + `oauth_auto_login: false` (fallback admin local preservado para incidente Keycloak)
- `grafana.envValueFrom.OIDC_CLIENT_SECRET`: referencia ao Secret K8s sintetizado pelo ExternalSecret (consumido como `${OIDC_CLIENT_SECRET}` no `client_secret` do bloco generic_oauth)
- `keycloak.oidcClientSecrets.enabled: true` + entrada inicial para `grafana`

## Bootstrap manual já executado

Antes deste PR, escrevi um client_secret aleatório (32 chars) em:

```
vault kv put secret/standalone/keycloak/clients/grafana client_secret=<random 32 chars>
```

Após merge, o ExternalSecret do keycloak-replica materializa o Secret K8s. O realm-reconcile-job lê via `envFrom`, substitui no realm.json e reaplica via keycloak-config-cli. Em paralelo o ExternalSecret do Grafana materializa o Secret no namespace `observability-grafana`. Reconcile ArgoCD orquestra a sequência.

## Validação local

- `helm lint` limpo nos 2 charts modificados
- `helm template -f environments/standalone/values.yaml`:
  - `apps/keycloak-replica`: ExternalSecret `<release>-oidc-client-secrets` renderizado, deployment + reconcile-job com `envFrom` extra
  - `platform/observability/grafana`: ExternalSecret `<release>-oidc-client-secret` renderizado

## Validação pós-merge esperada

1. ArgoCD reconcilia `apps/keycloak-replica`:
   - ExternalSecret sintetiza Secret K8s com `GRAFANA_CLIENT_SECRET`
   - KC pod restarta com env injetada
   - realm-reconcile-job roda e aplica client `grafana` no realm com o secret correto
2. ArgoCD reconcilia `platform/observability/grafana`:
   - ExternalSecret sintetiza Secret K8s no `observability-grafana`
   - Grafana pod restarta com env `OIDC_CLIENT_SECRET` injetada
3. Browser em `https://standalone.portaluni.com.br/grafana/login`:
   - Form local + botão "Sign in with Uni+ Keycloak"
   - Clicar no botão → redirect Keycloak → login → callback → autenticado como Viewer (default)
4. Após adicionar `jeferson.ferreira` ao grupo `/admins/grafana` manualmente via Keycloak UI:
   - Logout + login → role **Admin** (org admin)

## Não escopo

- Auto-provisioning de membros nos grupos `/admins/grafana` — adicionar usuário a grupo continua manual via Keycloak UI/kcadm.
- Rotação automática do client_secret — vira issue separada se necessário.
- Migração de usuários local Grafana (admin/uniplus continua via login form).

## Riscos

- **`disable_login_form: false`** mantém o form local exposto: usuários podem logar sem passar pelo Keycloak. Aceitável em standalone (debug); revisitar em prod.
- Restart do KC durante reconcile pode causar downtime curto da auth (mitigação: rollingUpdate + readinessProbe já configurados).

Closes #263
Refs unifesspa-edu-br/uniplus-infra#240, unifesspa-edu-br/uniplus-infra#262