### PR TITLE
feat(observability): exclui rotas /health* das queries PromQL dos dashboards

### DIFF
--- a/platform/observability/grafana/dashboards/uniplus-apis-red.json
+++ b/platform/observability/grafana/dashboards/uniplus-apis-red.json
@@ -39,7 +39,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_namespace=\"uniplus\",service_name=~\"$service\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_namespace=\"uniplus\",service_name=~\"$service\",http_route!~\"/health(/.*)?\"}[$__rate_interval])))",
           "legendFormat": "p95",
           "refId": "A"
         }
@@ -78,7 +78,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "1 - ((sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[$__rate_interval])) or vector(0)) / (sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\"}[$__rate_interval])) > 0))",
+          "expr": "1 - ((sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\",http_route!~\"/health(/.*)?\"}[$__rate_interval])) or vector(0)) / (sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_route!~\"/health(/.*)?\"}[$__rate_interval])) > 0))",
           "legendFormat": "disponibilidade",
           "refId": "A"
         }
@@ -117,7 +117,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "(sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[$__rate_interval])) or vector(0)) / (sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\"}[$__rate_interval])) > 0)",
+          "expr": "(sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\",http_route!~\"/health(/.*)?\"}[$__rate_interval])) or vector(0)) / (sum(rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_route!~\"/health(/.*)?\"}[$__rate_interval])) > 0)",
           "legendFormat": "erro 5xx",
           "refId": "A"
         }
@@ -137,7 +137,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (service_name) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\"}[$__rate_interval]))",
+          "expr": "sum by (service_name) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_route!~\"/health(/.*)?\"}[$__rate_interval]))",
           "legendFormat": "{{ service_name }}",
           "refId": "A"
         }
@@ -157,7 +157,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (service_name) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"[45]..\"}[$__rate_interval])) / sum by (service_name) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\"}[$__rate_interval]))",
+          "expr": "sum by (service_name) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"[45]..\",http_route!~\"/health(/.*)?\"}[$__rate_interval])) / sum by (service_name) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_route!~\"/health(/.*)?\"}[$__rate_interval]))",
           "legendFormat": "{{ service_name }}",
           "refId": "A"
         }
@@ -181,7 +181,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "histogram_quantile(0.50, sum by (le, service_name, http_route) (rate(http_server_request_duration_seconds_bucket{service_namespace=\"uniplus\",service_name=~\"$service\",http_route=~\"$route\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le, service_name, http_route) (rate(http_server_request_duration_seconds_bucket{service_namespace=\"uniplus\",service_name=~\"$service\",http_route=~\"$route\",http_route!~\"/health(/.*)?\"}[5m])))",
           "legendFormat": "p50",
           "refId": "A",
           "instant": true,
@@ -189,7 +189,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "histogram_quantile(0.95, sum by (le, service_name, http_route) (rate(http_server_request_duration_seconds_bucket{service_namespace=\"uniplus\",service_name=~\"$service\",http_route=~\"$route\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, service_name, http_route) (rate(http_server_request_duration_seconds_bucket{service_namespace=\"uniplus\",service_name=~\"$service\",http_route=~\"$route\",http_route!~\"/health(/.*)?\"}[5m])))",
           "legendFormat": "p95",
           "refId": "B",
           "instant": true,
@@ -197,7 +197,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "histogram_quantile(0.99, sum by (le, service_name, http_route) (rate(http_server_request_duration_seconds_bucket{service_namespace=\"uniplus\",service_name=~\"$service\",http_route=~\"$route\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le, service_name, http_route) (rate(http_server_request_duration_seconds_bucket{service_namespace=\"uniplus\",service_name=~\"$service\",http_route=~\"$route\",http_route!~\"/health(/.*)?\"}[5m])))",
           "legendFormat": "p99",
           "refId": "C",
           "instant": true,
