### PR TITLE
feat(otelcol): ativa pipeline metrics via prometheusremotewrite

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -371,6 +371,10 @@ otelCollector:
       value: http://platform-observability-loki-uniplus-standalone.observability-loki.svc.cluster.local:3100/otlp
     - name: TEMPO_OTLP_ENDPOINT
       value: http://platform-observability-tempo-uniplus-standalone.observability-tempo.svc.cluster.local:4318
+    - name: PROMETHEUS_REMOTE_WRITE_ENDPOINT
+      # Service do Prometheus standalone (fullnameOverride=platform-observability-pro, porta 9090).
+      # Mesmo service usado no datasource do Grafana (environments/standalone/values.yaml §grafana.datasources).
+      value: http://platform-observability-pro-prometheus.observability-prometheus.svc.cluster.local:9090/api/v1/write
 
 otelCollectorWrapper:
   networkPolicy:
@@ -383,6 +387,7 @@ otelCollectorWrapper:
       - keycloak
     egressLokiNamespace: observability-loki
     egressTempoNamespace: observability-tempo
+    egressPrometheusNamespace: observability-prometheus
     kubeApiCidrs:
       - 10.43.0.0/16
       - 10.0.1.0/24

--- a/platform/observability/otelcol/templates/networkpolicy.yaml
+++ b/platform/observability/otelcol/templates/networkpolicy.yaml
@@ -8,6 +8,7 @@
 # - Egress:
 #   - Loki (porta 3100/HTTP no NS observability-loki) — exporter logs
 #   - Tempo (porta 4318/HTTP no NS observability-tempo) — exporter traces
+#   - Prometheus (porta 9090/HTTP no NS observability-prometheus) — remote write metrics
 #   - DNS K8s
 #   - kube-apiserver (k8sattributes processor watcha pods)
 apiVersion: networking.k8s.io/v1
@@ -59,6 +60,14 @@ spec:
         - port: 4318
           protocol: TCP
         - port: 4317
+          protocol: TCP
+    # Prometheus (metrics remote write)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.egressPrometheusNamespace | quote }}
+      ports:
+        - port: 9090
           protocol: TCP
     # DNS K8s
     - to:

--- a/platform/observability/otelcol/values.schema.json
+++ b/platform/observability/otelcol/values.schema.json
@@ -46,6 +46,7 @@
             },
             "egressLokiNamespace": { "type": "string", "minLength": 1 },
             "egressTempoNamespace": { "type": "string", "minLength": 1 },
