### PR TITLE
chore(standalone): bump uniplus-api para v0.3.7 (snake_case nativo)

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.6"
+    tag: "v0.3.7"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.6"
+    tag: "v0.3.7"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.6"
+    tag: "v0.3.7"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
Promove standalone para v0.3.7 ([release](https://github.com/unifesspa-edu-br/uniplus-api/releases/tag/v0.3.7)) — naming convention snake_case ativo + InitialCreate regenerada com dotnet ef.

## Pré-condição

Bancos `uniplus_selecao` e `uniplus_ingresso` no data-host (`10.0.2.87`) **já foram drop+recreate** (pre-prod, sem dados). `MigrationHostedService` aplica o novo InitialCreate em snake_case puro no startup dos pods.

## Pós-merge

- ArgoCD reconcilia 3 Applications → pods restart com v0.3.7
- Smoke E2E (`scripts/smoke-encryption-e2e.sh`) confirma cifragem + insert

## Test plan

- [x] Imagens v0.3.7 publicadas em GHCR
- [x] Bancos selecao/ingresso vazios no standalone
- [ ] ArgoCD apps Synced/Healthy
- [ ] Pods Ready em v0.3.7
- [ ] Smoke E2E verde