### PR TITLE
chore(deploy): atualiza APIs para v0.3.11 — fix nível de log Loki

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.10"
+    tag: "v0.3.11"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.10"
+    tag: "v0.3.11"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.10"
+    tag: "v0.3.11"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
Bump de v0.3.10 → v0.3.11 para os três serviços API.

**v0.3.11 inclui:**
- fix(logging): troca `{Level:u3}` por `{Level}` no `ConsoleOutputTemplate` do Serilog
  - Elimina a categoria `unknown` (64% dos logs) no painel Grafana "Logs per service"
  - Loki detecta agora `information`, `warning`, `error` em vez de `INF`/`WRN`/`ERR`
- test(logging): sentinela que impede regressão para `{Level:u3}`

Refs: uniplus-api#513, uniplus-api PR #514