### PR TITLE
chore(deploy): atualiza APIs para v0.3.13 — silencia logs OIDC health check

### DIFF
--- a/apps/uniplus-api-ingresso/values.yaml
+++ b/apps/uniplus-api-ingresso/values.yaml
@@ -15,7 +15,7 @@ uniplusApiIngresso:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-ingresso
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.12"
+    tag: "v0.3.13"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -15,7 +15,7 @@ uniplusApiPortal:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-portal
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.12"
+    tag: "v0.3.13"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/apps/uniplus-api-selecao/values.yaml
+++ b/apps/uniplus-api-selecao/values.yaml
@@ -15,7 +15,7 @@ uniplusApiSelecao:
     registry: ghcr.io
     repository: unifesspa-edu-br/uniplus-api-selecao
     # Sincronizar com tag publicada em GHCR.
-    tag: "v0.3.12"
+    tag: "v0.3.13"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []


### PR DESCRIPTION
Bump uniplus-api v0.3.12 → v0.3.13 nos 3 values.yaml (selecao/ingresso/portal).

**Mudanças em v0.3.13 (PR #519 / Issue #518):**
- Silencia logs `Information` do `OidcDiscoveryHealthCheck` via override Serilog em 5 módulos (selecao, ingresso, portal, organizacao-institucional, parametrizacao)
- Remove sink Console duplicado de organizacao-institucional e parametrizacao (mesmo fix do v0.3.12 para os outros 3 módulos)