### PR TITLE
fix(grafana): usa hash do release name no prefixo dos ConfigMaps de dashboard

### DIFF
--- a/platform/observability/grafana/templates/dashboards.yaml
+++ b/platform/observability/grafana/templates/dashboards.yaml
@@ -5,9 +5,15 @@
   (requer `sidecar.dashboards.folderAnnotation: grafana_folder` no values).
   Naming: nome composto truncado em 63 chars (limite Kubernetes).
 */}}
+{{/*
+  Prefix: "gf-db-" (6) + hash[6] + "-" (1) = 13 chars → 50 chars de budget para o slug.
+  Usar hash do release name (em vez do fullname completo) garante unicidade por release
+  sem estourar o limite de 63 chars do Kubernetes, independente do tamanho do release name.
+*/}}
+{{- $hash := $.Release.Name | sha256sum | trunc 6 }}
+{{- $prefix := printf "gf-db-%s-" $hash }}
 {{- range $path, $content := .Files.Glob "dashboards/*.json" }}
 {{- $slug := base $path | trimSuffix ".json" }}
-{{- $prefix := printf "%s-db-" (include "grafana.fullname" $) }}
 {{- $budget := int (sub 63 (len $prefix)) }}
 ---
 apiVersion: v1

--- a/platform/observability/grafana/templates/dashboards.yaml
+++ b/platform/observability/grafana/templates/dashboards.yaml
@@ -12,9 +12,9 @@
 */}}
 {{- $hash := $.Release.Name | sha256sum | trunc 6 }}
 {{- $prefix := printf "gf-db-%s-" $hash }}
+{{- $budget := int (sub 63 (len $prefix)) }}
 {{- range $path, $content := .Files.Glob "dashboards/*.json" }}
 {{- $slug := base $path | trimSuffix ".json" }}
-{{- $budget := int (sub 63 (len $prefix)) }}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
## Problema

O prefixo do ConfigMap era gerado a partir de `grafana.fullname`, que inclui o release name completo. No ambiente standalone, o release name `platform-observability-grafana-uniplus-standalone-grafana` tem 57 chars; com o sufixo `-db-` o prefixo chegava a **61 chars**, deixando apenas **2 chars de budget** para o slug do dashboard.

Todos os slugs de dashboard começam com `uniplus-` → truncados para `un` → **colisão**: apenas um ConfigMap sobrevivia (nome `...-un`). Os 4 outros dashboards não eram provisionados pelo sidecar.

## Solução

Substituir o prefixo baseado no fullname por:

```
gf-db-{sha256[:6]}-
```

- `gf-db-` (6) + hash de 6 chars lowercase hex + `-` (1) = **13 chars fixos**
- Budget resultante: 63 − 13 = **50 chars** — suficiente para todos os slugs atuais (max 26 chars)
- Hash é determinístico entre upgrades (mesmo release name → mesmo hash)
- SHA-256 truncado em 6 chars hex = 16^6 ≈ 16 M valores; colisão entre releases coexistentes é negligível

## Evidência do bug (antes do fix)

```
kubectl get configmaps -A -l grafana_dashboard=1
# NAMESPACE      NAME
# observability-grafana   ...grafana-db-un   ← único ConfigMap, slug colide
```

## Após o fix

Esperado: 5 ConfigMaps distintos com nomes `gf-db-{hash}-uniplus-apis-red`, `gf-db-{hash}-uniplus-dotnet-runtime`, etc.

## Relacionado

Closes #227

Parte da Epic #240 (dashboards operacionais Grafana).