### PR TITLE
feat(grafana): dashboard Traces & Service Map com nodeGraph e TraceQL

### DIFF
--- a/platform/observability/grafana/dashboards/uniplus-traces-service-map.json
+++ b/platform/observability/grafana/dashboards/uniplus-traces-service-map.json
@@ -1,26 +1,34 @@
 {
   "annotations": { "list": [] },
-  "description": "Service Map cross-service (traces_service_graph_*) + traces lentos/erros via TraceQL.",
+  "description": "Service Map cross-service (Tempo service graph) + traces lentos/erros via TraceQL.",
   "editable": true,
   "graphTooltip": 1,
   "id": null,
   "links": [],
   "panels": [
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": { "type": "tempo", "uid": "tempo" },
       "fieldConfig": { "defaults": {}, "overrides": [] },
       "gridPos": { "h": 12, "w": 12, "x": 0, "y": 0 },
       "id": 1,
-      "options": { "nodes": {}, "edges": {} },
+      "options": {
+        "nodes": {
+          "mainStat": "requestsPerSecond",
+          "secondaryStat": "errorRate",
+          "arc1": "successRate",
+          "arc2": "errorRate"
+        },
+        "edges": {
+          "mainStat": "requestsPerSecond"
+        }
+      },
       "title": "Service Map (node graph)",
       "type": "nodeGraph",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (client, server) (rate(traces_service_graph_request_total[$__rate_interval]))",
-          "legendFormat": "{{client}} → {{server}}",
-          "refId": "A",
-          "instant": true
+          "datasource": { "type": "tempo", "uid": "tempo" },
+          "queryType": "serviceMap",
+          "refId": "A"
         }
       ]
     },
@@ -39,7 +47,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "expr": "histogram_quantile(0.95, sum by (le, client, server) (rate(traces_service_graph_request_server_seconds_bucket[$__rate_interval])))",
-          "legendFormat": "{{client}}→{{server}}",
+          "legendFormat": "{{client}}->{{server}}",
           "refId": "A"
         }
       ]
@@ -50,19 +58,17 @@
       "gridPos": { "h": 10, "w": 12, "x": 0, "y": 12 },
       "id": 3,
       "options": {
-        "dedupStrategy": "none",
-        "enableLogDetails": false,
-        "showLabels": false,
-        "showTime": true,
-        "sortOrder": "Descending"
+        "frameIndex": 0,
+        "showHeader": true
       },
       "title": "Top traces lentos (> 1s)",
-      "type": "traces",
+      "type": "table",
       "targets": [
         {
           "datasource": { "type": "tempo", "uid": "tempo" },
           "queryType": "traceql",
-          "query": "{ duration > 1s } | select(resource.service.name, name, duration) | limit 20",
+          "query": "{ duration > 1s } | select(resource.service.name, name, duration)",
+          "limit": 20,
           "refId": "A"
         }
       ]
@@ -73,19 +79,17 @@
       "gridPos": { "h": 10, "w": 12, "x": 12, "y": 12 },
       "id": 4,
       "options": {
-        "dedupStrategy": "none",
-        "enableLogDetails": false,
-        "showLabels": false,
-        "showTime": true,
-        "sortOrder": "Descending"
+        "frameIndex": 0,
+        "showHeader": true
       },
       "title": "Traces com erro",
-      "type": "traces",
+      "type": "table",
       "targets": [
         {
           "datasource": { "type": "tempo", "uid": "tempo" },
           "queryType": "traceql",
-          "query": "{ status = error } | select(resource.service.name, name, duration) | limit 20",
+          "query": "{ status = error } | select(resource.service.name, name, duration)",
+          "limit": 20,
           "refId": "A"
         }
       ]
@@ -120,5 +124,5 @@
   "timezone": "browser",
   "title": "Uni+ — Traces & Service Map",
   "uid": "uniplus-traces-service-map",
-  "version": 1
+  "version": 2
 }

--- a/platform/observability/grafana/dashboards/uniplus-traces-service-map.json
+++ b/platform/observability/grafana/dashboards/uniplus-traces-service-map.json
@@ -1,0 +1,124 @@
+{
+  "annotations": { "list": [] },
+  "description": "Service Map cross-service (traces_service_graph_*) + traces lentos/erros via TraceQL.",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "nodes": {}, "edges": {} },
+      "title": "Service Map (node graph)",
+      "type": "nodeGraph",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (client, server) (rate(traces_service_graph_request_total[$__rate_interval]))",
+          "legendFormat": "{{client}} → {{server}}",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 12, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "title": "Latência p95 por aresta (client→server)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (le, client, server) (rate(traces_service_graph_request_server_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "{{client}}→{{server}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "tempo", "uid": "tempo" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 12 },
+      "id": 3,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending"
+      },
+      "title": "Top traces lentos (> 1s)",
+      "type": "traces",
+      "targets": [
+        {
+          "datasource": { "type": "tempo", "uid": "tempo" },
+          "queryType": "traceql",
+          "query": "{ duration > 1s } | select(resource.service.name, name, duration) | limit 20",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "tempo", "uid": "tempo" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 12 },
+      "id": 4,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending"
+      },
+      "title": "Traces com erro",
+      "type": "traces",
+      "targets": [
+        {
+          "datasource": { "type": "tempo", "uid": "tempo" },
+          "queryType": "traceql",
+          "query": "{ status = error } | select(resource.service.name, name, duration) | limit 20",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 22 },
+      "id": 5,
+      "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "title": "Span rate por service",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (service_name) (rate(traces_spanmetrics_calls_total[$__rate_interval]))",
+          "legendFormat": "{{service_name}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["uniplus", "traces", "service-map"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Uni+ — Traces & Service Map",
+  "uid": "uniplus-traces-service-map",
+  "version": 1
+}


### PR DESCRIPTION
## Resumo

- Adiciona o dashboard **Uni+ — Traces & Service Map** (`uniplus-traces-service-map`) com visualização de service graph e busca de traces lentos/erros via TraceQL.

## Mudanças

### Novos arquivos
- `platform/observability/grafana/dashboards/uniplus-traces-service-map.json` — 5 painéis: node graph (serviceMap via Tempo), latência p95 por aresta, top traces lentos > 1s, traces com erro, span rate por service

## Painéis

| # | Tipo | Datasource | Descrição |
|---|---|---|---|
| 1 | nodeGraph | Tempo | Service Map — `queryType:serviceMap` via Tempo metrics-generator |
| 2 | timeseries | Prometheus | Latência p95 por aresta client→server via `traces_service_graph_request_server_seconds_bucket` |
| 3 | table | Tempo | Top traces lentos > 1s via TraceQL com limit 20 |
| 4 | table | Tempo | Traces com status=error via TraceQL com limit 20 |
| 5 | timeseries | Prometheus | Span rate por service via `traces_spanmetrics_calls_total` |

## Rastreabilidade

Closes #252
Refs #241 (Feature: dashboards operacionais)
Refs #240 (Epic: observabilidade Grafana)