### PR TITLE
chore(deploy): atualiza APIs para v0.3.12 — remove Console sink duplicado

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.11"
+    tag: "v0.3.12"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.11"
+    tag: "v0.3.12"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.11"
+    tag: "v0.3.12"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
Bump v0.3.11 → v0.3.12.

**v0.3.12 inclui:**
- fix(logging): remove WriteTo.Console e Using do appsettings.json dos 3 APIs — eliminava sink duplicado com template padrão Serilog ({Level:u3} → INF → Loki unknown)

Refs: uniplus-api#516, uniplus-api PR #517