### PR TITLE
Feature/246 tempo metrics generator

### DIFF
--- a/environments/standalone/values.yaml
+++ b/environments/standalone/values.yaml
@@ -249,7 +249,8 @@ grafana:
               tags:
                 - key: service.name
                   value: service_name
-            # Service Graph desligado — Tempo metricsGenerator off em standalone (ADR-012).
+            # Service Map habilitado — Tempo metricsGenerator ativo (issue #246, ADR-012).
+            # Consome traces_service_graph_request_total do Prometheus via remote_write.
             serviceMap:
               datasourceUid: prometheus
             nodeGraph:
@@ -332,6 +333,35 @@ tempo:
           # Nome FIXO derivado de chart-name (helper uniplus-tempo.s3SecretName).
           # Mesma justificativa do PR #221 (Loki Codex P2): release-independente.
           name: tempo-s3-creds
+    # ---- Metrics generator (issue #246, Feature #243) ----
+    # Ativado com o Prometheus standalone após enableRemoteWriteReceiver (issue #244).
+    # Gera traces_service_graph_request_total + traces_span_metrics_* via remote_write.
+    metricsGenerator:
+      enabled: true
+      remoteWriteUrl: "http://platform-observability-pro-prometheus.observability-prometheus.svc.cluster.local:9090/api/v1/write"
+      processor:
+        service_graphs:
+          wait: 10s
+          max_items: 10000
+        span_metrics:
+          enable_target_info: true
+      registry:
+        collection_interval: 15s
+        external_labels:
+          source: tempo
+          cluster: standalone
+      storage:
+        # PVC-backed via StatefulSet — sobrevive a restart.
+        path: /var/tempo/generator/wal
+      traces_storage:
+        path: /var/tempo/generator/traces
+    # Habilitar processors para o tenant padrão (multitenancy off em standalone).
+    overrides:
+      defaults:
+        metrics_generator:
+          processors:
+            - service-graphs
+            - span-metrics
   persistence:
     # ATENÇÃO: chart upstream tempo usa `storageClassName` (não `storageClass`
     # como Loki). Setar `storageClass` aqui seria ignorado pelo subchart.
@@ -352,6 +382,8 @@ tempoWrapper:
       - observability-tempo
     minioCIDR: "10.0.2.87/32"
     minioPort: 9000
+    # Libera egress :9090 para Prometheus (remote_write do metricsGenerator).
+    egressPrometheusNamespace: observability-prometheus
     kubeApiCidrs:
       - 10.43.0.0/16
       - 10.0.1.0/24

--- a/platform/observability/otelcol/values.yaml
+++ b/platform/observability/otelcol/values.yaml
@@ -45,9 +45,12 @@ otelCollector:
   mode: daemonset
 
   image:
-    # Distribution k8s — inclui contrib receivers/exporters (filelog, k8sattributes,
-    # otlphttp, etc.). Default upstream se vazio.
-    repository: otel/opentelemetry-collector-k8s
+    # Distribution contrib — necessária para o exporter `prometheusremotewrite`
+    # (pipeline metrics → Prometheus). A distribuição `k8s` não inclui esse
+    # exporter; a `contrib` inclui tudo da k8s + todos os contrib components.
+    # Diferença de tamanho: ~80 MB (k8s) → ~450 MB (contrib); aceitável em
+    # standalone onde o DaemonSet roda em 1 nó apenas.
+    repository: otel/opentelemetry-collector-contrib
 
   # ============================================================================
   # Presets — chart configura volumes + RBAC + pipeline injection automaticamente.

--- a/platform/observability/tempo/templates/networkpolicy.yaml
+++ b/platform/observability/tempo/templates/networkpolicy.yaml
@@ -87,4 +87,14 @@ spec:
           protocol: TCP
         - port: 6443
           protocol: TCP
+    {{- if $np.egressPrometheusNamespace }}
+    # Prometheus remote_write — necessário quando metricsGenerator.enabled=true
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.egressPrometheusNamespace | quote }}
+      ports:
+        - port: 9090
+          protocol: TCP
+    {{- end }}
 {{- end }}

--- a/platform/observability/tempo/values.yaml
+++ b/platform/observability/tempo/values.yaml
@@ -51,12 +51,50 @@ tempo:
     # ----- Reporting upstream off (não enviar telemetria pro Grafana Labs) -----
     reportingEnabled: false
 
-    # ----- Metrics generator off em standalone -----
-    # Geração de métricas a partir de traces requer Prometheus remote-write
-    # alvo. Só ligar quando o Prometheus consumidor + protocolo estiverem
-    # claros (sub-issue futura).
+    # ----- Metrics generator -----
+    # Gera métricas RED (request rate/error/duration) e service graph a partir
+    # dos spans recebidos, publicando via Prometheus remote_write.
+    # Pré-requisito: Prometheus com `enableRemoteWriteReceiver: true` (issue #244).
+    # Environments que habilitam devem sobrescrever `metricsGenerator.enabled: true`
+    # e setar `remoteWriteUrl` apontando para o endpoint /api/v1/write do Prometheus.
     metricsGenerator:
       enabled: false
