### PR TITLE
chore(standalone): bump uniplus-api para v0.3.8

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.7"
+    tag: "v0.3.8"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.7"
+    tag: "v0.3.8"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.7"
+    tag: "v0.3.8"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
## Sumário

Bump das 3 releases Helm `uniplus-api-{selecao,ingresso,portal}` para a tag `v0.3.8` publicada em [uniplus-api](https://github.com/unifesspa-edu-br/uniplus-api/releases/tag/v0.3.8).

Inclui o pin de `__EFMigrationsHistory` + alinhamento design-time↔runtime do uniplus-api [PR #438](https://github.com/unifesspa-edu-br/uniplus-api/pull/438) / [issue #437](https://github.com/unifesspa-edu-br/uniplus-api/issues/437). Resolve o cenário em que pods de um rollout misto podiam consultar tabelas de histórico distintas (drift entre PascalCase legado e snake_case nativo).

## Imagens

| Módulo | Image | SHA |
|--------|-------|-----|
| selecao | `ghcr.io/unifesspa-edu-br/uniplus-api-selecao:v0.3.8` | `sha256:9ab60e1b12a3...` |
| ingresso | `ghcr.io/unifesspa-edu-br/uniplus-api-ingresso:v0.3.8` | `sha256:3a5328e843e6...` |
| portal | `ghcr.io/unifesspa-edu-br/uniplus-api-portal:v0.3.8` | `sha256:28fd8a626b0a...` |

(Todas em `sha-a446f32`, último commit do PR #438.)

## Procedimento pós-merge (não automatizável)

Após ArgoCD sincronizar os 3 apps:

1. SSH no standalone (`164.152.53.29`) → `psql -h 10.0.2.87 -U postgres`.
2. `DROP DATABASE uniplus_selecao; DROP DATABASE uniplus_ingresso;`
3. `CREATE DATABASE uniplus_selecao OWNER selecao; CREATE DATABASE uniplus_ingresso OWNER ingresso;`
4. Restart pods → `MigrationHostedService` recria schema 100% snake_case via `InitialCreate`.
5. Smoke E2E (`POST /api/v1/selecao/editais` com Idempotency-Key) deve retornar 201 e exercitar cifragem real.

RUNBOOK completo no uniplus-api: [`RUNBOOKS/migrations-standalone-reset.md`](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/RUNBOOKS/migrations-standalone-reset.md).

## Test plan

- [x] Imagens publicadas no GHCR (3/3 v0.3.8)
- [x] CI/lint do uniplus-infra verde
- [ ] ArgoCD sync `Synced/Healthy` para os 3 apps
- [ ] Drop+recreate `uniplus_selecao` + `uniplus_ingresso`
- [ ] Pods v0.3.8 sem CrashLoop, `MigrationHostedService` aplica InitialCreate snake_case
- [ ] Smoke E2E POST edital → 201