### PR TITLE
fix(grafana): corrige nomes de métricas no dashboard Uni+ .NET Runtime

### DIFF
--- a/platform/observability/grafana/dashboards/uniplus-dotnet-runtime.json
+++ b/platform/observability/grafana/dashboards/uniplus-dotnet-runtime.json
@@ -20,7 +20,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (service_name, dotnet_gc_heap_generation) (dotnet_gc_last_collection_heap_size{service_namespace=\"uniplus\",service_name=~\"$service\"})",
+          "expr": "sum by (service_name, dotnet_gc_heap_generation) (dotnet_gc_last_collection_heap_size_bytes{service_namespace=\"uniplus\",service_name=~\"$service\"})",
           "legendFormat": "{{service_name}} gen{{dotnet_gc_heap_generation}}",
           "refId": "A"
         }
@@ -80,7 +80,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "max by (service_name) (dotnet_thread_pool_queue_length{service_namespace=\"uniplus\",service_name=~\"$service\"})",
+          "expr": "max by (service_name) (dotnet_thread_pool_queue_length_total{service_namespace=\"uniplus\",service_name=~\"$service\"})",
           "legendFormat": "{{service_name}}",
           "refId": "A"
         }
@@ -135,14 +135,14 @@
       {
         "current": {},
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "definition": "label_values(dotnet_gc_last_collection_heap_size{service_namespace=\"uniplus\"}, service_name)",
+        "definition": "label_values(dotnet_gc_last_collection_heap_size_bytes{service_namespace=\"uniplus\"}, service_name)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "service",
         "options": [],
         "query": {
-          "query": "label_values(dotnet_gc_last_collection_heap_size{service_namespace=\"uniplus\"}, service_name)",
+          "query": "label_values(dotnet_gc_last_collection_heap_size_bytes{service_namespace=\"uniplus\"}, service_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/platform/observability/otelcol/values.yaml
+++ b/platform/observability/otelcol/values.yaml
@@ -152,6 +152,12 @@ otelCollector:
         endpoint: ${env:PROMETHEUS_REMOTE_WRITE_ENDPOINT}
         tls:
           insecure: true
+        # Converte Resource attributes (service.name, service.namespace, etc.) em
+        # labels Prometheus. Sem isso os dashboards que filtram por
+        # service_namespace="uniplus" retornam vazio — o job label é gerado
+        # por default mas os demais resource attrs são descartados.
+        resource_to_telemetry_conversion:
+          enabled: true
         retry_on_failure:
           enabled: true
           initial_interval: 5s


### PR DESCRIPTION
## Resumo

Corrige 2 nomes de métricas no dashboard **Uni+ — .NET Runtime** que não correspondiam ao que o `OpenTelemetry.Instrumentation.Runtime` v1.15.1 emite:

| Antes | Depois |
|---|---|
| `dotnet_gc_last_collection_heap_size` | `dotnet_gc_last_collection_heap_size_bytes` |
| `dotnet_thread_pool_queue_length` | `dotnet_thread_pool_queue_length_total` |

Todas as 6 métricas do dashboard foram validadas contra os nomes reais no Prometheus antes do commit.

## Plano de teste

- [ ] Após merge + ArgoCD sync (ConfigMap de dashboard atualizado), abrir "Uni+ — .NET Runtime" no Grafana
- [ ] Painel "GC Heap Size" exibe dados por geração (SOH/LOH/POH)
- [ ] Painel "Thread Pool Queue Length" exibe dados

Closes #293