### PR TITLE
chore(apps): bump uniplus-api para v0.3.10

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.9"
+    tag: "v0.3.10"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.9"
+    tag: "v0.3.10"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.9"
+    tag: "v0.3.10"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
Atualiza tag das 3 APIs (selecao, ingresso, portal) para .

Mudança incluída: filtragem de rotas `/health*` do TracerProvider OTel — probes Kubernetes não geram mais spans, corrigindo distorção em SLOs/latência. Ver unifesspa-edu-br/uniplus-api#509.