### PR TITLE
fix(observability): filtra ruído de plataforma no Loki — Apicurio (89%) e regex dashboard

### DIFF
--- a/platform/observability/grafana/dashboards/uniplus-logs-traces.json
+++ b/platform/observability/grafana/dashboards/uniplus-logs-traces.json
@@ -204,7 +204,7 @@
         "options": [],
         "query": "label_values({k8s_namespace_name=\"uniplus\"}, service_name)",
         "refresh": 2,
-        "regex": "uniplus-.*",
+        "regex": "^uniplus-",
         "type": "query",
         "label": "Serviço"
       },

--- a/platform/observability/otelcol/values.yaml
+++ b/platform/observability/otelcol/values.yaml
@@ -138,6 +138,19 @@ otelCollector:
               - 'set(severity_number, SEVERITY_NUMBER_WARN) where severity_text == "Warning"'
               - 'set(severity_number, SEVERITY_NUMBER_ERROR) where severity_text == "Error"'
               - 'set(severity_number, SEVERITY_NUMBER_FATAL) where severity_text == "Fatal"'
+      # Descarta logs de serviços de plataforma que geram ruído sem valor para
+      # monitoração das APIs Uni+. Filtros aplicados antes do batch/exporter
+      # para evitar custo de armazenamento no Loki.
+      #
+      # Apicurio Registry: probe K8s em /apis/registry/v3/system/info a cada ~4s
+      # via JBossLoggingAccessLogReceiver — representava 89% do volume do namespace.
+      # ClamAV: saída de texto não estruturado do scanner, detected_level=unknown.
+      filter/drop-platform-noise:
+        error_mode: ignore
+        logs:
+          log_record:
+            - 'resource.attributes["service.name"] == "apicurio-registry-uniplus-standalone" and IsMatch(body, "system/info")'
+            - 'resource.attributes["service.name"] == "clamav-scanner-uniplus-standalone"'
       # k8sattributes é injetado pelo preset kubernetesAttributes.
 
     exporters:
@@ -192,7 +205,7 @@ otelCollector:
         # Logs: filelog (preset) + otlp (apps push) → memory_limiter → severity → resource → batch → loki
         logs:
           receivers: [otlp]                  # filelog adicionado pelo preset
-          processors: [memory_limiter, transform/serilog-severity, resource, batch]   # k8sattributes adicionado pelo preset
+          processors: [memory_limiter, filter/drop-platform-noise, transform/serilog-severity, resource, batch]   # k8sattributes adicionado pelo preset
           exporters: [otlphttp/loki, debug]
         # Traces: otlp → resource → memory_limiter → batch → tempo
         traces:


### PR DESCRIPTION
## Resumo

- Adiciona `filter/drop-platform-noise` no OTel Collector para descartar probes do Apicurio Registry e logs do ClamAV antes da ingestão no Loki
- Corrige regex `uniplus-.*` → `^uniplus-` na variável `service` do dashboard Logs & Traces

## Problema identificado em produção

Análise dos logs OCI standalone revelou que **89% do volume de logs no namespace `uniplus`** vinha do Apicurio Registry:

```
uniplus-api-selecao     15 (2,5%)   Information  ← nossas APIs
uniplus-selecao         15 (2,5%)   Information
apicurio-registry      540 (89,4%)  info          ← ruído puro
uniplus-ingresso/api     6 (1,0%)   Warning
clamav-scanner           3 (0,5%)   unknown
```

O Apicurio loga cada probe K8s liveness em `/apis/registry/v3/system/info` via `JBossLoggingAccessLogReceiver` (~1 log/4s = 17.000 logs/dia de ruído).

O ClamAV emite texto não estruturado (`detected_level=unknown`) sem valor para monitoração das APIs.

O regex `uniplus-.*` sem âncora `^` fazia match por substring, incluindo `apicurio-registry-uniplus-standalone` e `clamav-scanner-uniplus-standalone` no dropdown do dashboard.

## Mudanças

### `platform/observability/otelcol/values.yaml`

```yaml
filter/drop-platform-noise:
  error_mode: ignore
  logs:
    log_record:
      - 'resource.attributes["service.name"] == "apicurio-registry-uniplus-standalone" and IsMatch(body, "system/info")'
      - 'resource.attributes["service.name"] == "clamav-scanner-uniplus-standalone"'
```

Posicionado após `memory_limiter` e antes do `transform/serilog-severity` para eliminar o ruído o mais cedo possível no pipeline.

### `platform/observability/grafana/dashboards/uniplus-logs-traces.json`

```diff
-"regex": "uniplus-.*"
+"regex": "^uniplus-"
```

## Plano de teste

- [ ] ArgoCD sync da app `platform-observability-otelcol-uniplus-standalone` após merge
- [ ] Aguardar 5 min e verificar: `sum by (service_name) (count_over_time({k8s_namespace_name="uniplus"}[5m]))` não deve mostrar `apicurio-registry` nem `clamav`
- [ ] Dashboard "Uni+ — Logs & Traces": dropdown de serviços deve mostrar apenas serviços começando com `uniplus-`
- [ ] Logs das APIs (`uniplus-selecao`, `uniplus-ingresso`) continuam visíveis normalmente

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)