+            "egressPrometheusNamespace": { "type": "string", "minLength": 1 },
             "kubeApiCidrs": {
               "type": "array",
               "items": {

--- a/platform/observability/otelcol/values.yaml
+++ b/platform/observability/otelcol/values.yaml
@@ -149,6 +149,13 @@ otelCollector:
         endpoint: ${env:PROMETHEUS_REMOTE_WRITE_ENDPOINT}
         tls:
           insecure: true
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_elapsed_time: 60s   # fail fast — não acumular por 5 min (default) se Prometheus indisponível
+        sending_queue:
+          enabled: true
+          num_consumers: 5        # standalone não precisa dos 10 workers do default
       # Debug (stdout) — útil em dev; manter para troubleshooting.
       debug:
         verbosity: basic
@@ -174,7 +181,7 @@ otelCollector:
         metrics:
           receivers: [otlp]
           processors: [memory_limiter, resource, batch]   # k8sattributes adicionado pelo preset
-          exporters: [prometheusremotewrite, debug]
+          exporters: [prometheusremotewrite]
 
   # ============================================================================
   # Resources — DaemonSet pequeno em standalone

--- a/platform/observability/otelcol/values.yaml
+++ b/platform/observability/otelcol/values.yaml
@@ -9,7 +9,7 @@
 # Pipelines:
 # - logs: filelog (containers do nó) + otlp (apps push direto) → loki
 # - traces: otlp (apps push) → tempo
-# - metrics: NÃO ativada — Prometheus já scrape direto (kube-prometheus-stack)
+# - metrics: otlp (apps .NET push OTLP) → prometheusremotewrite (Prometheus standalone)
 #
 # IMPORTANTE — chart upstream tem alias `otelCollector` (definido em
 # Chart.yaml). Diferente do Loki/Tempo, aqui usamos alias para distinguir
@@ -141,6 +141,14 @@ otelCollector:
         endpoint: ${env:TEMPO_OTLP_ENDPOINT}
         tls:
           insecure: true
+      # Prometheus remote write — recebe métricas OTLP dos apps .NET e encaminha
+      # para o Prometheus standalone via /api/v1/write.
+      # Endpoint via env var `${env:PROMETHEUS_REMOTE_WRITE_ENDPOINT}` —
+      # mesmo padrão do Loki/Tempo: valor real injetado por environment.
+      prometheusremotewrite:
+        endpoint: ${env:PROMETHEUS_REMOTE_WRITE_ENDPOINT}
+        tls:
+          insecure: true
       # Debug (stdout) — útil em dev; manter para troubleshooting.
       debug:
         verbosity: basic
@@ -159,9 +167,14 @@ otelCollector:
           receivers: [otlp]
           processors: [memory_limiter, resource, batch]   # k8sattributes adicionado pelo preset
           exporters: [otlphttp/tempo, debug]
-        # SEM metrics pipeline — Prometheus do platform/observability/prometheus/
-        # já scrape direto os apps via ServiceMonitor. Adicionar pipeline aqui
-        # seria redundante.
+        # Metrics: apps .NET emitem métricas OTLP → OTel Collector → Prometheus
+        # via remote_write. Complementar ao scrape do kube-prometheus-stack
+        # (que cobre K8s/infra); este pipeline cobre métricas de aplicação
+        # empurradas via OpenTelemetryConfiguration.cs (SDK .NET).
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, resource, batch]   # k8sattributes adicionado pelo preset
+          exporters: [prometheusremotewrite, debug]
 
   # ============================================================================
   # Resources — DaemonSet pequeno em standalone
@@ -183,6 +196,8 @@ otelCollector:
     - name: LOKI_OTLP_ENDPOINT
       value: ""
     - name: TEMPO_OTLP_ENDPOINT
+      value: ""
+    - name: PROMETHEUS_REMOTE_WRITE_ENDPOINT
       value: ""
 
   # ============================================================================
@@ -243,6 +258,7 @@ otelCollectorWrapper:
     # Loki + Tempo destinos dos exporters.
     egressLokiNamespace: observability-loki
     egressTempoNamespace: observability-tempo
+    egressPrometheusNamespace: observability-prometheus
     # Service CIDR do K3s para acesso ao kube-apiserver (k8sattributes precisa
     # de Watch em pods).
     kubeApiCidrs:


### PR DESCRIPTION
## Contexto

Story #245 da Feature #242 (Observabilidade — pipeline metrics). Refs #242, #240.

## O que muda

Adiciona o pipeline `metrics` ao ConfigMap do `otelcol-agent` (namespace `observability-otelcol`), completando o tripé de pipelines do OTel Collector:

| Pipeline | Receiver | Processadores | Exporter |
|---|---|---|---|
| `logs` | `otlp` + `filelog` (preset) | `memory_limiter`, `k8sattributes` (preset), `resource`, `batch` | `otlphttp/loki` |
| `traces` | `otlp` | `memory_limiter`, `k8sattributes` (preset), `resource`, `batch` | `otlphttp/tempo` |
| **`metrics`** ✨ | `otlp` | `memory_limiter`, `k8sattributes` (preset), `resource`, `batch` | **`prometheusremotewrite`** |

## Arquivos alterados

- `platform/observability/otelcol/values.yaml` — exporter `prometheusremotewrite`, pipeline `metrics`, env var padrão vazia, `egressPrometheusNamespace` no wrapper
- `platform/observability/otelcol/templates/networkpolicy.yaml` — egress para `observability-prometheus:9090`
- `platform/observability/otelcol/values.schema.json` — adiciona `egressPrometheusNamespace`
- `environments/standalone/values.yaml` — `PROMETHEUS_REMOTE_WRITE_ENDPOINT` real + `egressPrometheusNamespace`

## Padrão adotado

Consistente com Loki/Tempo: endpoint injetado via env var `PROMETHEUS_REMOTE_WRITE_ENDPOINT` (valor real em cada environment, vazio no wrapper padrão). Isso desacopla o chart wrapper de release names específicos de cluster.

O pipeline cobre métricas de **aplicação** empurradas via OTLP (SDK .NET `OpenTelemetryConfiguration.cs`), complementando o scrape nativo do kube-prometheus-stack (que cobre K8s/infra via ServiceMonitor).

## Pré-requisito de deploy

Story #244 (habilitar `remote_write` receiver no Prometheus) **precisa estar no cluster antes** de deployar este PR — do contrário o exporter receberá `405 Method Not Allowed` do Prometheus. A ordem de deploy é #244 → este PR → #247 (smoke).

## Critérios de aceite (Story #245)

- [x] Pipeline `metrics` adicionado via chart values (não via `kubectl edit`)
- [x] Exporter `prometheusremotewrite` configurado com endpoint do Prometheus standalone
- [x] Processor `resource` mantém `cluster=standalone` e `dc=standalone` nas séries
- [x] NetworkPolicy com egress para `observability-prometheus:9090`
- [ ] Argo CD Synced/Healthy após merge (validação pós-deploy)
- [ ] Logs sem `dropping data because sending_queue is full` (validação pós-deploy)
- [ ] `otelcol_exporter_sent_metric_points` > 0 (validação pós-deploy — Story #247)

Closes #245