### PR TITLE
feat(grafana): dashboard HTTP Errors detail com drill-down Loki

### DIFF
--- a/platform/observability/grafana/dashboards/uniplus-http-errors.json
+++ b/platform/observability/grafana/dashboards/uniplus-http-errors.json
@@ -43,7 +43,15 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Value" },
+            "properties": [{ "id": "displayName", "value": "req/s" }]
+          }
+        ]
+      },
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
       "id": 2,
       "options": {
@@ -51,21 +59,30 @@
         "showHeader": true,
         "sortBy": [{ "desc": true, "displayName": "req/s" }]
       },
-      "title": "Top 10 routes com 5xx",
+      "title": "Top 10 routes com 5xx (últimos $__rate_interval)",
       "type": "table",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "topk(10, sum by (service_name, http_route) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[5m])))",
-          "legendFormat": "{{service_name}} {{http_route}}",
+          "expr": "topk(10, sum by (service_name, http_route) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[$__rate_interval])))",
+          "legendFormat": "",
           "refId": "A",
-          "instant": true
+          "instant": true,
+          "format": "table"
         }
       ]
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Value" },
+            "properties": [{ "id": "displayName", "value": "req/s" }]
+          }
+        ]
+      },
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
       "id": 3,
       "options": {
@@ -73,22 +90,23 @@
         "showHeader": true,
         "sortBy": [{ "desc": true, "displayName": "req/s" }]
       },
-      "title": "Top 10 routes com 4xx",
+      "title": "Top 10 routes com 4xx (últimos $__rate_interval)",
       "type": "table",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "topk(10, sum by (service_name, http_route) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"4..\"}[5m])))",
-          "legendFormat": "{{service_name}} {{http_route}}",
+          "expr": "topk(10, sum by (service_name, http_route) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"4..\"}[$__rate_interval])))",
+          "legendFormat": "",
           "refId": "A",
-          "instant": true
+          "instant": true,
+          "format": "table"
         }
       ]
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" },
         "overrides": []
       },
       "gridPos": { "h": 6, "w": 24, "x": 0, "y": 16 },
@@ -125,7 +143,7 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "{k8s_namespace_name=\"uniplus\",service_name=~\"$service\"} |~ \"(?i)(\\\\[(ERR|WRN)\\\\]|exception|500|error)\"",
+          "expr": "{k8s_namespace_name=\"uniplus\",service_name=~\"$service\"} |~ \"(?i)(\\[(ERR|WRN)\\]|exception|error)\"",
           "legendFormat": "",
           "refId": "A"
         }
@@ -161,5 +179,5 @@
   "timezone": "browser",
   "title": "Uni+ — HTTP Errors detail",
   "uid": "uniplus-http-errors",
-  "version": 1
+  "version": 2
 }

--- a/platform/observability/grafana/dashboards/uniplus-http-errors.json
+++ b/platform/observability/grafana/dashboards/uniplus-http-errors.json
@@ -1,0 +1,165 @@
+{
+  "annotations": { "list": [] },
+  "description": "Breakdown de erros HTTP 4xx/5xx por route + feed de logs Loki com drill-down para Tempo.",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": "5xx" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": "4xx" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "title": "Error rate timeseries (4xx vs 5xx)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[$__rate_interval]))",
+          "legendFormat": "5xx {{http_response_status_code}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"4..\"}[$__rate_interval]))",
+          "legendFormat": "4xx {{http_response_status_code}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 2,
+      "options": {
+        "footer": { "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "req/s" }]
+      },
+      "title": "Top 10 routes com 5xx",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "topk(10, sum by (service_name, http_route) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[5m])))",
+          "legendFormat": "{{service_name}} {{http_route}}",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 3,
+      "options": {
+        "footer": { "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "req/s" }]
+      },
+      "title": "Top 10 routes com 4xx",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "topk(10, sum by (service_name, http_route) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"4..\"}[5m])))",
+          "legendFormat": "{{service_name}} {{http_route}}",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 16 },
+      "id": 4,
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "right" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "title": "Distribuição por status code",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\"}[$__rate_interval]))",
+          "legendFormat": "{{http_response_status_code}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 22 },
+      "id": 5,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "title": "Feed de logs de erro (ERR / WRN)",
+      "type": "logs",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{k8s_namespace_name=\"uniplus\",service_name=~\"$service\"} |~ \"(?i)(\\\\[(ERR|WRN)\\\\]|exception|500|error)\"",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["uniplus", "errors", "troubleshooting"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(http_server_request_duration_seconds_count{service_namespace=\"uniplus\"}, service_name)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_request_duration_seconds_count{service_namespace=\"uniplus\"}, service_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "type": "query",
+        "label": "Service"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Uni+ — HTTP Errors detail",
+  "uid": "uniplus-http-errors",
+  "version": 1
+}


### PR DESCRIPTION
## Resumo

- Adiciona o dashboard **Uni+ — HTTP Errors detail** (`uniplus-http-errors`) para análise de erros 4xx/5xx por route com acesso direto aos logs de erro via Loki.

## Mudanças

### Novos arquivos
- `platform/observability/grafana/dashboards/uniplus-http-errors.json` — 5 painéis: timeseries 4xx/5xx, top-10 routes 5xx (tabela), top-10 routes 4xx (tabela), distribuição por status code, feed de logs ERR/WRN via Loki

## Painéis

| # | Tipo | Descrição |
|---|---|---|
| 1 | timeseries | Error rate por status code (4xx vs 5xx) com $__rate_interval |
| 2 | table | Top 10 routes com 5xx — instant query com format:table, sorted por req/s |
| 3 | table | Top 10 routes com 4xx — instant query com format:table, sorted por req/s |
| 4 | timeseries | Distribuição por status code (todos os códigos) |
| 5 | logs | Feed de logs Loki filtrado por ERR/WRN via regex |

## Rastreabilidade

Closes #250
Refs #241 (Feature: dashboards operacionais)
Refs #240 (Epic: observabilidade Grafana)