@@ -231,14 +231,14 @@
       {
         "current": {},
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "definition": "label_values(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\"}, http_route)",
+        "definition": "label_values(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_route!~\"/health(/.*)?\"},http_route)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "route",
         "options": [],
         "query": {
-          "query": "label_values(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\"}, http_route)",
+          "query": "label_values(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_route!~\"/health(/.*)?\"},http_route)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -252,5 +252,5 @@
   "timezone": "browser",
   "title": "Uni+ APIs — RED",
   "uid": "uniplus-apis-red",
-  "version": 2
+  "version": 3
 }

--- a/platform/observability/grafana/dashboards/uniplus-http-errors.json
+++ b/platform/observability/grafana/dashboards/uniplus-http-errors.json
@@ -29,13 +29,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[$__rate_interval]))",
+          "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\",http_route!~\"/health(/.*)?\"}[$__rate_interval]))",
           "legendFormat": "5xx {{http_response_status_code}}",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"4..\"}[$__rate_interval]))",
+          "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"4..\",http_route!~\"/health(/.*)?\"}[$__rate_interval]))",
           "legendFormat": "4xx {{http_response_status_code}}",
           "refId": "B"
         }
@@ -64,7 +64,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "topk(10, sum by (service_name, http_route) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[$__rate_interval])))",
+          "expr": "topk(10, sum by (service_name, http_route) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"5..\",http_route!~\"/health(/.*)?\"}[$__rate_interval])))",
           "legendFormat": "",
           "refId": "A",
           "instant": true,
@@ -95,7 +95,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "topk(10, sum by (service_name, http_route) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"4..\"}[$__rate_interval])))",
+          "expr": "topk(10, sum by (service_name, http_route) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_response_status_code=~\"4..\",http_route!~\"/health(/.*)?\"}[$__rate_interval])))",
           "legendFormat": "",
           "refId": "A",
           "instant": true,
@@ -117,7 +117,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\"}[$__rate_interval]))",
+          "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{service_namespace=\"uniplus\",service_name=~\"$service\",http_route!~\"/health(/.*)?\"}[$__rate_interval]))",
           "legendFormat": "{{http_response_status_code}}",
           "refId": "A"
         }
@@ -179,5 +179,5 @@
   "timezone": "browser",
   "title": "Uni+ — HTTP Errors detail",
   "uid": "uniplus-http-errors",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
## Resumo

- Adiciona `http_route!~"/health(/.*)?"` em todos os painéis de ambos os dashboards Grafana que consultam métricas `http_server_request_*`
- Atualiza o seletor de variável `$route` no dashboard RED para excluir health routes do dropdown

## Contexto

O SDK `OpenTelemetry.Instrumentation.AspNetCore` 1.15.1 não oferece filtro de métricas no `MeterProviderBuilder.AddAspNetCoreInstrumentation()` — apenas tracing suporta filtro via `AspNetCoreTraceInstrumentationOptions.Filter` (uniplus-api PR #509).

Portanto, a filtragem de métricas de health check só é possível nas queries PromQL do Grafana.

## Regex escolhido

`/health(/.*)?"` (RE2, anchored full-string match):
- Exclui `/health` e `/health/live`, `/health/ready`, `/health/startup`
- **Não** exclui `/healthz` — consistente com `PathString.StartsWithSegments` do SDK

## Dashboards atualizados

### `uniplus-apis-red.json` (v2 → v3, 13 ocorrências)
- SLO — Latência p95: bucket filter
- SLO — Disponibilidade: numerador 5xx e denominador total
- SLO — Taxa de erro 5xx: numerador 5xx e denominador total
- RPS por service: count filter
- Error rate por service (4xx+5xx): numerador e denominador
- p50/p95/p99 por route: 3 targets (p50, p95, p99)
- Variável `$route`: query `label_values` filtra health routes do dropdown

### `uniplus-http-errors.json` (v2 → v3, 5 ocorrências)
- Error rate timeseries: 5xx e 4xx
- Top 10 routes com 5xx
- Top 10 routes com 4xx
- Distribuição por status code

## Referências

Complementa uniplus-api PR #509 (tracing filter na fonte)
Refs unifesspa-edu-br/uniplus-api#508