### PR TITLE
fix(otelcol): remove sending_queue — chave removida no contrib 0.151.0

### DIFF
--- a/platform/observability/otelcol/values.yaml
+++ b/platform/observability/otelcol/values.yaml
@@ -156,9 +156,6 @@ otelCollector:
           enabled: true
           initial_interval: 5s
           max_elapsed_time: 60s   # fail fast — não acumular por 5 min (default) se Prometheus indisponível
-        sending_queue:
-          enabled: true
-          num_consumers: 5        # standalone não precisa dos 10 workers do default
       # Debug (stdout) — útil em dev; manter para troubleshooting.
       debug:
         verbosity: basic


### PR DESCRIPTION
## Resumo

Corrige CrashLoopBackOff do OTel Collector agent em produção.

## Problema

O exporter `prometheusremotewrite` no contrib v0.151.0 removeu o suporte ao campo `sending_queue` direto na config. O pod falhava na inicialização com:

```
'prometheusremotewriteexporter.Config' has invalid keys: sending_queue
```

## Solução

Remove o bloco `sending_queue` (5 workers default já aplicados internamente). O `retry_on_failure` permanece para resiliência.

## Impacto

Sem esta correção, métricas OTLP não chegam ao Prometheus (pipeline `metrics` não processa). Logs e traces funcionavam via Loki/Tempo (exporters `otlphttp/*` não afetados).

Closes #256