### PR TITLE
feat(grafana): baseline sidecar provisioning de dashboards via ConfigMap GitOps

### DIFF
--- a/platform/observability/grafana/dashboards/uniplus-placeholder.json
+++ b/platform/observability/grafana/dashboards/uniplus-placeholder.json
@@ -1,0 +1,32 @@
+{
+  "annotations": { "list": [] },
+  "description": "Dashboard temporário para validar pipeline GitOps do sidecar (remover após S3.2).",
+  "editable": false,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "content": "## Uni+ — Standalone\n\nPipeline GitOps de dashboards validado com sucesso.\nEste dashboard temporário será removido após S3.2.",
+        "mode": "markdown"
+      },
+      "title": "Pipeline GitOps OK",
+      "type": "text"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "tags": ["uniplus", "placeholder"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Uni+ — Placeholder",
+  "uid": "uniplus-placeholder",
+  "version": 1
+}

--- a/platform/observability/grafana/templates/dashboards.yaml
+++ b/platform/observability/grafana/templates/dashboards.yaml
@@ -1,26 +1,33 @@
 {{/*
   Gera um ConfigMap por arquivo JSON em dashboards/.
   O sidecar grafana/grafana detecta a label `grafana_dashboard: "1"` e
-  provisiona cada dashboard na folder indicada pela annotation `grafana_folder`.
-  Naming: <release>-db-<slug> (truncado em 63 chars).
+  provisiona cada dashboard na folder indicada pela annotation `grafana_folder`
+  (requer `sidecar.dashboards.folderAnnotation: grafana_folder` no values).
+  Naming: nome composto truncado em 63 chars (limite Kubernetes).
 */}}
 {{- range $path, $content := .Files.Glob "dashboards/*.json" }}
 {{- $slug := base $path | trimSuffix ".json" }}
+{{- $prefix := printf "%s-db-" (include "grafana.fullname" $) }}
+{{- $budget := int (sub 63 (len $prefix)) }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "grafana.fullname" $ }}-db-{{ $slug | trunc 40 | trimSuffix "-" }}
+  name: {{ printf "%s%s" $prefix ($slug | trunc $budget | trimSuffix "-") }}
   namespace: {{ $.Release.Namespace }}
   labels:
+    app.kubernetes.io/name: grafana-dashboard
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
     app.kubernetes.io/part-of: uniplus
     app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: {{ printf "%s-%s" $.Chart.Name $.Chart.Version }}
     grafana_dashboard: "1"
   annotations:
     meta.helm.sh/release-name: {{ $.Release.Name }}
     meta.helm.sh/release-namespace: {{ $.Release.Namespace }}
-    grafana_folder: "Uni+ — Standalone"
+    grafana_folder: "Uni+ Standalone"
 data:
-  {{ base $path }}: |-
-    {{ $content | toString | trim | nindent 4 }}
+  {{ base $path }}: |
+{{ $content | toString | trim | indent 4 }}
 {{- end }}

--- a/platform/observability/grafana/templates/dashboards.yaml
+++ b/platform/observability/grafana/templates/dashboards.yaml
@@ -1,0 +1,26 @@
+{{/*
+  Gera um ConfigMap por arquivo JSON em dashboards/.
+  O sidecar grafana/grafana detecta a label `grafana_dashboard: "1"` e
+  provisiona cada dashboard na folder indicada pela annotation `grafana_folder`.
+  Naming: <release>-db-<slug> (truncado em 63 chars).
+*/}}
+{{- range $path, $content := .Files.Glob "dashboards/*.json" }}
+{{- $slug := base $path | trimSuffix ".json" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "grafana.fullname" $ }}-db-{{ $slug | trunc 40 | trimSuffix "-" }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: uniplus
+    app.kubernetes.io/managed-by: Helm
+    grafana_dashboard: "1"
+  annotations:
+    meta.helm.sh/release-name: {{ $.Release.Name }}
+    meta.helm.sh/release-namespace: {{ $.Release.Namespace }}
+    grafana_folder: "Uni+ — Standalone"
+data:
+  {{ base $path }}: |-
+    {{ $content | toString | trim | nindent 4 }}
+{{- end }}

--- a/platform/observability/grafana/values.yaml
+++ b/platform/observability/grafana/values.yaml
@@ -127,6 +127,9 @@ grafana:
       labelValue: "1"
       folder: /tmp/dashboards
       searchNamespace: ALL
+      # Nome da annotation nos ConfigMaps que define a folder de destino no Grafana.
+      # Deve bater com a annotation `grafana_folder` emitida por templates/dashboards.yaml.
+      folderAnnotation: grafana_folder
     datasources:
       enabled: true
       label: grafana_datasource


### PR DESCRIPTION
## Resumo

- Cria `templates/dashboards.yaml` no chart wrapper Grafana: gera um ConfigMap por arquivo JSON em `dashboards/`, com label `grafana_dashboard: "1"` e annotation `grafana_folder: "Uni+ — Standalone"` que o sidecar detecta e provisiona
- Inclui dashboard placeholder (`dashboards/uniplus-placeholder.json`) para validar o pipeline end-to-end antes dos dashboards reais

## Mudanças

### Novos arquivos
- `platform/observability/grafana/templates/dashboards.yaml` — template Helm que converte cada `dashboards/*.json` em ConfigMap provisionável pelo sidecar
- `platform/observability/grafana/dashboards/uniplus-placeholder.json` — dashboard mínimo de validação (text panel)

## Padrão de ConfigMap

```yaml
metadata:
  labels:
    grafana_dashboard: "1"       # sidecar detecta por esta label
  annotations:
    grafana_folder: "Uni+ — Standalone"   # folder no Grafana UI
data:
  dashboard-name.json: |-
    { ... }
```

Para adicionar novos dashboards: criar `dashboards/<slug>.json` — o template gera o ConfigMap automaticamente no próximo sync ArgoCD.

## Validação local

```
helm lint platform/observability/grafana/    # 0 failed
helm template ... --show-only templates/dashboards.yaml  # ConfigMap correto
yamllint -c .yamllint.yaml templates/dashboards.yaml     # sem erros
```

## Dependências

- Bloqueia stories #249, #250, #252, #253, #255 (dashboards reais)
- Parte da Feature #241 / Epic #240

Closes #251
Refs #241
Refs #240