### PR TITLE
feat(observability): adiciona dashboard de frontends web

### DIFF
--- a/platform/observability/grafana/dashboards/uniplus-web.json
+++ b/platform/observability/grafana/dashboards/uniplus-web.json
@@ -56,7 +56,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "kube_deployment_status_replicas_available{namespace=\"uniplus\",deployment=\"uniplus-web-uniplus-standalone-uniplus-web-selecao\"}",
+          "expr": "kube_deployment_status_replicas_available{namespace=\"uniplus\",deployment=~\".*-uniplus-web-selecao\"}",
           "legendFormat": "selecao",
           "refId": "A"
         }
@@ -97,7 +97,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "kube_deployment_status_replicas_available{namespace=\"uniplus\",deployment=\"uniplus-web-uniplus-standalone-uniplus-web-ingresso\"}",
+          "expr": "kube_deployment_status_replicas_available{namespace=\"uniplus\",deployment=~\".*-uniplus-web-ingresso\"}",
           "legendFormat": "ingresso",
           "refId": "A"
         }
@@ -138,7 +138,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "kube_deployment_status_replicas_available{namespace=\"uniplus\",deployment=\"uniplus-web-uniplus-standalone-uniplus-web-portal\"}",
+          "expr": "kube_deployment_status_replicas_available{namespace=\"uniplus\",deployment=~\".*-uniplus-web-portal\"}",
           "legendFormat": "portal",
           "refId": "A"
         }
@@ -157,7 +157,7 @@
         "defaults": {
           "color": { "mode": "palette-classic" },
           "custom": { "lineWidth": 1 },
-          "unit": "percentunit"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -167,12 +167,12 @@
         "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
         "tooltip": { "mode": "multi", "sort": "desc" }
       },
-      "title": "CPU — frontends web",
+      "title": "CPU — frontends web (cores)",
       "type": "timeseries",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"uniplus\",pod=~\"uniplus-web-uniplus-standalone-uniplus-web-($app)-.*\",container!=\"POD\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"uniplus\",pod=~\".*-uniplus-web-($app)-.*\",container!=\"POD\",container!=\"\"}[$__rate_interval]))",
           "legendFormat": "{{ pod }}",
           "refId": "A"
         }
@@ -199,7 +199,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"uniplus\",pod=~\"uniplus-web-uniplus-standalone-uniplus-web-($app)-.*\",container!=\"POD\",container!=\"\"})",
+          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"uniplus\",pod=~\".*-uniplus-web-($app)-.*\",container!=\"POD\",container!=\"\"})",
           "legendFormat": "{{ pod }}",
           "refId": "A"
         }
