### PR TITLE
feat(grafana): dashboard Logs por service com live tail e severity

### DIFF
--- a/platform/observability/grafana/dashboards/uniplus-logs-per-service.json
+++ b/platform/observability/grafana/dashboards/uniplus-logs-per-service.json
@@ -1,0 +1,151 @@
+{
+  "annotations": { "list": [] },
+  "description": "Logs Loki das APIs Uni+ — live tail, distribuição por severity e volume por service.",
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "title": "Live tail — $service",
+      "type": "logs",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{k8s_namespace_name=\"uniplus\",service_name=~\"$service\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 14, "x": 0, "y": 10 },
+      "id": 2,
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "right" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "title": "Distribuição por severity",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum by (detected_level) (count_over_time({k8s_namespace_name=\"uniplus\",service_name=~\"$service\"}[$__interval]))",
+          "legendFormat": "{{detected_level}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 10, "x": 14, "y": 10 },
+      "id": 3,
+      "options": {
+        "footer": { "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "volume" }]
+      },
+      "title": "Top 10 services por volume",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "topk(10, sum by (service_name) (count_over_time({k8s_namespace_name=\"uniplus\"}[5m])))",
+          "legendFormat": "{{service_name}}",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 18 },
+      "id": 4,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "title": "Logs de erro últimos 15 min",
+      "type": "logs",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{k8s_namespace_name=\"uniplus\",service_name=~\"$service\"} |~ \"(?i)(\\\\[ERR\\\\]|exception)\"",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 27 },
+      "id": 5,
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "right" }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "title": "Volume total por hora",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum (count_over_time({k8s_namespace_name=\"uniplus\",service_name=~\"$service\"}[1h]))",
+          "legendFormat": "volume/h",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "tags": ["uniplus", "logs"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "loki", "uid": "loki" },
+        "definition": "label_values({k8s_namespace_name=\"uniplus\"}, service_name)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": "label_values({k8s_namespace_name=\"uniplus\"}, service_name)",
+        "refresh": 2,
+        "type": "query",
+        "label": "Service"
+      }
+    ]
+  },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Uni+ — Logs por service",
+  "uid": "uniplus-logs-per-service",
+  "version": 1
+}

--- a/platform/observability/grafana/dashboards/uniplus-logs-per-service.json
+++ b/platform/observability/grafana/dashboards/uniplus-logs-per-service.json
@@ -54,7 +54,15 @@
     },
     {
       "datasource": { "type": "loki", "uid": "loki" },
-      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Value" },
+            "properties": [{ "id": "displayName", "value": "volume" }]
+          }
+        ]
+      },
       "gridPos": { "h": 8, "w": 10, "x": 14, "y": 10 },
       "id": 3,
       "options": {
@@ -62,13 +70,13 @@
         "showHeader": true,
         "sortBy": [{ "desc": true, "displayName": "volume" }]
       },
-      "title": "Top 10 services por volume",
+      "title": "Top 10 services por volume (últimos 5min)",
       "type": "table",
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
           "expr": "topk(10, sum by (service_name) (count_over_time({k8s_namespace_name=\"uniplus\"}[5m])))",
-          "legendFormat": "{{service_name}}",
+          "legendFormat": "",
           "refId": "A",
           "instant": true
         }
@@ -94,7 +102,7 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "{k8s_namespace_name=\"uniplus\",service_name=~\"$service\"} |~ \"(?i)(\\\\[ERR\\\\]|exception)\"",
+          "expr": "{k8s_namespace_name=\"uniplus\",service_name=~\"$service\"} |~ \"(?i)(\\[(ERR|WRN)\\]|exception)\"",
           "legendFormat": "",
           "refId": "A"
         }
@@ -147,5 +155,5 @@
   "timezone": "browser",
   "title": "Uni+ — Logs por service",
   "uid": "uniplus-logs-per-service",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
## Resumo

- Adiciona o dashboard **Uni+ — Logs por service** (`uniplus-logs-per-service`) com live tail, distribuição por severity via Loki `detected_level`, e volume por hora.

## Mudanças

### Novos arquivos
- `platform/observability/grafana/dashboards/uniplus-logs-per-service.json` — 5 painéis: live tail, distribuição severity, top 10 services por volume, logs de erro 15min, volume total/hora

## Painéis

| # | Tipo | Descrição |
|---|---|---|
| 1 | logs | Live tail todos os logs do $service selecionado |
| 2 | timeseries | Distribuição por `detected_level` (Loki auto-detect) |
| 3 | table | Top 10 services por volume (últimos 5min, instant query) |
| 4 | logs | Logs de erro/warning dos últimos 15min |
| 5 | timeseries | Volume total por hora (count_over_time [1h]) |

## Rastreabilidade

Closes #255
Refs #241 (Feature: dashboards operacionais)
Refs #240 (Epic: observabilidade Grafana)