### PR TITLE
chore(standalone): bump uniplus-api para v0.3.6

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.5"
+    tag: "v0.3.6"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.5"
+    tag: "v0.3.6"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.5"
+    tag: "v0.3.6"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
Promove standalone para `uniplus-api v0.3.6` ([release](https://github.com/unifesspa-edu-br/uniplus-api/releases/tag/v0.3.6)).

## O que v0.3.6 traz

- ADR-0054 + `docs/guia-banco-de-dados.md` (estratégia definitiva de persistência).
- Helper `UseUniPlusNpgsqlConventions` centralizando wire-up EF Core.
- Ordem `Migration → WolverineRuntime` garantida nos 3 Program.cs + fitness test.
- `CascadingFixture` sem `MigrateAsync` redundante.

## Compatibilidade

- **Sem breaking changes** vs v0.3.5.
- Schema EF idêntico — `UseSnakeCaseNamingConvention()` está preparado mas NÃO ativado no runtime ainda (espera Story de normalização).
- Pods reiniciam → `MigrationHostedService` é no-op (banco já migrado).

## Plano de rollout

ArgoCD vai reconciliar as 3 Applications (`uniplus-api-{portal,selecao,ingresso}-uniplus-standalone`) e fazer rollout dos pods. Smoke E2E (`scripts/smoke-encryption-e2e.sh`) será executado pós-rollout para confirmar cifragem.

## Test plan

- [x] Imagens v0.3.6 publicadas em GHCR (workflow `publish-images.yml` run #25824524876).
- [ ] ArgoCD `Synced/Healthy` nas 3 Applications pós-merge.
- [ ] Pods rodando `v0.3.6`.
- [ ] Smoke E2E verde (HTTP 422 + `transit/encrypt` no audit log do Vault).