@@ -236,7 +236,7 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(count_over_time({service_name=\"uniplus-web-uniplus-standalone\",k8s_deployment_name=~\".*-($app)\"}[$__range]))",
+          "expr": "sum(count_over_time({k8s_namespace_name=\"uniplus\",k8s_deployment_name=~\".*-uniplus-web-($app)\"}[$__range]))",
           "refId": "A",
           "instant": true
         }
@@ -273,7 +273,7 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(count_over_time({service_name=\"uniplus-web-uniplus-standalone\",k8s_deployment_name=~\".*-($app)\"} |~ `\" [45][0-9]{2} ` [$__range]))",
+          "expr": "sum(count_over_time({k8s_namespace_name=\"uniplus\",k8s_deployment_name=~\".*-uniplus-web-($app)\"} |~ `\" [45][0-9]{2} ` [$__range]))",
           "refId": "A",
           "instant": true
         }
@@ -309,7 +309,7 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum by (detected_level) (count_over_time({service_name=\"uniplus-web-uniplus-standalone\",k8s_deployment_name=~\".*-($app)\"}[$__rate_interval]))",
+          "expr": "sum by (detected_level) (count_over_time({k8s_namespace_name=\"uniplus\",k8s_deployment_name=~\".*-uniplus-web-($app)\"}[$__rate_interval]))",
           "legendFormat": "{{detected_level}}",
           "refId": "A"
         }
@@ -335,7 +335,7 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "{service_name=\"uniplus-web-uniplus-standalone\",k8s_deployment_name=~\".*-($app)\"}",
+          "expr": "{k8s_namespace_name=\"uniplus\",k8s_deployment_name=~\".*-uniplus-web-($app)\"}",
           "refId": "A"
         }
       ]

--- a/platform/observability/grafana/dashboards/uniplus-web.json
+++ b/platform/observability/grafana/dashboards/uniplus-web.json
@@ -1,0 +1,373 @@
+{
+  "annotations": { "list": [] },
+  "description": "Disponibilidade, recursos e logs dos 3 frontends Angular Uni+ (selecao, ingresso, portal). Fonte: Prometheus (kube-state-metrics, cAdvisor) + Loki (filelog nginx).",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "icon": "external link",
+      "tags": ["uniplus"],
+      "title": "APIs — RED",
+      "type": "dashboards",
+      "url": "/d/uniplus-apis-red"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 10,
+      "title": "Disponibilidade dos frontends",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "text": "INDISPONÍVEL" } }, "type": "value" },
+            { "options": { "from": 1, "to": 1e10, "result": { "text": "OK" } }, "type": "range" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",   "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "selecao — pods disponíveis",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "kube_deployment_status_replicas_available{namespace=\"uniplus\",deployment=\"uniplus-web-uniplus-standalone-uniplus-web-selecao\"}",
+          "legendFormat": "selecao",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "text": "INDISPONÍVEL" } }, "type": "value" },
+            { "options": { "from": 1, "to": 1e10, "result": { "text": "OK" } }, "type": "range" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",   "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "ingresso — pods disponíveis",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "kube_deployment_status_replicas_available{namespace=\"uniplus\",deployment=\"uniplus-web-uniplus-standalone-uniplus-web-ingresso\"}",
+          "legendFormat": "ingresso",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "text": "INDISPONÍVEL" } }, "type": "value" },
+            { "options": { "from": 1, "to": 1e10, "result": { "text": "OK" } }, "type": "range" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",   "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "portal — pods disponíveis",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "kube_deployment_status_replicas_available{namespace=\"uniplus\",deployment=\"uniplus-web-uniplus-standalone-uniplus-web-portal\"}",
+          "legendFormat": "portal",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 11,
+      "title": "Recursos (K8s — cAdvisor)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1 },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "CPU — frontends web",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"uniplus\",pod=~\"uniplus-web-uniplus-standalone-uniplus-web-($app)-.*\",container!=\"POD\",container!=\"\"}[$__rate_interval]))",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1 },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Memória (working set) — frontends web",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"uniplus\",pod=~\"uniplus-web-uniplus-standalone-uniplus-web-($app)-.*\",container!=\"POD\",container!=\"\"})",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 12,
+      "title": "Logs nginx",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "blue", "mode": "fixed" },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 15 },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "Volume de logs (período)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(count_over_time({service_name=\"uniplus-web-uniplus-standalone\"}[$__range]))",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "red", "mode": "fixed" },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red",   "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 15 },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "Erros no período (Error/Warning)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(count_over_time({service_name=\"uniplus-web-uniplus-standalone\", detected_level=~\"Error|error|Warning|warn\"}[$__range]))",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Error" },      "properties": [{ "id": "color", "value": { "fixedColor": "red",    "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "Warning" },    "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "Information" },"properties": [{ "id": "color", "value": { "fixedColor": "blue",   "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "unknown" },    "properties": [{ "id": "color", "value": { "fixedColor": "gray",   "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 4, "w": 12, "x": 12, "y": 15 },
+      "id": 8,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Logs por nível — frontends",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum by (detected_level) (count_over_time({service_name=\"uniplus-web-uniplus-standalone\"}[$__interval]))",
+          "legendFormat": "{{detected_level}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 14, "w": 24, "x": 0, "y": 19 },
+      "id": 9,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "title": "Logs nginx — frontends",
+      "type": "logs",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{service_name=\"uniplus-web-uniplus-standalone\"}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["uniplus", "web", "frontend", "nginx", "disponibilidade"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "app",
+        "options": [
+          { "selected": false, "text": "selecao",  "value": "selecao"  },
+          { "selected": false, "text": "ingresso",  "value": "ingresso"  },
+          { "selected": false, "text": "portal",   "value": "portal"   }
+        ],
+        "query": "selecao,ingresso,portal",
+        "allValue": "selecao|ingresso|portal",
+        "type": "custom",
+        "label": "App"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Uni+ — Frontends Web",
+  "uid": "uniplus-web",
+  "version": 1
+}

--- a/platform/observability/grafana/dashboards/uniplus-web.json
+++ b/platform/observability/grafana/dashboards/uniplus-web.json
@@ -236,7 +236,7 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(count_over_time({service_name=\"uniplus-web-uniplus-standalone\"}[$__range]))",
+          "expr": "sum(count_over_time({service_name=\"uniplus-web-uniplus-standalone\",k8s_deployment_name=~\".*-($app)\"}[$__range]))",
           "refId": "A",
           "instant": true
         }
@@ -268,12 +268,12 @@
         "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
         "textMode": "auto"
       },
-      "title": "Erros no período (Error/Warning)",
+      "title": "Erros HTTP 4xx/5xx (período)",
       "type": "stat",
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(count_over_time({service_name=\"uniplus-web-uniplus-standalone\", detected_level=~\"Error|error|Warning|warn\"}[$__range]))",
+          "expr": "sum(count_over_time({service_name=\"uniplus-web-uniplus-standalone\",k8s_deployment_name=~\".*-($app)\"} |~ `\" [45][0-9]{2} ` [$__range]))",
           "refId": "A",
           "instant": true
         }
@@ -309,7 +309,7 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum by (detected_level) (count_over_time({service_name=\"uniplus-web-uniplus-standalone\"}[$__interval]))",
+          "expr": "sum by (detected_level) (count_over_time({service_name=\"uniplus-web-uniplus-standalone\",k8s_deployment_name=~\".*-($app)\"}[$__rate_interval]))",
           "legendFormat": "{{detected_level}}",
           "refId": "A"
         }
@@ -330,12 +330,12 @@
         "sortOrder": "Descending",
         "wrapLogMessage": false
       },
-      "title": "Logs nginx — frontends",
+      "title": "Logs nginx — frontends ($app)",
       "type": "logs",
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "{service_name=\"uniplus-web-uniplus-standalone\"}",
+          "expr": "{service_name=\"uniplus-web-uniplus-standalone\",k8s_deployment_name=~\".*-($app)\"}",
           "refId": "A"
         }
       ]


### PR DESCRIPTION
## Resumo

- Dashboard `uniplus-web` com uid `uniplus-web` para os 3 frontends Angular (selecao, ingresso, portal)
- Disponibilidade via `kube_deployment_status_replicas_available` (kube-state-metrics): stat verde/vermelho por deployment
- Recursos via cAdvisor: timeseries de CPU (`container_cpu_usage_seconds_total`) e memória working set por pod
- Logs nginx via Loki (`service_name="uniplus-web-uniplus-standalone"`): volume total, contagem de erros/warnings, distribuição por nível e painel raw
- Variável `$app` (selecao/ingresso/portal) para filtrar os painéis de recursos e logs

## Detalhes técnicos

- `schemaVersion: 38`, `refresh: 30s`, `uid: uniplus-web`
- Datasources: `prometheus` (kube-state + cAdvisor) e `loki` (filelog nginx)
- Link de navegação para o dashboard `uniplus-apis-red`

Closes #307