### PR TITLE
feat(grafana): dashboard Logs por service com live tail e severity

### DIFF
--- a/platform/observability/grafana/dashboards/uniplus-logs-per-service.json
+++ b/platform/observability/grafana/dashboards/uniplus-logs-per-service.json
@@ -1,0 +1,151 @@
+{
+  "annotations": { "list": [] },
+  "description": "Logs Loki das APIs Uni+ — live tail, distribuição por severity e volume por service.",
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "title": "Live tail — $service",
+      "type": "logs",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{k8s_namespace_name=\"uniplus\",service_name=~\"$service\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 14, "x": 0, "y": 10 },
+      "id": 2,
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "right" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "title": "Distribuição por severity",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum by (detected_level) (count_over_time({k8s_namespace_name=\"uniplus\",service_name=~\"$service\"}[$__interval]))",
+          "legendFormat": "{{detected_level}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 10, "x": 14, "y": 10 },
+      "id": 3,
+      "options": {
+        "footer": { "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "volume" }]
+      },
+      "title": "Top 10 services por volume",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "topk(10, sum by (service_name) (count_over_time({k8s_namespace_name=\"uniplus\"}[5m])))",
+          "legendFormat": "{{service_name}}",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 18 },
+      "id": 4,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "title": "Logs de erro últimos 15 min",
+      "type": "logs",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{k8s_namespace_name=\"uniplus\",service_name=~\"$service\"} |~ \"(?i)(\\\\[ERR\\\\]|exception)\"",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 27 },
+      "id": 5,
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "right" }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "title": "Volume total por hora",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum (count_over_time({k8s_namespace_name=\"uniplus\",service_name=~\"$service\"}[1h]))",
+          "legendFormat": "volume/h",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "tags": ["uniplus", "logs"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "loki", "uid": "loki" },
+        "definition": "label_values({k8s_namespace_name=\"uniplus\"}, service_name)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": "label_values({k8s_namespace_name=\"uniplus\"}, service_name)",
+        "refresh": 2,
+        "type": "query",
+        "label": "Service"
+      }
+    ]
+  },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Uni+ — Logs por service",
+  "uid": "uniplus-logs-per-service",
+  "version": 1
+}


### PR DESCRIPTION
## Resumo

Dashboard **\"Uni+ — Logs por service\"** com 5 painéis Loki: live tail, distribuição por severity, top services por volume, feed de erros e volume por hora. Auto-refresh 10s para operação em tempo real.

## Painéis

| # | Query | Conteúdo |
|---|---|---|
| 1 | `{k8s_namespace_name="uniplus",service_name=~"$service"}` | Live tail |
| 2 | `count_over_time ... by (detected_level)` | Distribuição por severity |
| 3 | `topk(10, sum by (service_name) ...)` | Top 10 services por volume |
| 4 | `\|~ "(?i)(\\[ERR\\]\|exception)"` | Logs de erro últimos 15min |
| 5 | `count_over_time ... [1h]` | Volume total por hora |

## Arquivo

`platform/observability/grafana/dashboards/uniplus-logs-per-service.json`

Closes #255
Refs #241
Refs #240