### PR TITLE
feat(observability): adiciona dashboard do Traefik (ingress controller)

### DIFF
--- a/platform/observability/grafana/dashboards/uniplus-traefik.json
+++ b/platform/observability/grafana/dashboards/uniplus-traefik.json
@@ -87,8 +87,7 @@
         {
           "datasource": { "type": "loki", "uid": "loki" },
           "expr": "sum(rate({service_name=\"platform-traefik-uniplus-standalone-traefik\"}[$__rate_interval]))",
-          "refId": "A",
-          "instant": true
+          "refId": "A"
         }
       ]
     },
@@ -248,19 +247,19 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "quantile_over_time(0.50, {service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | unwrap Duration [$__interval])",
+          "expr": "quantile_over_time(0.50, {service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | unwrap Duration [$__rate_interval])",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "quantile_over_time(0.95, {service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | unwrap Duration [$__interval])",
+          "expr": "quantile_over_time(0.95, {service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | unwrap Duration [$__rate_interval])",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "quantile_over_time(0.99, {service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | unwrap Duration [$__interval])",
+          "expr": "quantile_over_time(0.99, {service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | unwrap Duration [$__rate_interval])",
           "legendFormat": "p99",
           "refId": "C"
         }

--- a/platform/observability/grafana/dashboards/uniplus-traefik.json
+++ b/platform/observability/grafana/dashboards/uniplus-traefik.json
@@ -1,0 +1,329 @@
+{
+  "annotations": { "list": [] },
+  "description": "Disponibilidade, tráfego HTTP e logs de acesso do Traefik (ingress controller). Fonte: kube-state-metrics (pod) + Loki (JSON access log).",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "icon": "external link",
+      "tags": ["uniplus"],
+      "title": "APIs — RED",
+      "type": "dashboards",
+      "url": "/d/uniplus-apis-red"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 10,
+      "title": "Disponibilidade",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "text": "INDISPONÍVEL" } }, "type": "value" },
+            { "options": { "from": 1, "to": 1e10, "result": { "text": "OK" } }, "type": "range" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",   "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "Traefik — pods disponíveis",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "kube_deployment_status_replicas_available{namespace=\"traefik\",deployment=\"platform-traefik-uniplus-standalone\"}",
+          "legendFormat": "traefik",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "blue", "mode": "fixed" },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "Req/s (agora)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(rate({service_name=\"platform-traefik-uniplus-standalone-traefik\"}[$__rate_interval]))",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "red", "mode": "fixed" },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red",   "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "5xx no período",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(count_over_time({service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= 500 [$__range]))",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "orange", "mode": "fixed" },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "orange", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "4xx no período",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(count_over_time({service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= 400 | DownstreamStatus < 500 [$__range]))",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 11,
+      "title": "Tráfego HTTP (Loki — access log)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "2xx" }, "properties": [{ "id": "color", "value": { "fixedColor": "green",  "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "3xx" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue",   "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "4xx" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "5xx" }, "properties": [{ "id": "color", "value": { "fixedColor": "red",    "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Requests/s por status",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(rate({service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= 200 | DownstreamStatus < 300 [$__rate_interval]))",
+          "legendFormat": "2xx",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(rate({service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= 300 | DownstreamStatus < 400 [$__rate_interval]))",
+          "legendFormat": "3xx",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(rate({service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= 400 | DownstreamStatus < 500 [$__rate_interval]))",
+          "legendFormat": "4xx",
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(rate({service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= 500 [$__rate_interval]))",
+          "legendFormat": "5xx",
+          "refId": "D"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1 },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Latência (Duration — p50/p95/p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "quantile_over_time(0.50, {service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | unwrap Duration [$__interval])",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "quantile_over_time(0.95, {service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | unwrap Duration [$__interval])",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "quantile_over_time(0.99, {service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | unwrap Duration [$__interval])",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 12,
+      "title": "Logs de acesso Traefik",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 14, "w": 24, "x": 0, "y": 15 },
+      "id": 7,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "title": "Access log — Traefik (status ≥ $min_status)",
+      "type": "logs",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= $min_status",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["uniplus", "traefik", "ingress", "http", "disponibilidade"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": true, "text": "100", "value": "100" },
+        "hide": 0,
+        "name": "min_status",
+        "options": [
+          { "selected": true,  "text": "Todos (>=100)", "value": "100" },
+          { "selected": false, "text": "4xx e 5xx (>=400)", "value": "400" },
+          { "selected": false, "text": "5xx apenas (>=500)", "value": "500" }
+        ],
+        "query": "100,400,500",
+        "type": "custom",
+        "label": "Filtro status",
+        "allValue": null
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Uni+ — Traefik (Ingress)",
+  "uid": "uniplus-traefik",
+  "version": 1
+}

--- a/platform/observability/grafana/dashboards/uniplus-traefik.json
+++ b/platform/observability/grafana/dashboards/uniplus-traefik.json
@@ -56,7 +56,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "kube_deployment_status_replicas_available{namespace=\"traefik\",deployment=\"platform-traefik-uniplus-standalone\"}",
+          "expr": "kube_deployment_status_replicas_available{namespace=\"traefik\",deployment=~\"platform-traefik-.*\"}",
           "legendFormat": "traefik",
           "refId": "A"
         }
@@ -86,7 +86,7 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(rate({service_name=\"platform-traefik-uniplus-standalone-traefik\"}[$__rate_interval]))",
+          "expr": "sum(rate({service_name=~\"platform-traefik-.*\"}[$__rate_interval]))",
           "refId": "A"
         }
       ]
@@ -122,7 +122,7 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(count_over_time({service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= 500 [$__range]))",
+          "expr": "sum(count_over_time({service_name=~\"platform-traefik-.*\"} | json | DownstreamStatus >= 500 [$__range]))",
           "refId": "A",
           "instant": true
         }
@@ -159,7 +159,7 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(count_over_time({service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= 400 | DownstreamStatus < 500 [$__range]))",
+          "expr": "sum(count_over_time({service_name=~\"platform-traefik-.*\"} | json | DownstreamStatus >= 400 | DownstreamStatus < 500 [$__range]))",
           "refId": "A",
           "instant": true
         }
@@ -202,25 +202,25 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(rate({service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= 200 | DownstreamStatus < 300 [$__rate_interval]))",
+          "expr": "sum(rate({service_name=~\"platform-traefik-.*\"} | json | DownstreamStatus >= 200 | DownstreamStatus < 300 [$__rate_interval]))",
           "legendFormat": "2xx",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(rate({service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= 300 | DownstreamStatus < 400 [$__rate_interval]))",
+          "expr": "sum(rate({service_name=~\"platform-traefik-.*\"} | json | DownstreamStatus >= 300 | DownstreamStatus < 400 [$__rate_interval]))",
           "legendFormat": "3xx",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(rate({service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= 400 | DownstreamStatus < 500 [$__rate_interval]))",
+          "expr": "sum(rate({service_name=~\"platform-traefik-.*\"} | json | DownstreamStatus >= 400 | DownstreamStatus < 500 [$__rate_interval]))",
           "legendFormat": "4xx",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(rate({service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= 500 [$__rate_interval]))",
+          "expr": "sum(rate({service_name=~\"platform-traefik-.*\"} | json | DownstreamStatus >= 500 [$__rate_interval]))",
           "legendFormat": "5xx",
           "refId": "D"
         }
@@ -247,19 +247,19 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "quantile_over_time(0.50, {service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | unwrap Duration [$__rate_interval])",
+          "expr": "quantile_over_time(0.50, {service_name=~\"platform-traefik-.*\"} | json | unwrap Duration [$__rate_interval])",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "quantile_over_time(0.95, {service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | unwrap Duration [$__rate_interval])",
+          "expr": "quantile_over_time(0.95, {service_name=~\"platform-traefik-.*\"} | json | unwrap Duration [$__rate_interval])",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "quantile_over_time(0.99, {service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | unwrap Duration [$__rate_interval])",
+          "expr": "quantile_over_time(0.99, {service_name=~\"platform-traefik-.*\"} | json | unwrap Duration [$__rate_interval])",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -292,7 +292,7 @@
       "targets": [
         {
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "{service_name=\"platform-traefik-uniplus-standalone-traefik\"} | json | DownstreamStatus >= $min_status",
+          "expr": "{service_name=~\"platform-traefik-.*\"} | json | DownstreamStatus >= $min_status",
           "refId": "A"
         }
       ]


### PR DESCRIPTION
## Resumo

- Dashboard `uniplus-traefik` com uid `uniplus-traefik` para monitoração do Traefik como ingress controller do cluster
- Disponibilidade via `kube_deployment_status_replicas_available{namespace="traefik",deployment="platform-traefik-uniplus-standalone"}` (kube-state-metrics)
- Tráfego HTTP extraído do JSON access log via Loki LogQL:
  - Req/s atual, contagem de 4xx e 5xx no período selecionado
  - Timeseries empilhado de requests/s por categoria (2xx/3xx/4xx/5xx) com cores fixas
  - Latência p50/p95/p99 usando `unwrap Duration` (campo nanosegundos do JSON do Traefik), unit `ns` com autoformat do Grafana
- Painel de logs de acesso raw com variável `$min_status` para filtrar por status mínimo (100/400/500)

## Detalhes técnicos

- `schemaVersion: 38`, `refresh: 30s`, `uid: uniplus-traefik`
- Service name Loki: `platform-traefik-uniplus-standalone-traefik` (filelog via OTel Collector DaemonSet)
- JSON access log: campos `DownstreamStatus` (int), `Duration` (ns), `RequestPath`, `RouterName`, `ServiceName`
- Datasources: `prometheus` (kube-state) e `loki` (JSON access log)
- Link de navegação para dashboard `uniplus-apis-red`

Closes #308