### PR TITLE
fix(grafana): exibe 100% disponibilidade e 0% erro quando não há 5xx

### DIFF
--- a/platform/observability/grafana/dashboards/uniplus-apis-red.json
+++ b/platform/observability/grafana/dashboards/uniplus-apis-red.json
@@ -78,7 +78,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "1 - (sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[$__rate_interval])) / (sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\"}[$__rate_interval])) > 0))",
+          "expr": "1 - ((sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[$__rate_interval])) or vector(0)) / (sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\"}[$__rate_interval])) > 0))",
           "legendFormat": "disponibilidade",
           "refId": "A"
         }
@@ -117,7 +117,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[$__rate_interval])) / (sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\"}[$__rate_interval])) > 0)",
+          "expr": "(sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[$__rate_interval])) or vector(0)) / (sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\"}[$__rate_interval])) > 0)",
           "legendFormat": "erro 5xx",
           "refId": "A"
         }

--- a/platform/observability/grafana/dashboards/uniplus-dotnet-runtime.json
+++ b/platform/observability/grafana/dashboards/uniplus-dotnet-runtime.json
@@ -20,7 +20,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (service_name, dotnet_gc_heap_generation) (dotnet_gc_last_collection_heap_size{service_namespace=\"uniplus\",service_name=~\"$service\"})",
+          "expr": "sum by (service_name, dotnet_gc_heap_generation) (dotnet_gc_last_collection_heap_size_bytes{service_namespace=\"uniplus\",service_name=~\"$service\"})",
           "legendFormat": "{{service_name}} gen{{dotnet_gc_heap_generation}}",
           "refId": "A"
         }
@@ -80,7 +80,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "max by (service_name) (dotnet_thread_pool_queue_length{service_namespace=\"uniplus\",service_name=~\"$service\"})",
+          "expr": "max by (service_name) (dotnet_thread_pool_queue_length_total{service_namespace=\"uniplus\",service_name=~\"$service\"})",
           "legendFormat": "{{service_name}}",
           "refId": "A"
         }
@@ -135,14 +135,14 @@
       {
         "current": {},
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "definition": "label_values(dotnet_gc_last_collection_heap_size{service_namespace=\"uniplus\"}, service_name)",
+        "definition": "label_values(dotnet_gc_last_collection_heap_size_bytes{service_namespace=\"uniplus\"}, service_name)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "service",
         "options": [],
         "query": {
-          "query": "label_values(dotnet_gc_last_collection_heap_size{service_namespace=\"uniplus\"}, service_name)",
+          "query": "label_values(dotnet_gc_last_collection_heap_size_bytes{service_namespace=\"uniplus\"}, service_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/platform/observability/otelcol/values.yaml
+++ b/platform/observability/otelcol/values.yaml
@@ -152,6 +152,12 @@ otelCollector:
         endpoint: ${env:PROMETHEUS_REMOTE_WRITE_ENDPOINT}
         tls:
           insecure: true
+        # Converte Resource attributes (service.name, service.namespace, etc.) em
+        # labels Prometheus. Sem isso os dashboards que filtram por
+        # service_namespace="uniplus" retornam vazio — o job label é gerado
+        # por default mas os demais resource attrs são descartados.
+        resource_to_telemetry_conversion:
+          enabled: true
         retry_on_failure:
           enabled: true
           initial_interval: 5s


### PR DESCRIPTION
## Resumo

Corrige comportamento dos painéis SLO no dashboard **Uni+ APIs — RED**: quando o cluster está saudável (zero erros 5xx), os painéis exibiam "No data" em vez de 100% disponibilidade e 0% erro.

## Causa raiz

Prometheus retorna série **vazia** (não `0`) quando não há amostras com `http_response_status_code=~"5.."`. A divisão `vazio / total` propaga o vazio para o painel.

## Fix

`or vector(0)` no numerador das duas queries coerce vazio para zero quando há tráfego mas zero respostas 5xx. O painel continua sem dados se não houver tráfego algum — comportamento correto (guard `> 0` no denominador).

```promql
-- antes
sum(rate(...{status=~"5.."}[i])) / (sum(rate(...[i])) > 0)

-- depois  
(sum(rate(...{status=~"5.."}[i])) or vector(0)) / (sum(rate(...[i])) > 0)
```

## Plano de teste

- [ ] Com cluster saudável (zero 5xx): SLO Disponibilidade exibe 1 (100%), SLO Erro exibe 0 (0%)
- [ ] Com tráfego zero: ambos os painéis exibem "No data" — esperado

Closes #295