+      # remoteWriteUrl: "http://prometheus-svc.namespace.svc.cluster.local:9090/api/v1/write"
+      processor:
+        service_graphs:
+          # Janela de espera por spans client/server do mesmo trace.
+          # 10s cobre p99 de latências dentro do cluster.
+          wait: 10s
+          max_items: 10000
+        span_metrics:
+          # Inclui dimensão target_info (biblioteca, runtime, OS) — enriquece
+          # o USE dashboard de .NET Runtime.
+          enable_target_info: true
+      registry:
+        # Cadência de publicação das métricas no Prometheus.
+        collection_interval: 15s
+        external_labels:
+          source: tempo
+          # cluster: <definido por environment>
+      storage:
+        # PVC-backed (WAL do metrics generator). Evitar /tmp — não sobrevive
+        # a restart do pod em clusters com PVC de StatefulSet.
+        path: /var/tempo/generator/wal
+      traces_storage:
+        # WAL de traces consumidos pelo metrics generator (local blocks).
+        path: /var/tempo/generator/traces
+
+    # ----- Overrides (processors ativos por tenant) -----
+    # Em Tempo 2.x os processors do metrics generator precisam ser habilitados
+    # aqui OU em per_tenant_overrides para que o generator comece a emitir.
+    # Environments que habilitam metricsGenerator devem sobrescrever este bloco.
+    overrides:
+      defaults: {}
+      # defaults:
+      #   metrics_generator:
+      #     processors:
+      #       - service-graphs
+      #       - span-metrics
 
     # ----- Storage backend S3 -----
     # Credenciais via env var (`-config.expand-env=true` em extraArgs).
@@ -207,5 +245,8 @@ tempoWrapper:
       - observability-otelcol
     minioCIDR: "10.0.2.87/32"
     minioPort: 9000
+    # Quando metricsGenerator.enabled=true, setar este campo com o namespace
+    # do Prometheus para liberar egress :9090 (remote_write do generator).
+    egressPrometheusNamespace: ""
     kubeApiCidrs:
       - 10.43.0.0/16


### PR DESCRIPTION
## O que muda

  Dois commits neste PR:

  ### 1. `fix(otelcol)` — corrige CrashLoopBackOff do OTel Collector (bloqueante)

  **Bug:** PR #265 adicionou o exporter `prometheusremotewrite` ao pipeline de
  métricas, mas manteve a imagem `otel/opentelemetry-collector-k8s`, que não
  inclui esse exporter. O Collector entrou em CrashLoopBackOff imediatamente
  após o deploy (~47h, 559 restarts observados no standalone OCI).

  Error: 'exporters' unknown type: "prometheusremotewrite"
  (valid values: [debug otlp_http otlphttp file nop otlp_grpc otlp ...])

  **Fix:** troca para `otel/opentelemetry-collector-contrib`, única distribuição
  que inclui `prometheusremotewriteexporter`. Validado via pod de teste no
  standalone — `otelcol-contrib components` confirma o exporter presente na
  v0.151.0.

  **Trade-off:** imagem ~450 MB vs ~80 MB da `k8s`. Aceitável em standalone
  single-node. Em prod multi-nó (SP1/SP2), avaliar build customizado via OTel
  Operator — registrado como débito técnico.

  ---

  ### 2. `feat(tempo)` — habilita metrics-generator (stories #246, #248)

  Pré-requisitos satisfeitos: Prometheus com `enableRemoteWriteReceiver: true`
  (PR #266) + OTel Collector funcional (este PR, commit acima).

  **`platform/observability/tempo/values.yaml`**
  - Documenta o bloco `metricsGenerator` completo com todas as opções
    (processor, registry, storage, traces_storage, overrides). Default permanece
    `enabled: false` — environments sem Prometheus remote_write não são afetados.
  - Adiciona `egressPrometheusNamespace` (vazio por default) ao wrapper NetworkPolicy.

  **`platform/observability/tempo/templates/networkpolicy.yaml`**
  - Egress condicional para `:9090` quando `egressPrometheusNamespace` estiver setado.

  **`environments/standalone/values.yaml`**
  - `metricsGenerator.enabled: true`
  - `remoteWriteUrl` → Prometheus standalone (mesmo endpoint do OTel Collector em PR #265)
  - Processors: `service_graphs` (wait 10s, max_items 10k) + `span_metrics` (enable_target_info)
  - `registry.external_labels`: `cluster=standalone`, `source=tempo`
  - Storage em `/var/tempo/generator/wal` e `/var/tempo/generator/traces` (PVC-backed)
  - `overrides.defaults.metrics_generator.processors: [service-graphs, span-metrics]`
  - `tempoWrapper.networkPolicy.egressPrometheusNamespace: observability-prometheus`
  - Datasource Grafana Tempo: atualiza comentário (serviceMap já configurado)

  ## Validação no standalone OCI

  | Check | Resultado |
  |-------|-----------|
  | `prometheusremotewrite` presente na imagem `contrib:0.151.0` | ✅ confirmado via pod de teste |
  | Tempo 2.9.0 sobe com `metricsGenerator.enabled: true` | ✅ rollout sem erros fatais |
  | Helm lint + YAML lint | ✅ sem erros |
  | Pipeline end-to-end (OTLP → OTelCol → Tempo → Prometheus) | ⏳ aguarda ArgoCD sync pós-merge |

  > O pipeline ponta-a-ponta não pôde ser validado antes do merge porque o OTel
  > Collector estava em CrashLoopBackOff (o bug que este PR corrige). Após o
  > ArgoCD sincronizar, validar com:
  >
  > ```bash
  > # 1. Confirmar que o OTel Collector subiu
  > kubectl get pods -n observability-otelcol
  >
  > # 2. Gerar tráfego e aguardar ~2 min
  > for i in $(seq 1 50); do
  >   curl -sk http://<svc-selecao>:8080/api/editais -o /dev/null &
  > done; wait
  >
  > # 3. Verificar métricas no Prometheus
  > kubectl port-forward -n observability-prometheus \
  >   svc/platform-observability-pro-prometheus 9090:9090
  > curl -sg 'http://localhost:9090/api/v1/query?query=traces_service_graph_request_total' \
  >   | jq '.data.result | length'
  > # Esperado: > 0
  > ```

  ## Issues

  Closes #246
  Closes #248
  Refs #243
  Refs #240
