### PR TITLE
fix(otelcol): habilita resource_to_telemetry_conversion no prometheusremotewrite

### DIFF
--- a/platform/observability/otelcol/values.yaml
+++ b/platform/observability/otelcol/values.yaml
@@ -152,6 +152,12 @@ otelCollector:
         endpoint: ${env:PROMETHEUS_REMOTE_WRITE_ENDPOINT}
         tls:
           insecure: true
+        # Converte Resource attributes (service.name, service.namespace, etc.) em
+        # labels Prometheus. Sem isso os dashboards que filtram por
+        # service_namespace="uniplus" retornam vazio — o job label é gerado
+        # por default mas os demais resource attrs são descartados.
+        resource_to_telemetry_conversion:
+          enabled: true
         retry_on_failure:
           enabled: true
           initial_interval: 5s


### PR DESCRIPTION
## Resumo

- Adiciona `resource_to_telemetry_conversion: enabled: true` ao exporter `prometheusremotewrite` do OTel Collector
- Sem essa flag os Resource attributes OTel (`service.name`, `service.namespace`) não viram labels Prometheus — os dashboards Grafana que filtram por `service_namespace="uniplus"` ficam sem dados

## Causa raiz

Os dashboards usam queries como:
```promql
http_server_request_duration_seconds_count{service_namespace="uniplus",service_name=~"$service"}
```

Porém as métricas chegavam no Prometheus apenas com:
```
{job="uniplus/uniplus-selecao", http_route="/health", ...}
```

`service_namespace` e `service_name` estavam ausentes porque a conversão de Resource attributes → labels Prometheus não estava habilitada.

## Plano de teste

- [ ] Após merge + ArgoCD sync, consultar `http_server_request_duration_seconds_count{service_namespace="uniplus"}` no Prometheus — deve retornar séries para os 3 módulos
- [ ] Verificar `dotnet_gc_last_collection_heap_size_bytes{service_namespace="uniplus"}` — runtime metrics
- [ ] Abrir dashboards "Uni+ APIs — RED" e "Uni+ — .NET Runtime" no Grafana — dados visíveis

Closes #291