### PR TITLE
fix(otelcol): extrai severity Serilog para Loki detected_level

### DIFF
--- a/platform/observability/otelcol/values.yaml
+++ b/platform/observability/otelcol/values.yaml
@@ -119,6 +119,25 @@ otelCollector:
           - key: dc
             value: standalone
             action: upsert
+      # Extrai severidade dos logs Serilog (formato bracket) para alimentar
+      # o Loki detected_level. Sem isso, logs do stdout das APIs (coletados
+      # via filelog) chegam sem severity_text e o Loki classifica como
+      # 'unknown'. Aplica somente quando severity_text não está preenchido
+      # — logs OTLP das apps já chegam com severity setada pelo SDK .NET.
+      #
+      # Formato Serilog (após fix Issue #513 — {Level} sem :u3):
+      #   [14:59:54 Information] End processing HTTP request...
+      # Regex extrai o nivel e seta severity_text + severity_number.
+      transform/serilog-severity:
+        log_statements:
+          - context: log
+            statements:
+              - 'set(severity_text, ExtractPatterns(body, "^\\[\\d{2}:\\d{2}:\\d{2} (?P<level>\\w+)\\]")["level"]) where severity_text == "" and IsMatch(body, "^\\[\\d{2}:\\d{2}:\\d{2} \\w+\\]")'
+              - 'set(severity_number, SEVERITY_NUMBER_DEBUG) where severity_text == "Debug"'
+              - 'set(severity_number, SEVERITY_NUMBER_INFO) where severity_text == "Information"'
+              - 'set(severity_number, SEVERITY_NUMBER_WARN) where severity_text == "Warning"'
+              - 'set(severity_number, SEVERITY_NUMBER_ERROR) where severity_text == "Error"'
+              - 'set(severity_number, SEVERITY_NUMBER_FATAL) where severity_text == "Fatal"'
       # k8sattributes é injetado pelo preset kubernetesAttributes.
 
     exporters:
@@ -170,10 +189,10 @@ otelCollector:
       extensions:
         - health_check
       pipelines:
-        # Logs: filelog (preset) + otlp (apps push) → resource → memory_limiter → batch → loki
+        # Logs: filelog (preset) + otlp (apps push) → memory_limiter → severity → resource → batch → loki
         logs:
           receivers: [otlp]                  # filelog adicionado pelo preset
-          processors: [memory_limiter, resource, batch]   # k8sattributes adicionado pelo preset
+          processors: [memory_limiter, transform/serilog-severity, resource, batch]   # k8sattributes adicionado pelo preset
           exporters: [otlphttp/loki, debug]
         # Traces: otlp → resource → memory_limiter → batch → tempo
         traces:


### PR DESCRIPTION
## Problema

O painel "Logs per service" do Grafana mostrava `detected_level=unknown` como categoria dominante (64% dos logs) mesmo após o fix do Issue #513 (substituição de `{Level:u3}` por `{Level}` no Serilog).

Raiz do problema em duas camadas:

| Stream | Origem | Antes do fix |
|--------|--------|-------------|
| `uniplus-selecao` / `uniplus-ingresso` / `uniplus-portal` | OTLP SDK .NET → OTel Collector | OK — SDK seta `severity_text` |
| `uniplus-api-*-uniplus-standalone` | filelog (stdout containerd) → OTel Collector → Loki | `unknown` — filelog não extrai severity do corpo do log |

O stream filelog lê o stdout dos containers (ex: `[14:59:54 Information] End processing...`), mas não popula `severity_text` no registro OTLP. O Loki não consegue inferir `detected_level` sem esse campo.

## Solução

Adiciona processor `transform/serilog-severity` ao pipeline de logs do OTel Collector:

```yaml
transform/serilog-severity:
  log_statements:
    - context: log
      statements:
        # Só aplica quando severity_text está vazio (logs filelog)
        # — logs OTLP já vêm com severity setada pelo SDK .NET
        - 'set(severity_text, ExtractPatterns(body, "^\\[\\d{2}:\\d{2}:\\d{2} (?P<level>\\w+)\\]")["level"]) where severity_text == "" and IsMatch(body, "^\\[\\d{2}:\\d{2}:\\d{2} \\w+\\]")'
        - 'set(severity_number, SEVERITY_NUMBER_INFO) where severity_text == "Information"'
        # ... Debug, Warning, Error, Fatal
```

Pipeline de logs: `[memory_limiter, transform/serilog-severity, resource, batch]`

**Guarda `severity_text == ""`**: logs OTLP já chegam com severity setada pelo SDK .NET — o processor não sobrescreve.

## Contexto

- Issue #513 (uniplus-api PR #514): fix `{Level:u3}` → `{Level}` no `ConsoleOutputTemplate` do Serilog — o texto do stdout agora mostra `Information` em vez de `INF`
- PR #300 (v0.3.12): removeu o Console sink duplicado do `appsettings.json` — logs deixaram de aparecer em duplicata
- **Este PR** completa o ciclo: OTel Collector agora extrai o nível do stdout e popula `severity_text` antes de enviar ao Loki

Closes #516

## Test plan

- [ ] ArgoCD sync aplica o novo DaemonSet do otelcol automaticamente
- [ ] Verificar em OCI via Loki API: `detected_level` do stream `uniplus-api-selecao-uniplus-standalone` deve retornar `info`/`warn`/`error` em vez de `unknown`
- [ ] Painel Grafana "Logs per service" não deve mais mostrar `unknown` como categoria dominante