### PR TITLE
fix(smoke): corrige API_PATH default para /api/editais

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -3498,7 +3498,7 @@ export VAULT_TOKEN_FOR_AUDIT=<root token ou token com sys/audit>
 O script:
 
 1. Obtém token OIDC do realm `uniplus` validando audience.
-2. POST `/api/v1/selecao/editais` com `Idempotency-Key` UUID — exercita o `IdempotencyFilter` da uniplus-api que toca cifragem.
+2. POST `/api/editais` com `Idempotency-Key` UUID — exercita o `IdempotencyFilter` da uniplus-api que toca cifragem. A rota não tem prefixo `/v1` porque o Uni+ resolve versionamento via vendor MIME no boundary (ADR-0031) e identidade do módulo via subdomínio.
 3. Espera HTTP 201/422 (ambos válidos — qualquer 5xx é regressão).
 4. Lê audit log do Vault buscando entrada `transit/encrypt/uniplus-idempotency-aesgcm`.
 

--- a/scripts/smoke-encryption-e2e.sh
+++ b/scripts/smoke-encryption-e2e.sh
@@ -7,7 +7,7 @@
 #   1. Obtém um token OIDC do realm `uniplus` via apicurio-registry client
 #      (directAccessGrantsEnabled=true documentado em
 #      configs/uniplus-standalone/11-uniplus-apis.md).
-#   2. Envia POST /api/v1/selecao/editais com header `Idempotency-Key`
+#   2. Envia POST /api/editais com header `Idempotency-Key`
 #      contendo um UUID v4 (mais portável que v7 em sh) — força a uniplus-api
 #      a invocar o `IdempotencyFilter`, que toca o `IUniPlusEncryptionService`.
 #   3. Espera HTTP 201 (criado) ou 422 (validation falhou pelo payload mínimo).
@@ -24,7 +24,10 @@ set -euo pipefail
 
 # Defaults — sobrescrevíveis via env vars
 API_HOST="${API_HOST:-api-selecao.standalone.portaluni.com.br}"
-API_PATH="${API_PATH:-/api/v1/selecao/editais}"
+# Rota canônica do módulo Seleção. O Uni+ resolve versionamento via vendor
+# MIME no boundary (ADR-0031), não por prefixo `/v1` no path; o módulo é
+# implícito no subdomínio `api-selecao.standalone.portaluni.com.br`.
+API_PATH="${API_PATH:-/api/editais}"
 KEYCLOAK_BASE="${KEYCLOAK_BASE:-https://standalone.portaluni.com.br/auth/realms/uniplus}"
 KEYCLOAK_CLIENT_ID="${KEYCLOAK_CLIENT_ID:-apicurio-registry}"
 SSH_HOST="${SSH_HOST:-ubuntu@164.152.53.29}"
@@ -124,7 +127,7 @@ log "Token OIDC obtido com audience=${audiences}"
 # antes de `fromdate`.
 since_epoch_minus_1=$(( $(date -u +%s) - 1 ))
 
-# --- 3. POST /api/v1/selecao/editais com Idempotency-Key -------------------
+# --- 3. POST /api/editais com Idempotency-Key ------------------------------
 
 idempotency_key=$(uuidgen)
 log "POST https://${API_HOST}${API_PATH} Idempotency-Key=${idempotency_key}"


### PR DESCRIPTION
Closes #271
Refs #220, #45

## Contexto

`scripts/smoke-encryption-e2e.sh` foi entregue no PR #228 com `API_PATH` default `/api/v1/selecao/editais`. Esse path nunca existiu no runtime do módulo Seleção: o Uni+ resolve versionamento via **vendor MIME no boundary (ADR-0031)** — não por prefix `/v1` no path — e identidade do módulo é implícita no subdomínio (`api-selecao.standalone.portaluni.com.br`).

Rota canônica é simplesmente `/api/editais`.

## Mudanças

| Arquivo | Alteração |
|---|---|
| `scripts/smoke-encryption-e2e.sh` | `API_PATH` default → `/api/editais`; comentário remete à ADR-0031 para evitar regressão futura. Header docstring atualizado. |
| `docs/RUNBOOKS.md` §18 | Rota corrigida na descrição do smoke + nota sobre ADR-0031. |

## Evidência live (2026-05-13)

**Antes (default antigo):**

```
03:17:25 [smoke-encryption] POST https://api-selecao.standalone.portaluni.com.br/api/v1/selecao/editais
03:17:25 [smoke-encryption] POST retornou 404 inesperado.
```

**Depois (default novo, sem override):**

```
03:19:24 POST https://api-selecao.standalone.portaluni.com.br/api/editais Idempotency-Key=07e5068c-…
03:19:24 POST retornou 422 (esperado — pipeline de cifragem foi exercitado)
03:19:27 Audit log confirma uso do Vault Transit:
  2026-05-13T03:19:24.531762179Z transit/encrypt/uniplus-idempotency-aesgcm (op=update)
  2026-05-13T03:19:24.531949272Z transit/encrypt/uniplus-idempotency-aesgcm (op=update)
03:19:27 OK — smoke E2E verde
```

Comprova: cifragem real (request → Vault Transit `encrypt`), Provider=vault funcional em produção contra imagem `v0.3.5` que tem os bits de fail-fast dos PRs api#401/403/406/407.

## Test plan

- [x] `bash -n scripts/smoke-encryption-e2e.sh` (syntax check)
- [x] Smoke E2E executado verde com defaults (HTTP 422 + 2 transit/encrypt no audit)
- [ ] CI verde (`PR author is org member` é o gate requerido; lint workflows são warning-only)
- [ ] Review humano (jf2s)

## Fora de escopo

- O smoke continua dependendo de `Idempotency-Key` ser tratado pela API — comportamento já validado por PR #228 + Story api#286.
- Não toca código de aplicação `uniplus-api` (a rota `/api/editais` já está correta e canônica).
