### PR TITLE
chore(deploy): bump APIs para v0.3.9

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.8"
+    tag: "v0.3.9"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.8"
+    tag: "v0.3.9"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.8"
+    tag: "v0.3.9"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
## Resumo

Atualiza a tag de imagem das 3 APIs do Uni+ de `v0.3.8` → `v0.3.9` nos charts Helm.

| Chart | Antes | Depois |
|---|---|---|
| `uniplus-api-selecao` | `v0.3.8` | `v0.3.9` |
| `uniplus-api-ingresso` | `v0.3.8` | `v0.3.9` |
| `uniplus-api-portal` | `v0.3.8` | `v0.3.9` |

## O que está na v0.3.9

- **Módulo Parametrizacao** — scaffolding completo (5 csprojs + fitness tests R8/R9)
- **Módulo OrganizacaoInstitucional** — `AreaOrganizacional`, `IAreaScopedEntity`, autorização por área
- **Métricas OTLP** — pipeline `.WithMetrics()` verificado via teste E2E com OtelCollector; métricas `http_server_request_duration_seconds` e `dotnet_gc_*` devem aparecer no Prometheus após este deploy
- **ADRs** — 8 ADRs do módulo Parametrizacao (ADR-0055 a ADR-0062)

Release: https://github.com/unifesspa-edu-br/uniplus-api/releases/tag/v0.3.9
Imagens: `ghcr.io/unifesspa-edu-br/uniplus-api-{selecao,ingresso,portal}:v0.3.9`