### PR TITLE
feat(oci): modulo Tofu iad-arm — esqueleto para lab A1 ARM em us-ashburn-1

### DIFF
--- a/provisioning/oci/iad-arm/.gitignore
+++ b/provisioning/oci/iad-arm/.gitignore
@@ -1,0 +1,15 @@
+# OpenTofu / Terraform
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfvars
+!terraform.tfvars.example
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc

--- a/provisioning/oci/iad-arm/README.md
+++ b/provisioning/oci/iad-arm/README.md
@@ -113,7 +113,17 @@ ssh ubuntu@<k8s-host-ip> "ssh ubuntu@10.1.2.x 'sudo growpart /dev/sdb 1 && sudo 
 $EDITOR terraform.tfvars   # profile = "hml_arm"  (cobra ~$25/mês de A1 paga)
 tofu apply
 
-# Recriar do zero (cuidado — destrutivo total; preserva apenas Reserved Public IP)
+# Recriar do zero (CUIDADO — destrutivo total: destroi VMs, volumes, VCN
+# E o Reserved Public IP). Apos `tofu apply` subsequente, o RESERVED IP
+# alocado sera DIFERENTE — DNS records, callback URLs do gov.br,
+# Let's Encrypt certs e KC_HOSTNAME precisam ser reconfigurados.
+#
+# Para preservar o IP entre destroy/apply, ha duas opcoes:
+#   1. Adicionar `lifecycle { prevent_destroy = true }` ao
+#      `oci_core_public_ip.k8s_host` (forca destroy parcial — exclui o IP)
+#   2. `tofu state rm oci_core_public_ip.k8s_host` antes do destroy +
+#      `tofu import oci_core_public_ip.k8s_host <ocid>` apos o apply
+# Em qualquer caso, o IP nao volta automaticamente.
 tofu destroy
 tofu apply
 ```

--- a/provisioning/oci/iad-arm/README.md
+++ b/provisioning/oci/iad-arm/README.md
@@ -28,7 +28,7 @@ KMS Vault + Master Encryption Key, Dynamic Group, IAM Policy.
 | Imagem | Ubuntu 24.04 LTS x86_64 | Ubuntu 24.04 LTS **aarch64** |
 | Profile default | `poc` (3 OCPU / 16 GB E5) | `poc_arm` (3 OCPU / 16 GB A1) |
 | VCN CIDR | 10.0.0.0/16 | 10.1.0.0/16 |
-| Block volumes | 550 GB total (postgres 200 + kafka 100 + minio 200 + vault 50) | 200 GB total (postgres 80 + kafka 40 + minio 60 + vault 20) — cabe Always Free |
+| Block volumes | 550 GB total (postgres 200 + kafka 100 + minio 200 + vault 50) | 150 GB total (postgres 15 + kafka 15 + minio 110 + vault 10) — prioriza MinIO para logs; 50 GB de folga sob o limite Always Free de 200 GB |
 | Tag `uniplus_environment` | `standalone` | `iad-arm` |
 | DNS subdomínio | `*.standalone.portaluni.com.br` | `*.iad-arm.portaluni.com.br` |
 | Custo (PAYG estimado) | ~$108/mês | ~$0-3/mês (compute + storage Always Free) |

--- a/provisioning/oci/iad-arm/README.md
+++ b/provisioning/oci/iad-arm/README.md
@@ -197,10 +197,10 @@ tofu apply     # IP novo, diferente do anterior
 ### Recriar do zero PRESERVANDO o Reserved IP
 
 Duas sequências corretas para preservar o IP entre rebuilds (a ingênua
-`tofu destroy && tofu apply` rotaciona). OpenTofu ≥ 1.7 obrigatório para
+`tofu destroy && tofu apply` rotaciona). OpenTofu ≥ 1.9 obrigatório para
 `-exclude`.
 
-**Opção A (preferida) — `--exclude` no destroy** (OpenTofu ≥ 1.7):
+**Opção A (preferida) — `--exclude` no destroy** (OpenTofu ≥ 1.9):
 
 ```bash
 # 1. Destrói TUDO menos o IP. Restante das resources e data sources que
@@ -228,7 +228,7 @@ resource "oci_core_public_ip" "k8s_host" {
 > `Instance cannot be destroyed`. Não é "exclusão automática" — apenas
 > aborta o destroy se você esquecer do `-exclude`.
 
-**Opção B — `state rm` + `import` (compatível com OpenTofu < 1.7)**:
+**Opção B — `state rm` + `import` (compatível com OpenTofu < 1.9)**:
 
 ```bash
 # 1. Salvar OCID atual do IP antes de mexer

--- a/provisioning/oci/iad-arm/README.md
+++ b/provisioning/oci/iad-arm/README.md
@@ -57,21 +57,23 @@ Key, Dynamic Group, IAM Policy.
 
 ### Gate de validação operacional (Story #319/T1.1.3)
 
-Como a documentação Oracle é literal mas a prática da comunidade reporta A1
-cross-region funcionando sem cobrança, validar empiricamente ANTES de
-provisionar o lab completo:
+Validação parcial executada em 2026-05-19 02:03-02:11 UTC via OCI CLI:
 
-1. Após `oci compute image list` em IAD (T1.1.2), criar **1** instância A1
-   small (1 OCPU / 6 GB) no console OCI ou via `oci compute instance launch`
-2. Aguardar 30 min e checar `OCI Console → Cost Management → Cost Analysis`
-   filtrando por `Service=Compute Always Free` vs `Service=Compute`
-3. **Se cobrar PAYG**: docs estão corretas, custo do README ~$80/mês confirmado
-4. **Se aparecer como Always Free**: docs estão desatualizadas vs prática, revisar
-   README de volta para ~$42/mês e atualizar Epic #317
-5. Tear down a instância de teste antes de prosseguir com Story #329
+| Etapa | Resultado |
+|---|---|
+| `oci iam region-subscription list` | IAD já READY (subscrita) |
+| `oci compute image list --shape VM.Standard.A1.Flex` em IAD | imagem Ubuntu 24.04 aarch64 encontrada |
+| `oci compute instance launch` 1 OCPU / 1 GB em `mixQ:US-ASHBURN-AD-1` | ✓ **API aceitou sem rejeitar por home region** |
+| Instance lifecycle até `RUNNING` | ✓ ~30s, normal |
+| `oci usage-api request-summarized-usages` | inconclusivo — Usage API tem delay ~1h, dados não disponíveis no momento do teste |
 
-PAYG já ativo na tenancy desde a Feature #43, então qualquer cobrança aparece
-no billing imediatamente.
+**Achado parcial:** A doc Oracle diz literalmente `"must create in home region"` mas o API **não bloqueia** a criação em região não-home. Resta confirmar via billing se A1 em IAD é classificado como Always Free ou PAYG.
+
+**Próximo passo (Story #319/T1.1.3 ou follow-up):** repetir o teste deixando a instância rodar por ≥1h e re-query `oci usage-api` filtrando por `region=us-ashburn-1` e `service=Compute`:
+- Se aparecer com `computed-amount > 0` → PAYG confirmado, README ~$80/mês mantido
+- Se aparecer com `computed-amount = 0` ou ausente → Always Free aplica cross-region, revisar README para ~$42/mês e atualizar Epic #317
+
+PAYG já ativo na tenancy desde a Feature #43, então qualquer cobrança aparece no billing imediatamente após o flush (~1-2h).
 
 ## Pré-requisitos
 
@@ -152,7 +154,13 @@ ssh ubuntu@<k8s-host-ip> "ssh ubuntu@10.1.2.x 'sudo growpart /dev/sdb 1 && sudo 
 # Reduzir abaixo do mínimo de 50 GB NÃO é possível (CreateVolume rejeita).
 
 # Mudar perfil de capacidade
-$EDITOR terraform.tfvars   # profile = "hml_arm"  (cobra ~$25/mês de A1 paga)
+# poc_arm (default): 3 OCPU / 16 GB → ~$39/mês compute em IAD (PAYG, ver
+#                    cost table no topo do README)
+# hml_arm:           6 OCPU / 40 GB → ~$86/mês compute em IAD
+#                    (6 × $0.01/h + 40 × $0.0015/h ≈ $86.40/mês), total
+#                    com storage e NAT ~$127/mês — JÁ ULTRAPASSA o GRU
+#                    atual; só fazer sentido pós elimination do NAT GW.
+$EDITOR terraform.tfvars   # profile = "hml_arm"
 tofu apply
 
 # Recriar do zero (CUIDADO — destrutivo total: destroi VMs, volumes, VCN

--- a/provisioning/oci/iad-arm/README.md
+++ b/provisioning/oci/iad-arm/README.md
@@ -1,0 +1,144 @@
+# OpenTofu — iad-arm OCI
+
+Provisionamento OpenTofu do lab Uni+ em **`us-ashburn-1` (IAD)** sobre
+**`VM.Standard.A1.Flex`** (ARM Ampere). Esqueleto da Story
+[#323](https://github.com/unifesspa-edu-br/uniplus-infra/issues/323) (parte do
+Epic [#317](https://github.com/unifesspa-edu-br/uniplus-infra/issues/317) —
+migração do lab de GRU/E5 para IAD/A1 antes do trial OCI expirar em
+2026-06-03).
+
+Cobertura: VCN (10.1.0.0/16), 2 subnets, IGW, NAT GW, 2 route tables, 2
+security lists, 2 VMs A1.Flex (k8s-host + data-host), 4 block volumes ≤200 GB
+total, Reserved Public IP, 11 DNS records sob `iad-arm.portaluni.com.br`,
+KMS Vault + Master Encryption Key, Dynamic Group, IAM Policy.
+
+> **Paralelo a `provisioning/oci/standalone/`:** este módulo NÃO substitui o
+> lab GRU enquanto a migração não completar. Os dois coexistem durante a
+> janela: `standalone.portaluni.com.br` aponta para GRU, `iad-arm.portaluni.com.br`
+> aponta para IAD. O cutover final (Story
+> [#359](https://github.com/unifesspa-edu-br/uniplus-infra/issues/359))
+> reaponta o domínio canônico e destrói o lab GRU.
+
+## Diferenças vs `provisioning/oci/standalone/`
+
+| Atributo | standalone (GRU) | iad-arm (IAD) |
+|---|---|---|
+| Região | `sa-saopaulo-1` | `us-ashburn-1` |
+| Shape | `VM.Standard.E5.Flex` (AMD x86) | `VM.Standard.A1.Flex` (ARM Ampere) |
+| Imagem | Ubuntu 24.04 LTS x86_64 | Ubuntu 24.04 LTS **aarch64** |
+| Profile default | `poc` (3 OCPU / 16 GB E5) | `poc_arm` (3 OCPU / 16 GB A1) |
+| VCN CIDR | 10.0.0.0/16 | 10.1.0.0/16 |
+| Block volumes | 550 GB total (postgres 200 + kafka 100 + minio 200 + vault 50) | 200 GB total (postgres 80 + kafka 40 + minio 60 + vault 20) — cabe Always Free |
+| Tag `uniplus_environment` | `standalone` | `iad-arm` |
+| DNS subdomínio | `*.standalone.portaluni.com.br` | `*.iad-arm.portaluni.com.br` |
+| Custo (PAYG estimado) | ~$108/mês | ~$0-3/mês (compute + storage Always Free) |
+
+## Pré-requisitos
+
+- OpenTofu ≥ 1.6 (testado com 1.11.6)
+- Tenancy unifesspa-edu-br em modo **PAYG** (Always Free puro não permite
+  subscrição de região adicional — bloqueio confirmado em `TenantCapacityExceeded`)
+- Região `us-ashburn-1` assinada na tenancy
+  ([Task #320](https://github.com/unifesspa-edu-br/uniplus-infra/issues/320))
+- `oci` CLI configurado com permissão `manage` em `instance-family` +
+  `volume-family` no compartment alvo
+
+## Placeholders pendentes (REPLACE_AFTER_T1_1_2)
+
+Os defaults de `variables.tf` contêm 2 strings literais `REPLACE_AFTER_T1_1_2`
+em `availability_domain` e `image_ocid` que precisam ser substituídas após
+[Task #321](https://github.com/unifesspa-edu-br/uniplus-infra/issues/321):
+
+```bash
+# 1. Listar AD em IAD (após subscrição estar READY)
+oci iam availability-domain list --region us-ashburn-1 \
+  --compartment-id "$TENANCY" \
+  --query 'data[0].name' --raw-output
+
+# 2. Listar imagem Ubuntu 24.04 LTS aarch64 mais recente para A1.Flex
+oci compute image list --region us-ashburn-1 \
+  --compartment-id "$TENANCY" \
+  --operating-system "Canonical Ubuntu" \
+  --operating-system-version 24.04 \
+  --shape VM.Standard.A1.Flex \
+  --sort-by TIMECREATED --sort-order DESC \
+  --query 'data[0].id' --raw-output
+```
+
+Os 2 valores entram em `terraform.tfvars` (não em `variables.tf` — defaults
+ficam com placeholder no git para sinalizar pendência).
+
+## Setup inicial
+
+```bash
+cd provisioning/oci/iad-arm
+
+# 1. Copiar tfvars de exemplo e preencher OCIDs/SSH key/AD/image
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars
+
+# 2. Inicializar provider + plugins
+tofu init
+
+# 3. Validar sintaxe (rodável SEM access OCI)
+tofu validate
+
+# 4. Plan (precisa de OCI access para resolver data sources como dns_zones)
+tofu plan -out=plan.bin
+
+# 5. Apply (Story #329)
+tofu apply plan.bin
+```
+
+> **Sem importação:** diferente do `standalone/`, este módulo é apply
+> "from zero" — não há recursos vivos em IAD para importar.
+
+## Operações típicas
+
+```bash
+# Ver estado atual + outputs
+tofu show
+tofu output
+
+# Aumentar tamanho dos blocks (in-place, online, sem reboot)
+$EDITOR terraform.tfvars   # volume_sizes_gbs.postgres = 120
+tofu apply
+# Pós-apply, estender o FS dentro da VM:
+ssh ubuntu@<k8s-host-ip> "ssh ubuntu@10.1.2.x 'sudo growpart /dev/sdb 1 && sudo resize2fs /dev/sdb1'"
+
+# IMPORTANTE: aumentar volumes além de 200 GB total passa a cobrar
+# ~$0.0085/GB-extra/mês — verificar Budget USD 50/mês via OCI Console.
+
+# Mudar perfil de capacidade
+$EDITOR terraform.tfvars   # profile = "hml_arm"  (cobra ~$25/mês de A1 paga)
+tofu apply
+
+# Recriar do zero (cuidado — destrutivo total; preserva apenas Reserved Public IP)
+tofu destroy
+tofu apply
+```
+
+## Bridge para os charts Helm
+
+Mesma estratégia documentada em `provisioning/oci/standalone/README.md` —
+ao chegar na Story
+[#350](https://github.com/unifesspa-edu-br/uniplus-infra/issues/350) (bootstrap
+completo IAD), criar `environments/iad-arm/values.yaml` espelhando o
+`environments/standalone/values.yaml` com IPs/FQDN do IAD, e estender
+`scripts/sync-tofu-outputs.sh` para reconhecer este módulo.
+
+## State
+
+State **local** por padrão (`terraform.tfstate` ignorado pelo `.gitignore`).
+Mesma decisão do `standalone/`. Backend remoto fica para refinamento futuro.
+
+## Próximos passos
+
+| Story | Conteúdo |
+|---|---|
+| [#319](https://github.com/unifesspa-edu-br/uniplus-infra/issues/319) | Assinar IAD + descobrir OCIDs (AD, imagem aarch64) |
+| [#329](https://github.com/unifesspa-edu-br/uniplus-infra/issues/329) | `tofu apply` em IAD + validação de smoke |
+| [#346](https://github.com/unifesspa-edu-br/uniplus-infra/issues/346) | Adaptar `bootstrap-standalone.sh` para arm64 |
+| [#350](https://github.com/unifesspa-edu-br/uniplus-infra/issues/350) | Bootstrap k3s+ArgoCD+Helm em IAD |
+| [#354](https://github.com/unifesspa-edu-br/uniplus-infra/issues/354) | Migração de dados GRU → IAD |
+| [#359](https://github.com/unifesspa-edu-br/uniplus-infra/issues/359) | Cutover DNS + `tofu destroy` em GRU |

--- a/provisioning/oci/iad-arm/README.md
+++ b/provisioning/oci/iad-arm/README.md
@@ -8,9 +8,10 @@ migração do lab de GRU/E5 para IAD/A1 antes do trial OCI expirar em
 2026-06-03).
 
 Cobertura: VCN (10.1.0.0/16), 2 subnets, IGW, NAT GW, 2 route tables, 2
-security lists, 2 VMs A1.Flex (k8s-host + data-host), 4 block volumes ≤200 GB
-total, Reserved Public IP, 11 DNS records sob `iad-arm.portaluni.com.br`,
-KMS Vault + Master Encryption Key, Dynamic Group, IAM Policy.
+security lists, 2 VMs A1.Flex (k8s-host + data-host), 4 block volumes
+(4×50 GB = 200 GB total — 50 GB é o mínimo da OCI), Reserved Public IP,
+11 DNS records sob `iad-arm.portaluni.com.br`, KMS Vault + Master Encryption
+Key, Dynamic Group, IAM Policy.
 
 > **Paralelo a `provisioning/oci/standalone/`:** este módulo NÃO substitui o
 > lab GRU enquanto a migração não completar. Os dois coexistem durante a
@@ -28,10 +29,27 @@ KMS Vault + Master Encryption Key, Dynamic Group, IAM Policy.
 | Imagem | Ubuntu 24.04 LTS x86_64 | Ubuntu 24.04 LTS **aarch64** |
 | Profile default | `poc` (3 OCPU / 16 GB E5) | `poc_arm` (3 OCPU / 16 GB A1) |
 | VCN CIDR | 10.0.0.0/16 | 10.1.0.0/16 |
-| Block volumes | 550 GB total (postgres 200 + kafka 100 + minio 200 + vault 50) | 150 GB total (postgres 15 + kafka 15 + minio 110 + vault 10) — prioriza MinIO para logs; 50 GB de folga sob o limite Always Free de 200 GB |
+| Block volumes | 550 GB total (postgres 200 + kafka 100 + minio 200 + vault 50) | 200 GB total (4×50, mínimo OCI) — Always Free Block Volume é só na home region (GRU); em IAD os volumes são PAYG ~$5/mês |
 | Tag `uniplus_environment` | `standalone` | `iad-arm` |
 | DNS subdomínio | `*.standalone.portaluni.com.br` | `*.iad-arm.portaluni.com.br` |
-| Custo (PAYG estimado) | ~$108/mês | ~$0-3/mês (compute + storage Always Free) |
+| Custo (PAYG estimado) | ~$108/mês | **~$42/mês** (detalhamento abaixo) |
+
+### Detalhamento do custo IAD
+
+| Recurso | Custo/mês | Observação |
+|---|---|---|
+| Compute A1 (3 OCPU / 16 GB) | **$0** | Always Free A1 vale em qualquer região com A1, independente da home region |
+| Block volumes (4×50 GB = 200 GB, VPU 0) | **~$5,10** | Always Free Block Volume é **amarrado à home region** (GRU). IAD é PAYG ~$0,0255/GB-mês |
+| Boot volumes (2× ~47 GB ≈ 94 GB) | **~$2,40** | Mesma regra dos block volumes |
+| NAT Gateway | **~$33** | Cobrado mesmo em Always Free; eliminação é follow-up |
+| **Total** | **~$40-42/mês** | Economia vs GRU (~$108): ~$66/mês (~61%) |
+
+> A premissa original do Epic #317 era $0-3/mês em IAD assumindo Always Free
+> total. A documentação da Oracle confirma que o **Always Free Block Volume é
+> regional (home region only)** — a tenancy unifesspa-edu-br tem home em
+> sa-saopaulo-1 (GRU). A migração ainda compensa pelo compute A1 grátis,
+> mas a redução real é ~61%, não ~97%. Story #366 (ajuste do Budget OCI)
+> precisa revisar a meta de USD 10/mês para algo entre USD 25-50/mês.
 
 ## Pré-requisitos
 
@@ -106,8 +124,10 @@ tofu apply
 # Pós-apply, estender o FS dentro da VM:
 ssh ubuntu@<k8s-host-ip> "ssh ubuntu@10.1.2.x 'sudo growpart /dev/sdb 1 && sudo resize2fs /dev/sdb1'"
 
-# IMPORTANTE: aumentar volumes além de 200 GB total passa a cobrar
-# ~$0.0085/GB-extra/mês — verificar Budget USD 50/mês via OCI Console.
+# IMPORTANTE: block volumes em IAD são PAYG (Always Free é home-region-only,
+# = GRU para esta tenancy). Custo VPU 0: ~$0.0255/GB-mês. Cada 50 GB extras
+# = ~$1.28/mês — verificar Budget OCI via Console antes de aumentar.
+# Reduzir abaixo do mínimo de 50 GB NÃO é possível (CreateVolume rejeita).
 
 # Mudar perfil de capacidade
 $EDITOR terraform.tfvars   # profile = "hml_arm"  (cobra ~$25/mês de A1 paga)

--- a/provisioning/oci/iad-arm/README.md
+++ b/provisioning/oci/iad-arm/README.md
@@ -163,20 +163,68 @@ ssh ubuntu@<k8s-host-ip> "ssh ubuntu@10.1.2.x 'sudo growpart /dev/sdb 1 && sudo 
 $EDITOR terraform.tfvars   # profile = "hml_arm"
 tofu apply
 
-# Recriar do zero (CUIDADO — destrutivo total: destroi VMs, volumes, VCN
-# E o Reserved Public IP). Apos `tofu apply` subsequente, o RESERVED IP
-# alocado sera DIFERENTE — DNS records, callback URLs do gov.br,
-# Let's Encrypt certs e KC_HOSTNAME precisam ser reconfigurados.
-#
-# Para preservar o IP entre destroy/apply, ha duas opcoes:
-#   1. Adicionar `lifecycle { prevent_destroy = true }` ao
-#      `oci_core_public_ip.k8s_host` (forca destroy parcial — exclui o IP)
-#   2. `tofu state rm oci_core_public_ip.k8s_host` antes do destroy +
-#      `tofu import oci_core_public_ip.k8s_host <ocid>` apos o apply
-# Em qualquer caso, o IP nao volta automaticamente.
-tofu destroy
+# Recriar do zero — caminho INGÊNUO destrói o Reserved Public IP junto com
+# tudo, e o `tofu apply` subsequente aloca IP DIFERENTE (rotacionando DNS,
+# callbacks gov.br, certs Let's Encrypt e KC_HOSTNAME):
+tofu destroy   # ⚠️ destrói TUDO, IP incluso
+tofu apply     # IP novo, diferente do anterior
+```
+
+#### Recriar do zero PRESERVANDO o Reserved IP
+
+Duas sequências corretas para preservar o IP entre rebuilds (a ingênua
+`tofu destroy && tofu apply` rotaciona). OpenTofu ≥ 1.7 obrigatório para
+`-exclude`.
+
+**Opção A (preferida) — `--exclude` no destroy** (OpenTofu ≥ 1.7):
+
+```bash
+# 1. Destrói TUDO menos o IP. Restante das resources e data sources que
+#    dependem do VNIC do k8s-host serão destruídas; o IP fica em state
+#    mas sem private_ip_id atrelado a um VNIC vivo (estado AVAILABLE no OCI).
+tofu destroy -exclude=oci_core_public_ip.k8s_host
+
+# 2. Apply normal recria as VMs; Tofu UPDATE o `private_ip_id` do IP
+#    para apontar para o VNIC primário da nova k8s-host — mesma OCID
+#    de IP, novo VNIC anexado.
 tofu apply
 ```
+
+Combine com `lifecycle { prevent_destroy = true }` no resource do IP se
+quiser uma trava extra contra destroy acidental sem `-exclude`:
+
+```hcl
+resource "oci_core_public_ip" "k8s_host" {
+  # ...
+  lifecycle { prevent_destroy = true }
+}
+```
+
+> ⚠️ Com `prevent_destroy`, `tofu destroy` SEM `-exclude=...` falha com
+> `Instance cannot be destroyed`. Não é "exclusão automática" — apenas
+> aborta o destroy se você esquecer do `-exclude`.
+
+**Opção B — `state rm` + `import` (compatível com OpenTofu < 1.7)**:
+
+```bash
+# 1. Salvar OCID atual do IP antes de mexer
+OLD_IP_OCID=$(tofu output -raw public_ip_ocid 2>/dev/null || tofu state show oci_core_public_ip.k8s_host | awk '/^[[:space:]]*id[[:space:]]/{gsub(/"/,""); print $3}')
+echo "IP a preservar: $OLD_IP_OCID"
+
+# 2. Remover IP do state — fica órfão (vivo na OCI, fora do tracking Tofu)
+tofu state rm oci_core_public_ip.k8s_host
+
+# 3. Destroy normal (não toca no IP porque ele não está mais no state)
+tofu destroy
+
+# 4. CRÍTICO: importar o IP de volta ao state ANTES do próximo apply.
+#    Se rodar `apply` direto, Tofu aloca IP novo (recurso declarado no .tf).
+tofu import oci_core_public_ip.k8s_host "$OLD_IP_OCID"
+
+# 5. Apply — Tofu já reconhece o IP, atualiza private_ip_id para o novo VNIC
+tofu apply
+```
+
 
 ## Bridge para os charts Helm
 

--- a/provisioning/oci/iad-arm/README.md
+++ b/provisioning/oci/iad-arm/README.md
@@ -170,7 +170,7 @@ tofu destroy   # ⚠️ destrói TUDO, IP incluso
 tofu apply     # IP novo, diferente do anterior
 ```
 
-#### Recriar do zero PRESERVANDO o Reserved IP
+### Recriar do zero PRESERVANDO o Reserved IP
 
 Duas sequências corretas para preservar o IP entre rebuilds (a ingênua
 `tofu destroy && tofu apply` rotaciona). OpenTofu ≥ 1.7 obrigatório para
@@ -224,7 +224,6 @@ tofu import oci_core_public_ip.k8s_host "$OLD_IP_OCID"
 # 5. Apply — Tofu já reconhece o IP, atualiza private_ip_id para o novo VNIC
 tofu apply
 ```
-
 
 ## Bridge para os charts Helm
 

--- a/provisioning/oci/iad-arm/README.md
+++ b/provisioning/oci/iad-arm/README.md
@@ -32,24 +32,46 @@ Key, Dynamic Group, IAM Policy.
 | Block volumes | 550 GB total (postgres 200 + kafka 100 + minio 200 + vault 50) | 200 GB total (4×50, mínimo OCI) — Always Free Block Volume é só na home region (GRU); em IAD os volumes são PAYG ~$5/mês |
 | Tag `uniplus_environment` | `standalone` | `iad-arm` |
 | DNS subdomínio | `*.standalone.portaluni.com.br` | `*.iad-arm.portaluni.com.br` |
-| Custo (PAYG estimado) | ~$108/mês | **~$42/mês** (detalhamento abaixo) |
+| Custo (PAYG estimado) | ~$108/mês | **~$80/mês** (detalhamento abaixo) |
 
 ### Detalhamento do custo IAD
 
 | Recurso | Custo/mês | Observação |
 |---|---|---|
-| Compute A1 (3 OCPU / 16 GB) | **$0** | Always Free A1 vale em qualquer região com A1, independente da home region |
-| Block volumes (4×50 GB = 200 GB, VPU 0) | **~$5,10** | Always Free Block Volume é **amarrado à home region** (GRU). IAD é PAYG ~$0,0255/GB-mês |
+| Compute A1 (3 OCPU / 16 GB) | **~$39,40** | Oracle docs: "You must create the Always Free compute instances in your home region". Home = GRU, então A1 em IAD vai para PAYG (3 OCPU × $0,01/h + 16 GB × $0,0015/h ≈ $39,40/mês). Ver gate de validação abaixo |
+| Block volumes (4×50 GB = 200 GB, VPU 0) | **~$5,10** | Always Free Block Volume também é home-region-only — IAD é PAYG $0,0255/GB-mês |
 | Boot volumes (2× ~47 GB ≈ 94 GB) | **~$2,40** | Mesma regra dos block volumes |
 | NAT Gateway | **~$33** | Cobrado mesmo em Always Free; eliminação é follow-up |
-| **Total** | **~$40-42/mês** | Economia vs GRU (~$108): ~$66/mês (~61%) |
+| **Total** | **~$79-80/mês** | Economia vs GRU (~$108): ~$28/mês (~26%) |
 
-> A premissa original do Epic #317 era $0-3/mês em IAD assumindo Always Free
-> total. A documentação da Oracle confirma que o **Always Free Block Volume é
-> regional (home region only)** — a tenancy unifesspa-edu-br tem home em
-> sa-saopaulo-1 (GRU). A migração ainda compensa pelo compute A1 grátis,
-> mas a redução real é ~61%, não ~97%. Story #366 (ajuste do Budget OCI)
-> precisa revisar a meta de USD 10/mês para algo entre USD 25-50/mês.
+> **Premissa que mudou:** O Epic #317 foi escrito assumindo `~$0-3/mês em IAD`
+> com base na interpretação de que Always Free A1 valeria cross-region.
+> Re-leitura da [doc oficial Oracle](https://docs.oracle.com/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm)
+> mostra que o texto `"In regions with multiple availability domains: You can
+> create OCI Ampere A1 Compute instances in any availability domain"`
+> qualifica a flexibilidade **dentro de uma única região** (a home region),
+> não cross-region. A regra geral `"must create in home region"` se aplica
+> a A1 e a AMD Micro. Story #366 (ajuste do Budget OCI) mantém USD 50/mês
+> em vez de reduzir para USD 10-25 — a frente do NAT GW elimination ganha
+> prioridade para recuperar economia.
+
+### Gate de validação operacional (Story #319/T1.1.3)
+
+Como a documentação Oracle é literal mas a prática da comunidade reporta A1
+cross-region funcionando sem cobrança, validar empiricamente ANTES de
+provisionar o lab completo:
+
+1. Após `oci compute image list` em IAD (T1.1.2), criar **1** instância A1
+   small (1 OCPU / 6 GB) no console OCI ou via `oci compute instance launch`
+2. Aguardar 30 min e checar `OCI Console → Cost Management → Cost Analysis`
+   filtrando por `Service=Compute Always Free` vs `Service=Compute`
+3. **Se cobrar PAYG**: docs estão corretas, custo do README ~$80/mês confirmado
+4. **Se aparecer como Always Free**: docs estão desatualizadas vs prática, revisar
+   README de volta para ~$42/mês e atualizar Epic #317
+5. Tear down a instância de teste antes de prosseguir com Story #329
+
+PAYG já ativo na tenancy desde a Feature #43, então qualquer cobrança aparece
+no billing imediatamente.
 
 ## Pré-requisitos
 

--- a/provisioning/oci/iad-arm/README.md
+++ b/provisioning/oci/iad-arm/README.md
@@ -69,11 +69,35 @@ Validação parcial executada em 2026-05-19 02:03-02:11 UTC via OCI CLI:
 
 **Achado parcial:** A doc Oracle diz literalmente `"must create in home region"` mas o API **não bloqueia** a criação em região não-home. Resta confirmar via billing se A1 em IAD é classificado como Always Free ou PAYG.
 
-**Próximo passo (Story #319/T1.1.3 ou follow-up):** repetir o teste deixando a instância rodar por ≥1h e re-query `oci usage-api` filtrando por `region=us-ashburn-1` e `service=Compute`:
-- Se aparecer com `computed-amount > 0` → PAYG confirmado, README ~$80/mês mantido
-- Se aparecer com `computed-amount = 0` ou ausente → Always Free aplica cross-region, revisar README para ~$42/mês e atualizar Epic #317
+**Próximo passo (Story #319/T1.1.3 ou follow-up):** repetir o teste deixando a instância rodar por ≥1h, depois consultar o billing report. Há duas formas equivalentes de identificar Always Free na billing OCI (mecanismo confirmado via inspeção do report de GRU 18-19/05):
 
-PAYG já ativo na tenancy desde a Feature #43, então qualquer cobrança aparece no billing imediatamente após o flush (~1-2h).
+1. **Pelo `product/resource` SKU**: SKUs Always Free têm sufixo `_FREE`. Exemplos do report de GRU:
+   - `PIC_BLOCK_STORAGE_STANDARD_FREE` → Always Free
+   - `PIC_STANDARD_STORAGE` → PAYG
+
+2. **Pela tag `orcl-cloud.free-tier-retained`**: `true` indica linha contada como Always Free; vazio indica PAYG.
+
+Comando para consultar via CLI:
+
+```bash
+# Baixar report mais recente (CSV horário) via Console:
+# OCI Console → Billing → Cost Analysis → Reports → Generate Usage Report
+# ou usar oci usage-api request-summarized-usages (delay ~1h):
+oci usage-api usage-summary request-summarized-usages \
+  --tenant-id "$TENANCY" \
+  --time-usage-started "2026-05-19T02:00:00Z" \
+  --time-usage-ended   "2026-05-19T03:00:00Z" \
+  --granularity HOURLY --query-type COST \
+  --group-by '["service","skuName","region"]' \
+  | jq '.data.items[] | select(.region=="us-ashburn-1")'
+```
+
+Veredictos possíveis:
+
+- SKU `PIC_COMPUTE_A1_FREE` (ou tag `free-tier-retained=true`) para A1 em IAD → **Always Free cross-region funciona** → reverter README para ~$42/mês e atualizar Epic #317
+- SKU `PIC_COMPUTE_VM_STANDARD_A1_FLEX` (sem `_FREE`, sem tag) → **PAYG confirmado** → README ~$80/mês mantido
+
+PAYG já ativo na tenancy desde a Feature #43, então qualquer cobrança aparece no billing após o flush (~1-2h via usage-api, ~24h via Usage Report CSV diário).
 
 ## Pré-requisitos
 

--- a/provisioning/oci/iad-arm/compute.tf
+++ b/provisioning/oci/iad-arm/compute.tf
@@ -19,8 +19,16 @@ resource "oci_core_instance" "k8s_host" {
   }
 
   create_vnic_details {
-    subnet_id        = oci_core_subnet.public.id
-    assign_public_ip = true
+    subnet_id = oci_core_subnet.public.id
+    # `assign_public_ip = false`: o IP público do k8s-host vem do
+    # `oci_core_public_ip.k8s_host` (RESERVED, definido em public_ip.tf),
+    # anexado ao primary private IP via `private_ip_id`. Setar `true`
+    # aqui criaria um IP EPHEMERAL e o `oci_core_public_ip` falharia
+    # depois com "private IP already has a public IP assigned" — diferente
+    # do `standalone/` (que tem `true` mas só funciona porque foi
+    # importado após promoção manual EPHEMERAL→RESERVED via OCI CLI;
+    # `iad-arm` é apply from zero).
+    assign_public_ip = false
     hostname_label   = "k8s-host"
   }
 

--- a/provisioning/oci/iad-arm/compute.tf
+++ b/provisioning/oci/iad-arm/compute.tf
@@ -1,0 +1,80 @@
+# ==============================================================================
+# k8s-host — VM pública que roda k3s + Helm + ArgoCD + apps Uni+
+# ==============================================================================
+resource "oci_core_instance" "k8s_host" {
+  display_name        = "uniplus-iad-arm-k8s-host"
+  compartment_id      = var.compartment_ocid
+  availability_domain = var.availability_domain
+  fault_domain        = var.fault_domain
+  shape               = "VM.Standard.A1.Flex"
+
+  shape_config {
+    ocpus         = local.shapes.k8s_host.ocpus
+    memory_in_gbs = local.shapes.k8s_host.memory_in_gbs
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = var.image_ocid
+  }
+
+  create_vnic_details {
+    subnet_id        = oci_core_subnet.public.id
+    assign_public_ip = true
+    hostname_label   = "k8s-host"
+  }
+
+  metadata = {
+    ssh_authorized_keys = var.ssh_authorized_keys
+  }
+
+  freeform_tags = local.common_tags
+
+  # bootstrap-standalone.sh provisiona k3s/helm/argocd; cloud-init full vai
+  # numa Story de extensão. Por enquanto, recriar a VM exige rodar o script
+  # manualmente após o apply.
+  lifecycle {
+    ignore_changes = [
+      # source_details muda quando OCI bumpa a imagem Ubuntu LTS — não force
+      # recreate por isso.
+      source_details,
+    ]
+  }
+}
+
+# ==============================================================================
+# data-host — VM privada que roda Postgres + Kafka + Redis + MinIO via systemd
+# ==============================================================================
+resource "oci_core_instance" "data_host" {
+  display_name        = "uniplus-iad-arm-data-host"
+  compartment_id      = var.compartment_ocid
+  availability_domain = var.availability_domain
+  fault_domain        = var.fault_domain
+  shape               = "VM.Standard.A1.Flex"
+
+  shape_config {
+    ocpus         = local.shapes.data_host.ocpus
+    memory_in_gbs = local.shapes.data_host.memory_in_gbs
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = var.image_ocid
+  }
+
+  create_vnic_details {
+    subnet_id        = oci_core_subnet.private.id
+    assign_public_ip = false
+    hostname_label   = "data-host"
+  }
+
+  metadata = {
+    ssh_authorized_keys = var.ssh_authorized_keys
+  }
+
+  freeform_tags = local.common_tags
+
+  lifecycle {
+    ignore_changes = [source_details]
+  }
+}

--- a/provisioning/oci/iad-arm/dns.tf
+++ b/provisioning/oci/iad-arm/dns.tf
@@ -1,0 +1,81 @@
+# ==============================================================================
+# DNS records do iad-arm (lab paralelo durante a migração GRU → IAD)
+#
+# A zona `portaluni.com.br` é hospedada na OCI DNS (já existente em
+# sa-saopaulo-1, NÃO gerenciada por este código — é compartilhada com outros
+# ambientes da plataforma). Aqui declaramos apenas os records do subdomínio
+# `iad-arm.portaluni.com.br`, paralelos a `standalone.portaluni.com.br` que
+# continua apontando para o lab GRU durante a janela de migração.
+#
+# Topologia:
+#   iad-arm.portaluni.com.br      A     <reserved-ip-iad>
+#   <serviço>.iad-arm.portaluni…  CNAME iad-arm.portaluni.com.br.
+#
+# CNAMEs cobrem cada serviço exposto pelo Traefik no k8s-host. Adicionar
+# novo serviço = adicionar 1 entry em local.iad_arm_cnames.
+#
+# Cutover final (Story #359): reapontar o domínio canônico (a definir na
+# Story — `standalone.portaluni.com.br` ou um novo `lab.portaluni.com.br`)
+# para os IPs IAD, destruir o lab GRU, e decidir se mantém ou destrói os
+# records `iad-arm.*` após o corte.
+#
+# Import format (provider OCI):
+#   tofu import oci_dns_rrset.<name> \
+#     "zoneNameOrId/<zone-ocid>/domain/<fqdn>/rtype/<TYPE>"
+# (Formato chave/valor — slash simples NÃO funciona.)
+# ==============================================================================
+
+data "oci_dns_zones" "portaluni" {
+  compartment_id = var.compartment_ocid
+  name           = "portaluni.com.br"
+  scope          = "GLOBAL"
+}
+
+locals {
+  dns_zone_id = data.oci_dns_zones.portaluni.zones[0].id
+  apex_domain = "iad-arm.portaluni.com.br"
+
+  # Subdomínios CNAME que apontam para o apex `iad-arm.portaluni.com.br`.
+  # Adicionar entry aqui = `tofu apply` cria o RRset novo.
+  iad_arm_cnames = toset([
+    "api-ingresso",
+    "api-portal",
+    "api-selecao",
+    "ingresso",
+    "kafka-ui",
+    "minio",
+    "portal",
+    "redis-ui",
+    "schema-registry",
+    "selecao",
+  ])
+}
+
+resource "oci_dns_rrset" "iad_arm_apex" {
+  zone_name_or_id = local.dns_zone_id
+  domain          = local.apex_domain
+  rtype           = "A"
+
+  items {
+    domain = local.apex_domain
+    rtype  = "A"
+    rdata  = oci_core_public_ip.k8s_host.ip_address
+    ttl    = 300
+  }
+}
+
+resource "oci_dns_rrset" "iad_arm_cname" {
+  for_each = local.iad_arm_cnames
+
+  zone_name_or_id = local.dns_zone_id
+  domain          = "${each.key}.${local.apex_domain}"
+  rtype           = "CNAME"
+
+  items {
+    domain = "${each.key}.${local.apex_domain}"
+    rtype  = "CNAME"
+    # CNAMEs OCI sempre terminam em ponto.
+    rdata = "${local.apex_domain}."
+    ttl   = 300
+  }
+}

--- a/provisioning/oci/iad-arm/dns.tf
+++ b/provisioning/oci/iad-arm/dns.tf
@@ -26,7 +26,12 @@
 # ==============================================================================
 
 data "oci_dns_zones" "portaluni" {
-  compartment_id = var.compartment_ocid
+  # A zona é um recurso de plataforma compartilhada — vive no tenancy root,
+  # não no compartment de workload (mesmo quando ambos coincidem hoje no POC).
+  # Usar `var.tenancy_ocid` garante o lookup correto se algum operador isolar
+  # workload em child compartment no futuro. Caso contrário, `zones[0]` virá
+  # vazio e `tofu plan` quebra antes de criar qualquer registro.
+  compartment_id = var.tenancy_ocid
   name           = "portaluni.com.br"
   scope          = "GLOBAL"
 }

--- a/provisioning/oci/iad-arm/kms.tf
+++ b/provisioning/oci/iad-arm/kms.tf
@@ -1,0 +1,67 @@
+# ==============================================================================
+# OCI KMS para auto-unseal do HashiCorp Vault (Story #57)
+#
+# 4 recursos:
+#   - oci_kms_vault.unseal       container OCI das keys (DEFAULT, software-backed)
+#   - oci_kms_key.unseal         AES-256 envelope key usada pelo seal "ocikms"
+#   - oci_identity_dynamic_group.k8s_host  matches instance.id do k8s-host
+#   - oci_identity_policy.vault_unseal     allow DG to use keys + vaults
+#
+# Endpoints derivados (outputs):
+#   - kms_management_endpoint    https://<id>-management.kms.<region>.oraclecloud.com
+#   - kms_crypto_endpoint        https://<id>-crypto.kms.<region>.oraclecloud.com
+#
+# Esses 4 valores (key_id + crypto_endpoint + management_endpoint + auth_type)
+# alimentam o bloco `seal "ocikms"` no extraconfig do chart `platform/vault`,
+# permitindo unseal automático sem precisar de operator unseal manual a cada
+# restart. Story #64 cobre o re-init do Vault apontando pra esse seal type.
+#
+# Auth do Vault contra OCI KMS é via Resource Principal — `auth_type_api_key
+# = "false"` no seal block. O pod do Vault assume identidade do k8s-host
+# (instance principal); como instance.id está no DG, e o DG tem permissão
+# `use keys`, o Vault opera sem credenciais explícitas.
+# ==============================================================================
+
+resource "oci_kms_vault" "unseal" {
+  compartment_id = var.compartment_ocid
+  display_name   = "uniplus-iad-arm-vault-kms"
+  vault_type     = "DEFAULT"
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_kms_key" "unseal" {
+  compartment_id      = var.compartment_ocid
+  display_name        = "uniplus-iad-arm-vault-unseal-key"
+  management_endpoint = oci_kms_vault.unseal.management_endpoint
+  protection_mode     = "SOFTWARE"
+
+  key_shape {
+    algorithm = "AES"
+    length    = 32 # bytes — AES-256
+  }
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_identity_dynamic_group" "k8s_host" {
+  # Dynamic Groups vivem no tenancy raiz (não no compartment do recurso).
+  compartment_id = var.compartment_ocid
+  name           = "uniplus-iad-arm-k8s-host-dg"
+  description    = "Dynamic Group para o k8s-host do ambiente iad-arm — permite auto-unseal do Vault via OCI KMS"
+  matching_rule  = "ANY {instance.id = '${oci_core_instance.k8s_host.id}'}"
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_identity_policy" "vault_unseal" {
+  compartment_id = var.compartment_ocid
+  name           = "uniplus-iad-arm-vault-unseal-policy"
+  description    = "Permite que o k8s-host use a chave KMS para auto-unseal do HashiCorp Vault"
+  statements = [
+    "Allow dynamic-group ${oci_identity_dynamic_group.k8s_host.name} to use keys in tenancy where target.key.id = '${oci_kms_key.unseal.id}'",
+    "Allow dynamic-group ${oci_identity_dynamic_group.k8s_host.name} to use vaults in tenancy where target.vault.id = '${oci_kms_vault.unseal.id}'",
+  ]
+
+  freeform_tags = local.common_tags
+}

--- a/provisioning/oci/iad-arm/kms.tf
+++ b/provisioning/oci/iad-arm/kms.tf
@@ -45,8 +45,13 @@ resource "oci_kms_key" "unseal" {
 }
 
 resource "oci_identity_dynamic_group" "k8s_host" {
-  # Dynamic Groups vivem no tenancy raiz (não no compartment do recurso).
-  compartment_id = var.compartment_ocid
+  # IAM Dynamic Groups são tenancy-scoped: a OCI exige que o
+  # `compartment_id` aponte para a raiz da tenancy, não para um
+  # child compartment onde compute/network vivam. Apply falha com
+  # "InvalidParameter: dynamic group must be created at the tenancy
+  # level" se o operador colocar infra em child e passar o mesmo OCID
+  # aqui. `var.tenancy_ocid` é variável dedicada por isso.
+  compartment_id = var.tenancy_ocid
   name           = "uniplus-iad-arm-k8s-host-dg"
   description    = "Dynamic Group para o k8s-host do ambiente iad-arm — permite auto-unseal do Vault via OCI KMS"
   matching_rule  = "ANY {instance.id = '${oci_core_instance.k8s_host.id}'}"
@@ -55,7 +60,11 @@ resource "oci_identity_dynamic_group" "k8s_host" {
 }
 
 resource "oci_identity_policy" "vault_unseal" {
-  compartment_id = var.compartment_ocid
+  # Policy com statements tenancy-scoped (`... in tenancy where ...`)
+  # também precisa morar no compartment raiz para que o engine IAM
+  # avalie os recursos referenciados em qualquer parte da tenancy.
+  # Mesmo argumento de `var.tenancy_ocid` do dynamic group acima.
+  compartment_id = var.tenancy_ocid
   name           = "uniplus-iad-arm-vault-unseal-policy"
   description    = "Permite que o k8s-host use a chave KMS para auto-unseal do HashiCorp Vault"
   statements = [

--- a/provisioning/oci/iad-arm/kms.tf
+++ b/provisioning/oci/iad-arm/kms.tf
@@ -45,12 +45,20 @@ resource "oci_kms_key" "unseal" {
 }
 
 resource "oci_identity_dynamic_group" "k8s_host" {
-  # IAM Dynamic Groups são tenancy-scoped: a OCI exige que o
-  # `compartment_id` aponte para a raiz da tenancy, não para um
-  # child compartment onde compute/network vivam. Apply falha com
-  # "InvalidParameter: dynamic group must be created at the tenancy
-  # level" se o operador colocar infra em child e passar o mesmo OCID
-  # aqui. `var.tenancy_ocid` é variável dedicada por isso.
+  # IAM Dynamic Groups são tenancy-scoped em duas dimensões:
+  #
+  # 1. `compartment_id` precisa apontar para a raiz da tenancy (não um
+  #    child compartment). Apply falha com "InvalidParameter: dynamic
+  #    group must be created at the tenancy level" se o operador colocar
+  #    infra em child e passar o mesmo OCID aqui. `var.tenancy_ocid` é
+  #    variável dedicada por isso.
+  #
+  # 2. A criação/alteração precisa ir contra o IAM endpoint da HOME
+  #    REGION da tenancy. Como o provider default deste módulo aponta
+  #    para us-ashburn-1 (IAD), usar `provider = oci.home_region` aqui.
+  #    Sem isso, apply em tenancy cujo home_region != IAD retorna 404
+  #    no IAM endpoint do IAD. Detalhe e refs em versions.tf.
+  provider       = oci.home_region
   compartment_id = var.tenancy_ocid
   name           = "uniplus-iad-arm-k8s-host-dg"
   description    = "Dynamic Group para o k8s-host do ambiente iad-arm — permite auto-unseal do Vault via OCI KMS"
@@ -64,6 +72,10 @@ resource "oci_identity_policy" "vault_unseal" {
   # também precisa morar no compartment raiz para que o engine IAM
   # avalie os recursos referenciados em qualquer parte da tenancy.
   # Mesmo argumento de `var.tenancy_ocid` do dynamic group acima.
+  #
+  # Idem para `provider = oci.home_region` — IAM master só aceita
+  # mutações via endpoint da home region da tenancy.
+  provider       = oci.home_region
   compartment_id = var.tenancy_ocid
   name           = "uniplus-iad-arm-vault-unseal-policy"
   description    = "Permite que o k8s-host use a chave KMS para auto-unseal do HashiCorp Vault"

--- a/provisioning/oci/iad-arm/locals.tf
+++ b/provisioning/oci/iad-arm/locals.tf
@@ -4,11 +4,14 @@ locals {
   # suporte a arm64 (Story #346/T3.1.x). Por enquanto o script só conhece
   # shapes E5.Flex — este módulo `iad-arm` declara o estado-alvo A1.Flex.
   #
-  # poc_arm é o perfil-default: 3 OCPU / 16 GB total — cabe no Always Free
-  # A1 (4 OCPU / 24 GB) com folga, idêntico em capacidade ao poc do `standalone`.
-  # hml_arm extrapola Always Free; usar conscientemente (cobra ~$25/mês de A1
-  # paga). Os perfis E5 (poc/hml) ficam declarados como referência histórica —
-  # não selecionar via var.profile aqui pois A1.Flex rejeita configs de E5.Flex.
+  # poc_arm é o perfil-default: 3 OCPU / 16 GB total — idêntico em capacidade
+  # ao poc do `standalone`. Compute em IAD vai para PAYG (~$39/mês) porque
+  # Always Free A1 é home-region-only (home = GRU); ver README.md →
+  # "Gate de validação operacional" para o smoke test que pode reverter
+  # essa premissa caso billing mostre Always Free aplicando cross-region.
+  # hml_arm: 6 OCPU / 40 GB total — ~$86/mês compute em IAD PAYG. Total
+  # com storage + NAT GW ~$127/mês, já ultrapassando o GRU; só faz sentido
+  # pós elimination do NAT GW.
   shape_profiles = {
     poc_arm = {
       k8s_host  = { ocpus = 2, memory_in_gbs = 12 }

--- a/provisioning/oci/iad-arm/locals.tf
+++ b/provisioning/oci/iad-arm/locals.tf
@@ -1,0 +1,30 @@
+locals {
+  # Mapeamento de perfis para shape config (OCPU + memória) por host.
+  # Sincronizar com scripts/resize-standalone-oci.sh quando este script ganhar
+  # suporte a arm64 (Story #346/T3.1.x). Por enquanto o script só conhece
+  # shapes E5.Flex — este módulo `iad-arm` declara o estado-alvo A1.Flex.
+  #
+  # poc_arm é o perfil-default: 3 OCPU / 16 GB total — cabe no Always Free
+  # A1 (4 OCPU / 24 GB) com folga, idêntico em capacidade ao poc do `standalone`.
+  # hml_arm extrapola Always Free; usar conscientemente (cobra ~$25/mês de A1
+  # paga). Os perfis E5 (poc/hml) ficam declarados como referência histórica —
+  # não selecionar via var.profile aqui pois A1.Flex rejeita configs de E5.Flex.
+  shape_profiles = {
+    poc_arm = {
+      k8s_host  = { ocpus = 2, memory_in_gbs = 12 }
+      data_host = { ocpus = 1, memory_in_gbs = 4 }
+    }
+    hml_arm = {
+      k8s_host  = { ocpus = 4, memory_in_gbs = 24 }
+      data_host = { ocpus = 2, memory_in_gbs = 16 }
+    }
+  }
+
+  shapes = local.shape_profiles[var.profile]
+
+  # OCI freeform_tags rejeita '/' em key names; usar underscore.
+  common_tags = {
+    "uniplus_environment" = "iad-arm"
+    "uniplus_managed_by"  = "opentofu"
+  }
+}

--- a/provisioning/oci/iad-arm/network.tf
+++ b/provisioning/oci/iad-arm/network.tf
@@ -148,6 +148,21 @@ resource "oci_core_security_list" "public" {
     }
   }
 
+  # ICMP type 3 code 4 (Path MTU Discovery — "Destination Unreachable /
+  # Fragmentation Needed"). Source 0.0.0.0/0 porque essas mensagens são
+  # geradas por ROTEADORES no caminho da internet, não por hosts dentro
+  # da VCN. Necessário no k8s-host para conexões egress (apt-get, helm,
+  # docker pull) e ingress HTTP/HTTPS que atravessam paths com MTU < 1500.
+  ingress_security_rules {
+    source      = "0.0.0.0/0"
+    protocol    = "1"
+    description = "Path MTU Discovery (ICMP type 3 code 4) from internet routers"
+    icmp_options {
+      type = 3
+      code = 4
+    }
+  }
+
   freeform_tags = local.common_tags
 }
 
@@ -213,10 +228,15 @@ resource "oci_core_security_list" "private" {
 
   # ICMP type 3 code 4 (Path MTU Discovery — "Destination Unreachable /
   # Fragmentation Needed"). Necessário para hosts atrás do NAT GW
-  # negociarem MSS quando o caminho tem MTU menor.
+  # negociarem MSS quando o caminho tem MTU menor. Source 0.0.0.0/0 porque
+  # essas mensagens são geradas por ROTEADORES no caminho da internet
+  # (com IPs públicos arbitrários fora da VCN), não por hosts dentro da VCN.
+  # Restringir a `var.vcn_cidr` faz pacotes/imagens travarem em paths com
+  # MTU < 1500 mesmo com TCP egress aberto.
   ingress_security_rules {
-    source   = var.vcn_cidr
-    protocol = "1"
+    source      = "0.0.0.0/0"
+    protocol    = "1"
+    description = "Path MTU Discovery (ICMP type 3 code 4) from internet routers"
     icmp_options {
       type = 3
       code = 4

--- a/provisioning/oci/iad-arm/network.tf
+++ b/provisioning/oci/iad-arm/network.tf
@@ -1,0 +1,251 @@
+# ==============================================================================
+# Network — VCN + 2 subnets + IGW + NAT GW + route tables + security lists
+#
+# Topologia:
+#
+#                        Internet
+#                            │
+#                          ┌─┴─┐
+#                          │IGW│
+#                          └─┬─┘
+#         RT public ─────────┘
+#         (0.0.0.0/0 → IGW)
+#                │
+#         ┌──────▼──────────────────────┐
+#         │ subnet-public  10.0.1.0/24  │
+#         │ - k8s-host (10.0.1.61)      │
+#         │ - SL: 22/80/443 from world  │
+#         └──────────────┬──────────────┘
+#                        │ intra-VCN
+#         ┌──────────────▼──────────────┐
+#         │ subnet-private 10.0.2.0/24  │
+#         │ - data-host (10.0.2.87)     │
+#         │ - SL: 22/5432/6379/9000-1/  │
+#         │       9092/icmp from VCN    │
+#         └──────────────┬──────────────┘
+#                        │
+#         RT private ────┘
+#         (0.0.0.0/0 → NAT GW)
+#                │
+#              ┌─▼─┐
+#              │NAT│ 137.131.206.254 (egress only)
+#              └─┬─┘
+#                ▼
+#             Internet
+#
+# Decisões:
+# - Default route table + default security list do VCN ficam não-gerenciados
+#   pelo Tofu (recursos automáticos da OCI ao criar VCN; não anexados a
+#   nenhuma subnet aqui).
+# - Story #53 originalmente especificava NSGs separadas para k8s-host
+#   (22/80/443) e data-host (5432/6379/9000-1/9092). Implementação viva usa
+#   security lists por subnet — já cobre todas as necessidades sem
+#   granularidade adicional. Migração para NSG (mais granular, por VNIC)
+#   fica como refinamento futuro caso precise isolar tráfego entre VMs da
+#   mesma subnet.
+# - SSH na subnet privada vem de toda a VCN (10.0.0.0/16) para permitir
+#   jump via k8s-host. Restringir a 10.0.1.0/24 (só subnet pública) é
+#   refinamento de hardening futuro.
+# ==============================================================================
+
+resource "oci_core_vcn" "this" {
+  compartment_id = var.compartment_ocid
+  display_name   = "uniplus-iad-arm-vcn"
+  cidr_blocks    = [var.vcn_cidr]
+  dns_label      = "unipluslab"
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_core_internet_gateway" "this" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "uniplus-iad-arm-igw"
+  enabled        = true
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_core_nat_gateway" "this" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "uniplus-iad-arm-natgw"
+  block_traffic  = false
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_core_route_table" "public" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "uniplus-iad-arm-rt-public"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_internet_gateway.this.id
+  }
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_core_route_table" "private" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "uniplus-iad-arm-rt-private"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_nat_gateway.this.id
+  }
+
+  freeform_tags = local.common_tags
+}
+
+# Security lists — uma por subnet. Egress all (default OCI). Ingress aplicado
+# por porta + origem (0.0.0.0/0 na pública, intra-VCN na privada).
+resource "oci_core_security_list" "public" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "uniplus-iad-arm-sl-public"
+
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "all"
+  }
+
+  # SSH admin
+  ingress_security_rules {
+    source      = "0.0.0.0/0"
+    protocol    = "6" # TCP
+    description = "SSH"
+    tcp_options {
+      min = 22
+      max = 22
+    }
+  }
+
+  # HTTP (Traefik / cert-manager HTTP-01)
+  ingress_security_rules {
+    source      = "0.0.0.0/0"
+    protocol    = "6"
+    description = "HTTP"
+    tcp_options {
+      min = 80
+      max = 80
+    }
+  }
+
+  # HTTPS (Traefik)
+  ingress_security_rules {
+    source      = "0.0.0.0/0"
+    protocol    = "6"
+    description = "HTTPS"
+    tcp_options {
+      min = 443
+      max = 443
+    }
+  }
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_core_security_list" "private" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "uniplus-iad-arm-sl-private"
+
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "all"
+  }
+
+  # SSH (jump via k8s-host)
+  ingress_security_rules {
+    source   = var.vcn_cidr
+    protocol = "6"
+    tcp_options {
+      min = 22
+      max = 22
+    }
+  }
+
+  # Postgres
+  ingress_security_rules {
+    source   = var.vcn_cidr
+    protocol = "6"
+    tcp_options {
+      min = 5432
+      max = 5432
+    }
+  }
+
+  # Redis
+  ingress_security_rules {
+    source   = var.vcn_cidr
+    protocol = "6"
+    tcp_options {
+      min = 6379
+      max = 6379
+    }
+  }
+
+  # MinIO API (9000) + Console (9001)
+  ingress_security_rules {
+    source   = var.vcn_cidr
+    protocol = "6"
+    tcp_options {
+      min = 9000
+      max = 9001
+    }
+  }
+
+  # Kafka SASL_SSL
+  ingress_security_rules {
+    source   = var.vcn_cidr
+    protocol = "6"
+    tcp_options {
+      min = 9092
+      max = 9092
+    }
+  }
+
+  # ICMP type 3 code 4 (Path MTU Discovery — "Destination Unreachable /
+  # Fragmentation Needed"). Necessário para hosts atrás do NAT GW
+  # negociarem MSS quando o caminho tem MTU menor.
+  ingress_security_rules {
+    source   = var.vcn_cidr
+    protocol = "1"
+    icmp_options {
+      type = 3
+      code = 4
+    }
+  }
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_core_subnet" "public" {
+  compartment_id             = var.compartment_ocid
+  vcn_id                     = oci_core_vcn.this.id
+  display_name               = "uniplus-iad-arm-subnet-public"
+  cidr_block                 = var.subnet_cidrs.public
+  route_table_id             = oci_core_route_table.public.id
+  security_list_ids          = [oci_core_security_list.public.id]
+  prohibit_public_ip_on_vnic = false
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_core_subnet" "private" {
+  compartment_id             = var.compartment_ocid
+  vcn_id                     = oci_core_vcn.this.id
+  display_name               = "uniplus-iad-arm-subnet-private"
+  cidr_block                 = var.subnet_cidrs.private
+  route_table_id             = oci_core_route_table.private.id
+  security_list_ids          = [oci_core_security_list.private.id]
+  prohibit_public_ip_on_vnic = true
+
+  freeform_tags = local.common_tags
+}

--- a/provisioning/oci/iad-arm/outputs.tf
+++ b/provisioning/oci/iad-arm/outputs.tf
@@ -1,0 +1,117 @@
+output "k8s_host_ocid" {
+  description = "OCID da instância k8s-host."
+  value       = oci_core_instance.k8s_host.id
+}
+
+output "k8s_host_public_ip" {
+  description = "IP público do k8s-host (não-Reserved no momento; pode mudar em recreate)."
+  value       = oci_core_instance.k8s_host.public_ip
+}
+
+output "k8s_host_private_ip" {
+  description = "IP privado do k8s-host (subnet pública)."
+  value       = oci_core_instance.k8s_host.private_ip
+}
+
+output "data_host_ocid" {
+  description = "OCID da instância data-host."
+  value       = oci_core_instance.data_host.id
+}
+
+output "data_host_private_ip" {
+  description = "IP privado do data-host (subnet privada; sem público)."
+  value       = oci_core_instance.data_host.private_ip
+}
+
+output "data_volume_ocids" {
+  description = "Mapa de OCIDs dos block volumes do data-host (postgres, kafka, minio, vault)."
+  value       = { for k, v in oci_core_volume.data : k => v.id }
+}
+
+output "applied_profile" {
+  description = "Perfil de capacidade aplicado (poc_arm | hml_arm)."
+  value       = var.profile
+}
+
+output "applied_shapes" {
+  description = "Shape config efetivo das 2 VMs."
+  value = {
+    k8s_host  = local.shapes.k8s_host
+    data_host = local.shapes.data_host
+  }
+}
+
+output "vcn_ocid" {
+  description = "OCID da VCN do iad-arm."
+  value       = oci_core_vcn.this.id
+}
+
+output "subnet_public_ocid" {
+  description = "OCID da subnet pública (k8s-host)."
+  value       = oci_core_subnet.public.id
+}
+
+output "subnet_private_ocid" {
+  description = "OCID da subnet privada (data-host)."
+  value       = oci_core_subnet.private.id
+}
+
+output "internet_gateway_ocid" {
+  description = "OCID do Internet Gateway."
+  value       = oci_core_internet_gateway.this.id
+}
+
+output "nat_gateway_ocid" {
+  description = "OCID do NAT Gateway."
+  value       = oci_core_nat_gateway.this.id
+}
+
+output "nat_gateway_public_ip" {
+  description = "IP público do NAT Gateway (egress da subnet privada)."
+  value       = oci_core_nat_gateway.this.nat_ip
+}
+
+output "k8s_host_reserved_ip" {
+  description = "IP público RESERVED do k8s-host (sobrevive a recreate; apontado pelo apex DNS)."
+  value       = oci_core_public_ip.k8s_host.ip_address
+}
+
+output "k8s_host_reserved_ip_ocid" {
+  description = "OCID do Reserved Public IP do k8s-host."
+  value       = oci_core_public_ip.k8s_host.id
+}
+
+output "dns_apex_fqdn" {
+  description = "FQDN do apex do iad-arm (record A → reserved IP)."
+  value       = local.apex_domain
+}
+
+output "kms_vault_ocid" {
+  description = "OCID do KMS Vault que hospeda a unseal key (Story #57)."
+  value       = oci_kms_vault.unseal.id
+}
+
+output "kms_key_ocid" {
+  description = "OCID da Master Encryption Key usada pelo HashiCorp Vault como seal ocikms."
+  value       = oci_kms_key.unseal.id
+}
+
+output "kms_management_endpoint" {
+  description = "Endpoint de management do KMS Vault (alimenta `seal \"ocikms\".management_endpoint` no Vault)."
+  value       = oci_kms_vault.unseal.management_endpoint
+}
+
+output "kms_crypto_endpoint" {
+  description = "Endpoint de crypto do KMS Vault (alimenta `seal \"ocikms\".crypto_endpoint` no Vault)."
+  value       = oci_kms_vault.unseal.crypto_endpoint
+}
+
+output "kms_dynamic_group_ocid" {
+  description = "OCID do Dynamic Group do k8s-host (Resource Principal para acesso ao KMS)."
+  value       = oci_identity_dynamic_group.k8s_host.id
+}
+
+output "kms_policy_ocid" {
+  description = "OCID da Policy que concede permissão `use keys` + `use vaults` ao Dynamic Group."
+  value       = oci_identity_policy.vault_unseal.id
+}

--- a/provisioning/oci/iad-arm/outputs.tf
+++ b/provisioning/oci/iad-arm/outputs.tf
@@ -4,8 +4,8 @@ output "k8s_host_ocid" {
 }
 
 output "k8s_host_public_ip" {
-  description = "IP público do k8s-host (não-Reserved no momento; pode mudar em recreate)."
-  value       = oci_core_instance.k8s_host.public_ip
+  description = "IP público do k8s-host. No iad-arm é o mesmo valor de `k8s_host_reserved_ip` porque a `k8s_host` é criada com `assign_public_ip = false` (sem EPHEMERAL) e o IP vem do `oci_core_public_ip.k8s_host` (RESERVED). Schema preservado para compatibilidade com `scripts/sync-tofu-outputs.sh` e outros consumidores que leem ambos os outputs do `standalone/`."
+  value       = oci_core_public_ip.k8s_host.ip_address
 }
 
 output "k8s_host_private_ip" {

--- a/provisioning/oci/iad-arm/public_ip.tf
+++ b/provisioning/oci/iad-arm/public_ip.tf
@@ -1,17 +1,27 @@
 # ==============================================================================
 # Reserved Public IP do k8s-host (Story #56)
 #
-# RESERVED (vs EPHEMERAL) garante que o IP sobreviva a `tofu destroy && tofu
-# apply`: o IP é um recurso desacoplado da VM, anexado via `private_ip_id`.
-# Recriar a VM mantém o mesmo IP, evitando reconfigurar DNS, gov.br
-# callback URL, certs Let's Encrypt, KC_HOSTNAME, etc.
+# RESERVED (vs EPHEMERAL) desacopla o IP da VM no nível da OCI: o recurso
+# permanece alocado mesmo se a VM for terminada, e pode ser reanexado a uma
+# instância nova via `private_ip_id`. ISSO É UMA PROPRIEDADE DO OCI, NÃO DO
+# TOFU.
+#
+# ATENÇÃO: `tofu destroy` apaga `oci_core_public_ip.k8s_host` deste state e
+# libera o IP para o pool da OCI — RESERVED não preserva contra destroy
+# gerenciado pelo Tofu. Para preservar o IP entre destroy/apply, ver
+# README.md → "Recriar do zero (CUIDADO)" com 2 workflows possíveis:
+#   1. `lifecycle { prevent_destroy = true }` no recurso (destroy parcial)
+#   2. `tofu state rm` antes do destroy + `tofu import` após apply
+#
+# Sem usar uma das duas, o próximo apply aloca um IP DIFERENTE e exige
+# reconfigurar DNS, gov.br callback URL, certs Let's Encrypt, KC_HOSTNAME, etc.
 #
 # Custo: $0/h enquanto attached a uma VM running; $0.005/h (~$3.65/mês)
 # enquanto não-atribuído.
 #
-# Como o standalone vivo nasceu com IP ephemeral promovido manualmente para
-# RESERVED via OCI CLI, basta importar para o Tofu — o IP `164.152.53.29`
-# fica preservado.
+# Diferente do `standalone/` (que importou IP pré-existente promovido
+# manualmente), iad-arm é apply-from-zero — o IP é alocado novo no primeiro
+# `tofu apply` e deve ser registrado no DNS / gov.br callback nesse momento.
 # ==============================================================================
 
 data "oci_core_vnic_attachments" "k8s_host" {

--- a/provisioning/oci/iad-arm/public_ip.tf
+++ b/provisioning/oci/iad-arm/public_ip.tf
@@ -9,11 +9,13 @@
 # ATENÇÃO: `tofu destroy` apaga `oci_core_public_ip.k8s_host` deste state e
 # libera o IP para o pool da OCI — RESERVED não preserva contra destroy
 # gerenciado pelo Tofu. Para preservar o IP entre destroy/apply, ver
-# README.md → "Recriar do zero (CUIDADO)" com 2 workflows possíveis:
-#   1. `lifecycle { prevent_destroy = true }` no recurso (destroy parcial)
-#   2. `tofu state rm` antes do destroy + `tofu import` após apply
+# README.md → "Recriar do zero PRESERVANDO o Reserved IP" com 2 sequências:
+#   A. `tofu destroy -exclude=oci_core_public_ip.k8s_host` + `tofu apply`
+#      (OpenTofu ≥ 1.7; preferido — uma única flag)
+#   B. `tofu state rm` + `tofu destroy` + `tofu import <ocid>` + `tofu apply`
+#      (compatível < 1.7; precisa salvar OCID e importar ANTES do apply seguinte)
 #
-# Sem usar uma das duas, o próximo apply aloca um IP DIFERENTE e exige
+# A sequência ingênua `tofu destroy && tofu apply` rotaciona o IP — exige
 # reconfigurar DNS, gov.br callback URL, certs Let's Encrypt, KC_HOSTNAME, etc.
 #
 # Custo: $0/h enquanto attached a uma VM running; $0.005/h (~$3.65/mês)

--- a/provisioning/oci/iad-arm/public_ip.tf
+++ b/provisioning/oci/iad-arm/public_ip.tf
@@ -1,0 +1,33 @@
+# ==============================================================================
+# Reserved Public IP do k8s-host (Story #56)
+#
+# RESERVED (vs EPHEMERAL) garante que o IP sobreviva a `tofu destroy && tofu
+# apply`: o IP é um recurso desacoplado da VM, anexado via `private_ip_id`.
+# Recriar a VM mantém o mesmo IP, evitando reconfigurar DNS, gov.br
+# callback URL, certs Let's Encrypt, KC_HOSTNAME, etc.
+#
+# Custo: $0/h enquanto attached a uma VM running; $0.005/h (~$3.65/mês)
+# enquanto não-atribuído.
+#
+# Como o standalone vivo nasceu com IP ephemeral promovido manualmente para
+# RESERVED via OCI CLI, basta importar para o Tofu — o IP `164.152.53.29`
+# fica preservado.
+# ==============================================================================
+
+data "oci_core_vnic_attachments" "k8s_host" {
+  compartment_id = var.compartment_ocid
+  instance_id    = oci_core_instance.k8s_host.id
+}
+
+data "oci_core_private_ips" "k8s_host_primary" {
+  vnic_id = data.oci_core_vnic_attachments.k8s_host.vnic_attachments[0].vnic_id
+}
+
+resource "oci_core_public_ip" "k8s_host" {
+  compartment_id = var.compartment_ocid
+  display_name   = "uniplus-iad-arm-ip"
+  lifetime       = "RESERVED"
+  private_ip_id  = data.oci_core_private_ips.k8s_host_primary.private_ips[0].id
+
+  freeform_tags = local.common_tags
+}

--- a/provisioning/oci/iad-arm/public_ip.tf
+++ b/provisioning/oci/iad-arm/public_ip.tf
@@ -11,9 +11,9 @@
 # gerenciado pelo Tofu. Para preservar o IP entre destroy/apply, ver
 # README.md → "Recriar do zero PRESERVANDO o Reserved IP" com 2 sequências:
 #   A. `tofu destroy -exclude=oci_core_public_ip.k8s_host` + `tofu apply`
-#      (OpenTofu ≥ 1.7; preferido — uma única flag)
+#      (OpenTofu ≥ 1.9; preferido — uma única flag)
 #   B. `tofu state rm` + `tofu destroy` + `tofu import <ocid>` + `tofu apply`
-#      (compatível < 1.7; precisa salvar OCID e importar ANTES do apply seguinte)
+#      (compatível < 1.9; precisa salvar OCID e importar ANTES do apply seguinte)
 #
 # A sequência ingênua `tofu destroy && tofu apply` rotaciona o IP — exige
 # reconfigurar DNS, gov.br callback URL, certs Let's Encrypt, KC_HOSTNAME, etc.

--- a/provisioning/oci/iad-arm/storage.tf
+++ b/provisioning/oci/iad-arm/storage.tf
@@ -1,0 +1,57 @@
+# ==============================================================================
+# Block volumes do data-host
+#
+# 4 volumes anexados via paravirtualized — montagens LVM (`uniplus-vg/<lv>`)
+# feitas pelo `bootstrap-standalone.sh --role=standalone-data`.
+#
+# Resize do `volume_sizes_gbs`:
+#   - **Aumentar** (ex.: 200→500): in-place, online, sem reboot, sem perder
+#     dados. OCI provider trata `size_in_gbs` como atributo updateable.
+#     `tofu apply` chama UpdateVolume; resize é segundos no OCI side.
+#     Pós-apply, é necessário ESTENDER o sistema de arquivos dentro da VM:
+#       ssh ubuntu@10.0.2.87
+#       sudo lsblk                  # confirmar nome do device (ex.: sdc)
+#       sudo growpart /dev/sdc 1    # estende a partição (cloud-utils)
+#       sudo resize2fs /dev/sdc1    # ext4; ou xfs_growfs <mountpoint>
+#
+#   - **Diminuir** (ex.: 200→100): NÃO suportado pela OCI. Tofu calcula
+#     "in-place" mas o API rejeita com 400 no apply. Para encolher é
+#     necessário processo manual destrutivo: criar volume novo menor,
+#     `dd`/`rsync` dos dados, swap do attachment, delete do antigo.
+#     **Não recomendado em POC** — economia (<$10/mês) não compensa risco
+#     de perda de dados; usar VM nova (`tofu destroy && apply` com
+#     tamanhos menores em tfvars) é mais limpo.
+# ==============================================================================
+locals {
+  data_volumes = {
+    postgres = { size_gbs = var.volume_sizes_gbs.postgres }
+    kafka    = { size_gbs = var.volume_sizes_gbs.kafka }
+    minio    = { size_gbs = var.volume_sizes_gbs.minio }
+    vault    = { size_gbs = var.volume_sizes_gbs.vault }
+  }
+}
+
+resource "oci_core_volume" "data" {
+  for_each = local.data_volumes
+
+  display_name        = "uniplus-iad-arm-${each.key}"
+  compartment_id      = var.compartment_ocid
+  availability_domain = var.availability_domain
+  size_in_gbs         = each.value.size_gbs
+  vpus_per_gb         = var.volume_vpus_per_gb
+
+  freeform_tags = local.common_tags
+}
+
+resource "oci_core_volume_attachment" "data" {
+  for_each = local.data_volumes
+
+  attachment_type = "paravirtualized"
+  instance_id     = oci_core_instance.data_host.id
+  volume_id       = oci_core_volume.data[each.key].id
+  # `att-<vol>` é o display_name do recurso vivo (provisionado manualmente em
+  # 2026-05-04). OCI provider força replacement ao mudar display_name; trocar
+  # para `uniplus-iad-arm-...-attachment` faria detach/reattach (perde
+  # mounts ativos no data-host).
+  display_name = "att-${each.key}"
+}

--- a/provisioning/oci/iad-arm/terraform.tfvars.example
+++ b/provisioning/oci/iad-arm/terraform.tfvars.example
@@ -49,16 +49,31 @@ EOT
 # Mudar e aplicar `tofu apply` REBOOTA as VMs.
 profile = "poc_arm"
 
-# Tamanho dos 4 block volumes do data-host. Defaults somam EXATAMENTE 200 GB
-# para caber no Always Free OCI Block Volume (sem cobrança).
-# Aumentar é IN-PLACE online (sem reboot, sem perder dados), mas começa a cobrar
-# ~$0.0085/GB-extra/mês. Pós-apply, rodar `growpart` + `resize2fs` no data-host.
-# Diminuir NÃO é suportado pela OCI — só via `tofu destroy && tofu apply`.
+# Tamanho dos 4 block volumes do data-host. Defaults somam 150 GB com
+# alocação priorizando MinIO (logs + artefatos). 50 GB de folga sob o
+# limite Always Free de 200 GB. Folga serve para:
+#   1. Crescer um volume in-place quando o serviço precisar (até 200 GB
+#      total ainda fica grátis).
+#   2. Provisionar volume novo para serviço futuro sem precisar reduzir os
+#      existentes (reduzir NÃO é suportado pela OCI — só via destroy+recreate).
+# Aumentar acima de 200 GB total passa a cobrar ~$0.0085/GB-extra/mês.
+# Pós-apply, rodar `growpart` + `resize2fs` no data-host para o FS reconhecer.
+#
+# Distribuição esperada na operação:
+#   postgres = 15 GB  → base do app fica em ~2 GB durante testes; 15 GB cobre
+#                       WAL + índices + vacuum bloat com folga de 7x.
+#   kafka    = 15 GB  → event topics curtos (commands/events de domínio);
+#                       logs de aplicação NÃO passam por Kafka.
+#   minio    = 110 GB → bulk de logs da plataforma + artefatos (uploads de
+#                       candidatos, exports). Sem retention configurada, este
+#                       é o primeiro a encher — definir lifecycle policy no
+#                       bucket de logs antes de produção real.
+#   vault    = 10 GB  → secrets do app, KV store; nunca grande.
 volume_sizes_gbs = {
-  postgres = 80
-  kafka    = 40
-  minio    = 60
-  vault    = 20
+  postgres = 15
+  kafka    = 15
+  minio    = 110
+  vault    = 10
 }
 
 # 0 = Lower Cost (sem IOPS dedicado; suficiente para POC e mantém $0 dentro

--- a/provisioning/oci/iad-arm/terraform.tfvars.example
+++ b/provisioning/oci/iad-arm/terraform.tfvars.example
@@ -1,0 +1,66 @@
+# Copiar para terraform.tfvars (ignorado pelo .gitignore) e ajustar.
+#
+# Este módulo provisiona o lab Uni+ em us-ashburn-1 sobre VM.Standard.A1.Flex
+# (ARM Ampere) — alvo da migração descrita no Epic uniplus-infra#317.
+
+# Compartment raiz da tenancy unifesspa-edu-br (no iad-arm POC, recursos vivem
+# direto no compartment raiz, mesma topologia do standalone).
+compartment_ocid = "ocid1.tenancy.oc1..REPLACE_WITH_TENANCY_OCID"
+
+# Região destino fixada — não alterar sem revisar Epic #317. A escolha de IAD
+# foi binding (latência ~140ms BR + melhor capacidade A1 histórica).
+region = "us-ashburn-1"
+
+# Availability Domain de IAD — descobrir após assinar a região via Task #320:
+#   oci iam availability-domain list --region us-ashburn-1
+# IAD tem 3 ADs; pegar a primeira retornada (geralmente "<prefix>:US-ASHBURN-AD-1").
+availability_domain = "REPLACE_AFTER_T1_1_2"
+
+fault_domain = "FAULT-DOMAIN-1"
+
+# Topologia da VCN. Defaults (10.1.0.0/16, subnets 10.1.{1,2}.0/24) evitam
+# conflito com o lab GRU (10.0.0.0/16) durante a janela paralela de migração.
+# vcn_cidr = "10.1.0.0/16"
+# subnet_cidrs = {
+#   public  = "10.1.1.0/24"
+#   private = "10.1.2.0/24"
+# }
+
+# Imagem Ubuntu 24.04 LTS aarch64 em us-ashburn-1 — descobrir via Task #321:
+#   oci compute image list --region us-ashburn-1 \
+#     --compartment-id <tenancy> \
+#     --operating-system "Canonical Ubuntu" \
+#     --operating-system-version 24.04 \
+#     --shape VM.Standard.A1.Flex \
+#     --sort-by TIMECREATED --sort-order DESC \
+#     --query 'data[0].id' --raw-output
+# IMPORTANTE: imagem aarch64 ≠ amd64; verificar `display-name` contém "aarch64".
+image_ocid = "REPLACE_AFTER_T1_1_2"
+
+# Chave SSH pública (uma por linha) que será injetada via metadata.
+# Ubuntu cria ~/.ssh/authorized_keys automaticamente no usuário `ubuntu`.
+ssh_authorized_keys = <<-EOT
+  ssh-ed25519 AAAA... operador@host
+EOT
+
+# Perfil de capacidade A1.Flex:
+#   - "poc_arm" (default, RECOMENDADO): 3 OCPU / 16 GB — cabe Always Free, $0/mês
+#   - "hml_arm": 6 OCPU / 40 GB — EXTRAPOLA Always Free, cobra ~$25/mês de A1 paga
+# Mudar e aplicar `tofu apply` REBOOTA as VMs.
+profile = "poc_arm"
+
+# Tamanho dos 4 block volumes do data-host. Defaults somam EXATAMENTE 200 GB
+# para caber no Always Free OCI Block Volume (sem cobrança).
+# Aumentar é IN-PLACE online (sem reboot, sem perder dados), mas começa a cobrar
+# ~$0.0085/GB-extra/mês. Pós-apply, rodar `growpart` + `resize2fs` no data-host.
+# Diminuir NÃO é suportado pela OCI — só via `tofu destroy && tofu apply`.
+volume_sizes_gbs = {
+  postgres = 80
+  kafka    = 40
+  minio    = 60
+  vault    = 20
+}
+
+# 0 = Lower Cost (sem IOPS dedicado; suficiente para POC e mantém $0 dentro
+# do Always Free). 10 = Balanced (cobra). Manter 0 para o lab.
+volume_vpus_per_gb = 0

--- a/provisioning/oci/iad-arm/terraform.tfvars.example
+++ b/provisioning/oci/iad-arm/terraform.tfvars.example
@@ -56,8 +56,9 @@ EOT
 #     Free Compute é home-region-only — para esta tenancy (home=GRU), A1 em
 #     IAD provavelmente vai PAYG (~$39/mês para 3 OCPU/16 GB). Ver gate de
 #     validação no README.md → seção "Gate de validação operacional".
-#   - "hml_arm": 6 OCPU / 40 GB — sempre cobra mesmo se Always Free aplicasse
-#     em IAD (~$50/mês PAYG).
+#   - "hml_arm": 6 OCPU / 40 GB → ~$86/mês compute em IAD (6 × $0.01/h +
+#     40 × $0.0015/h × 730h). Total com storage + NAT ~$127/mês — já
+#     ULTRAPASSA o GRU atual. Só faz sentido pós elimination do NAT GW.
 # Mudar e aplicar `tofu apply` REBOOTA as VMs.
 profile = "poc_arm"
 

--- a/provisioning/oci/iad-arm/terraform.tfvars.example
+++ b/provisioning/oci/iad-arm/terraform.tfvars.example
@@ -7,6 +7,14 @@
 # direto no compartment raiz, mesma topologia do standalone).
 compartment_ocid = "ocid1.tenancy.oc1..REPLACE_WITH_TENANCY_OCID"
 
+# OCID da tenancy (compartment raiz). Necessário separadamente de
+# `compartment_ocid` porque IAM Dynamic Groups e Policies tenancy-scoped
+# DEVEM residir no compartment raiz, independente do compartment escolhido
+# para compute/network. No iad-arm POC ambos apontam para o mesmo OCID
+# (tenancy raiz). Em ambiente futuro com isolamento por compartment, manter
+# `tenancy_ocid` apontando para o root e `compartment_ocid` para o child.
+tenancy_ocid = "ocid1.tenancy.oc1..REPLACE_WITH_TENANCY_OCID"
+
 # Região destino fixada — não alterar sem revisar Epic #317. A escolha de IAD
 # foi binding (latência ~140ms BR + melhor capacidade A1 histórica).
 region = "us-ashburn-1"

--- a/provisioning/oci/iad-arm/terraform.tfvars.example
+++ b/provisioning/oci/iad-arm/terraform.tfvars.example
@@ -52,9 +52,12 @@ ssh_authorized_keys = <<-EOT
 EOT
 
 # Perfil de capacidade A1.Flex:
-#   - "poc_arm" (default, RECOMENDADO): 3 OCPU / 16 GB — cabe Always Free A1
-#     (válido em qualquer região com A1, INCLUSIVE não-home), custo $0/mês
-#   - "hml_arm": 6 OCPU / 40 GB — EXTRAPOLA Always Free, cobra ~$25/mês de A1 paga
+#   - "poc_arm" (default): 3 OCPU / 16 GB. ATENÇÃO: doc Oracle diz que Always
+#     Free Compute é home-region-only — para esta tenancy (home=GRU), A1 em
+#     IAD provavelmente vai PAYG (~$39/mês para 3 OCPU/16 GB). Ver gate de
+#     validação no README.md → seção "Gate de validação operacional".
+#   - "hml_arm": 6 OCPU / 40 GB — sempre cobra mesmo se Always Free aplicasse
+#     em IAD (~$50/mês PAYG).
 # Mudar e aplicar `tofu apply` REBOOTA as VMs.
 profile = "poc_arm"
 

--- a/provisioning/oci/iad-arm/terraform.tfvars.example
+++ b/provisioning/oci/iad-arm/terraform.tfvars.example
@@ -52,38 +52,41 @@ ssh_authorized_keys = <<-EOT
 EOT
 
 # Perfil de capacidade A1.Flex:
-#   - "poc_arm" (default, RECOMENDADO): 3 OCPU / 16 GB — cabe Always Free, $0/mês
+#   - "poc_arm" (default, RECOMENDADO): 3 OCPU / 16 GB — cabe Always Free A1
+#     (válido em qualquer região com A1, INCLUSIVE não-home), custo $0/mês
 #   - "hml_arm": 6 OCPU / 40 GB — EXTRAPOLA Always Free, cobra ~$25/mês de A1 paga
 # Mudar e aplicar `tofu apply` REBOOTA as VMs.
 profile = "poc_arm"
 
-# Tamanho dos 4 block volumes do data-host. Defaults somam 150 GB com
-# alocação priorizando MinIO (logs + artefatos). 50 GB de folga sob o
-# limite Always Free de 200 GB. Folga serve para:
-#   1. Crescer um volume in-place quando o serviço precisar (até 200 GB
-#      total ainda fica grátis).
-#   2. Provisionar volume novo para serviço futuro sem precisar reduzir os
-#      existentes (reduzir NÃO é suportado pela OCI — só via destroy+recreate).
-# Aumentar acima de 200 GB total passa a cobrar ~$0.0085/GB-extra/mês.
-# Pós-apply, rodar `growpart` + `resize2fs` no data-host para o FS reconhecer.
+# Tamanho dos 4 block volumes do data-host. OCI exige mínimo de 50 GB por
+# volume — defaults usam exato 4×50 = 200 GB. Limites e custo:
 #
-# Distribuição esperada na operação:
-#   postgres = 15 GB  → base do app fica em ~2 GB durante testes; 15 GB cobre
-#                       WAL + índices + vacuum bloat com folga de 7x.
-#   kafka    = 15 GB  → event topics curtos (commands/events de domínio);
-#                       logs de aplicação NÃO passam por Kafka.
-#   minio    = 110 GB → bulk de logs da plataforma + artefatos (uploads de
-#                       candidatos, exports). Sem retention configurada, este
-#                       é o primeiro a encher — definir lifecycle policy no
-#                       bucket de logs antes de produção real.
-#   vault    = 10 GB  → secrets do app, KV store; nunca grande.
+#   1. Always Free Block Volume (200 GB total) é amarrado à HOME REGION da
+#      tenancy. A unifesspa-edu-br tem home = sa-saopaulo-1 (GRU), então
+#      em IAD os volumes saem em PAYG normal: $0.0255/GB-mês (VPU 0).
+#      Custo estimado dos defaults: 200 GB × $0.0255 = ~$5.10/mês.
+#   2. Reduzir abaixo de 50 GB NÃO é possível — `CreateVolume` rejeita.
+#   3. Aumentar é in-place online (`tofu apply` chama UpdateVolume); pós-apply,
+#      rodar `growpart` + `resize2fs` no data-host para o FS reconhecer.
+#
+# Distribuição (todos no mínimo de 50 GB; serviços com menos demanda real
+# desperdiçam capacidade mas não há como compactar abaixo do floor da OCI):
+#   postgres = 50 GB  → base do app fica em ~2 GB durante testes; 50 GB é
+#                       muito mais do que necessário, mas é o mínimo OCI.
+#   kafka    = 50 GB  → event topics curtos (commands/events de domínio).
+#   minio    = 50 GB  → logs + artefatos; em POC sem volume real de uso.
+#                       Para HML/PROD, considerar aumentar para 100+ GB e
+#                       configurar lifecycle policy no bucket de logs.
+#   vault    = 50 GB  → secrets do app + KV store; nunca grande em POC.
 volume_sizes_gbs = {
-  postgres = 15
-  kafka    = 15
-  minio    = 110
-  vault    = 10
+  postgres = 50
+  kafka    = 50
+  minio    = 50
+  vault    = 50
 }
 
-# 0 = Lower Cost (sem IOPS dedicado; suficiente para POC e mantém $0 dentro
-# do Always Free). 10 = Balanced (cobra). Manter 0 para o lab.
+# 0 = Lower Cost (sem IOPS dedicado, $0.0255/GB-mês PAYG); 10 = Balanced
+# ($0.0425/GB-mês PAYG). Manter 0 no lab — IAD não tem Always Free Block
+# Volume (home = GRU), então o tier afeta custo direto. Em POC os volumes
+# não precisam de IOPS dedicado.
 volume_vpus_per_gb = 0

--- a/provisioning/oci/iad-arm/variables.tf
+++ b/provisioning/oci/iad-arm/variables.tf
@@ -3,6 +3,11 @@ variable "compartment_ocid" {
   type        = string
 }
 
+variable "tenancy_ocid" {
+  description = "OCID da tenancy (compartment raiz). Necessário separadamente de `compartment_ocid` porque IAM Dynamic Groups e Policies tenancy-scoped DEVEM residir no compartment raiz, independente do compartment onde compute/network vivem. No iad-arm POC esse valor é igual a `compartment_ocid` (tudo na raiz); em ambientes com isolamento por compartment, manter este aqui apontando para o root e `compartment_ocid` para o child."
+  type        = string
+}
+
 variable "region" {
   description = "Região OCI alvo. iad-arm é fixado em us-ashburn-1 (IAD) — maior capacidade A1 ARM histórica nos EUA e menor latência do Brasil entre as regiões PAYG-disponíveis."
   type        = string

--- a/provisioning/oci/iad-arm/variables.tf
+++ b/provisioning/oci/iad-arm/variables.tf
@@ -1,0 +1,91 @@
+variable "compartment_ocid" {
+  description = "OCID do compartment onde os recursos vivem (no iad-arm POC, igual ao tenancy_ocid raiz)."
+  type        = string
+}
+
+variable "region" {
+  description = "Região OCI alvo. iad-arm é fixado em us-ashburn-1 (IAD) — maior capacidade A1 ARM histórica nos EUA e menor latência do Brasil entre as regiões PAYG-disponíveis."
+  type        = string
+  default     = "us-ashburn-1"
+}
+
+variable "availability_domain" {
+  description = "Availability Domain das VMs e block volumes em IAD. IAD tem 3 ADs; default escolhe a primeira. Substituir pelo valor real após Story #319/T1.1.2 (`oci iam availability-domain list --region us-ashburn-1`)."
+  type        = string
+  default     = "REPLACE_AFTER_T1_1_2"
+}
+
+variable "fault_domain" {
+  description = "Fault Domain das VMs."
+  type        = string
+  default     = "FAULT-DOMAIN-1"
+}
+
+variable "vcn_cidr" {
+  description = "CIDR block da VCN. iad-arm usa 10.1.0.0/16 (não 10.0.0.0/16 do `standalone`) para evitar conflito quando ambos os labs coexistirem durante a janela de migração."
+  type        = string
+  default     = "10.1.0.0/16"
+}
+
+variable "subnet_cidrs" {
+  description = "CIDR blocks das 2 subnets (public para k8s-host, private para data-host). Devem caber dentro de vcn_cidr."
+  type = object({
+    public  = string
+    private = string
+  })
+  default = {
+    public  = "10.1.1.0/24"
+    private = "10.1.2.0/24"
+  }
+}
+
+variable "image_ocid" {
+  description = "OCID da imagem base Ubuntu 24.04 LTS aarch64 em us-ashburn-1. Substituir após Story #319/T1.1.2 (`oci compute image list --region us-ashburn-1 --shape VM.Standard.A1.Flex --operating-system 'Canonical Ubuntu' --operating-system-version 24.04 --sort-by TIMECREATED --sort-order DESC`)."
+  type        = string
+  default     = "REPLACE_AFTER_T1_1_2"
+}
+
+# Nota: o nome da zona DNS pública (`portaluni.com.br`) é hardcoded em
+# dns.tf via data source porque é compartilhado entre ambientes da plataforma.
+# iad-arm cria registros sob o subdomínio `iad-arm.portaluni.com.br` enquanto
+# `standalone.portaluni.com.br` continua apontando para o lab GRU; o cutover
+# DNS final (Story #359) reaponta o domínio canônico (definir na Story) para
+# os IPs IAD e destrói o lab GRU.
+
+variable "ssh_authorized_keys" {
+  description = "Chaves SSH (uma por linha) injetadas via metadata em ambas instâncias."
+  type        = string
+}
+
+variable "profile" {
+  description = "Perfil de capacidade das VMs A1.Flex. 'poc_arm' (default) = 3 OCPU / 16 GB total, cabe em Always Free A1 (4 OCPU / 24 GB). 'hml_arm' = 6 OCPU / 40 GB total — EXTRAPOLA Always Free, cobra ~$25/mês. Mapeamento em locals.tf."
+  type        = string
+  default     = "poc_arm"
+
+  validation {
+    condition     = contains(["poc_arm", "hml_arm"], var.profile)
+    error_message = "profile deve ser 'poc_arm' ou 'hml_arm' (perfis A1.Flex)."
+  }
+}
+
+variable "volume_sizes_gbs" {
+  description = "Tamanho em GB de cada block volume anexado ao data-host. Defaults somam 200 GB exatos (limite Always Free OCI Block Volume). Aumentar passa a cobrar ~$0.0085/GB-extra/mês."
+  type = object({
+    postgres = number
+    kafka    = number
+    minio    = number
+    vault    = number
+  })
+  default = {
+    postgres = 80
+    kafka    = 40
+    minio    = 60
+    vault    = 20
+  }
+}
+
+variable "volume_vpus_per_gb" {
+  description = "VPUs por GB nos block volumes. 0 = Lower Cost (mínimo, sem IOPS dedicado); 10 = Balanced default OCI. iad-arm usa 0 (suficiente para POC e mantém custo em zero dentro do Always Free)."
+  type        = number
+  default     = 0
+}

--- a/provisioning/oci/iad-arm/variables.tf
+++ b/provisioning/oci/iad-arm/variables.tf
@@ -74,7 +74,7 @@ variable "profile" {
 }
 
 variable "volume_sizes_gbs" {
-  description = "Tamanho em GB de cada block volume anexado ao data-host. Defaults somam 150 GB priorizando MinIO (110 GB) que recebe logs da plataforma além de artefatos. Postgres fica em 15 GB (~7.5x o teto esperado de 2 GB durante testes, cobrindo WAL + índices + vacuum bloat). Limite Always Free OCI Block Volume é 200 GB — restam 50 GB de folga para crescer in-place ou provisionar volume novo sem sair do free tier. Aumentar acima de 200 GB total passa a cobrar ~$0.0085/GB-extra/mês."
+  description = "Tamanho em GB de cada block volume anexado ao data-host. OCI rejeita volumes <50 GB no `CreateVolume` (mínimo documentado: 50 GB, máximo 32 TB, incrementos de 1 GB). Defaults distribuem 4×50 GB = 200 GB total — bate exato no teto histórico da decisão binding do Epic #317. ATENÇÃO: o Always Free Block Volume (200 GB) é amarrado à HOME REGION da tenancy (GRU, no caso da unifesspa-edu-br); volumes em IAD são cobrados em PAYG a ~$0.0255/GB-mês (VPU 0). Custo estimado em IAD: 4×50 GB = ~$5.10/mês."
   type = object({
     postgres = number
     kafka    = number
@@ -82,15 +82,15 @@ variable "volume_sizes_gbs" {
     vault    = number
   })
   default = {
-    postgres = 15
-    kafka    = 15
-    minio    = 110
-    vault    = 10
+    postgres = 50
+    kafka    = 50
+    minio    = 50
+    vault    = 50
   }
 }
 
 variable "volume_vpus_per_gb" {
-  description = "VPUs por GB nos block volumes. 0 = Lower Cost (mínimo, sem IOPS dedicado); 10 = Balanced default OCI. iad-arm usa 0 (suficiente para POC e mantém custo em zero dentro do Always Free)."
+  description = "VPUs por GB nos block volumes. 0 = Lower Cost (mínimo, sem IOPS dedicado, $0.0255/GB-mês PAYG); 10 = Balanced default OCI ($0.0425/GB-mês PAYG). iad-arm usa 0 (suficiente para POC e minimiza custo já que IAD não tem Always Free Block Volume — home region = GRU)."
   type        = number
   default     = 0
 }

--- a/provisioning/oci/iad-arm/variables.tf
+++ b/provisioning/oci/iad-arm/variables.tf
@@ -74,7 +74,7 @@ variable "profile" {
 }
 
 variable "volume_sizes_gbs" {
-  description = "Tamanho em GB de cada block volume anexado ao data-host. OCI rejeita volumes <50 GB no `CreateVolume` (mínimo documentado: 50 GB, máximo 32 TB, incrementos de 1 GB). Defaults distribuem 4×50 GB = 200 GB total — bate exato no teto histórico da decisão binding do Epic #317. ATENÇÃO: o Always Free Block Volume (200 GB) é amarrado à HOME REGION da tenancy (GRU, no caso da unifesspa-edu-br); volumes em IAD são cobrados em PAYG a ~$0.0255/GB-mês (VPU 0). Custo estimado em IAD: 4×50 GB = ~$5.10/mês."
+  description = "Tamanho em GB de cada block volume anexado ao data-host. OCI rejeita volumes <50 GB no `CreateVolume` (mínimo documentado: 50 GB, máximo 32 TB, incrementos de 1 GB). Defaults distribuem 4×50 GB = 200 GB total — bate exato no teto histórico da decisão binding do Epic #317. ATENÇÃO: o Always Free Block Volume (200 GB) é amarrado à HOME REGION da tenancy (GRU, no caso da unifesspa-edu-br); volumes em IAD são cobrados em PAYG a ~$0.0255/GB-mês (VPU 0). Custo estimado em IAD: 4×50 GB = ~$5.10/mês. **DEPENDÊNCIA**: `scripts/bootstrap-standalone.sh` hoje identifica papéis dos block volumes por tamanho (45-55 → vault; 95-105 → kafka; 190-210 → postgres+minio). Com 4×50 GB todos os disks colidem na faixa do vault, e o bootstrap aborta na função `discover_disks`. A refatoração para identificação por display_name/LUN/OCI metadata é PRÉ-REQUISITO da Story #329 (apply em IAD) e está rastreada como follow-up do Epic #317 (ver thread Codex em PR #374)."
   type = object({
     postgres = number
     kafka    = number

--- a/provisioning/oci/iad-arm/variables.tf
+++ b/provisioning/oci/iad-arm/variables.tf
@@ -69,7 +69,7 @@ variable "profile" {
 }
 
 variable "volume_sizes_gbs" {
-  description = "Tamanho em GB de cada block volume anexado ao data-host. Defaults somam 200 GB exatos (limite Always Free OCI Block Volume). Aumentar passa a cobrar ~$0.0085/GB-extra/mês."
+  description = "Tamanho em GB de cada block volume anexado ao data-host. Defaults somam 150 GB priorizando MinIO (110 GB) que recebe logs da plataforma além de artefatos. Postgres fica em 15 GB (~7.5x o teto esperado de 2 GB durante testes, cobrindo WAL + índices + vacuum bloat). Limite Always Free OCI Block Volume é 200 GB — restam 50 GB de folga para crescer in-place ou provisionar volume novo sem sair do free tier. Aumentar acima de 200 GB total passa a cobrar ~$0.0085/GB-extra/mês."
   type = object({
     postgres = number
     kafka    = number
@@ -77,10 +77,10 @@ variable "volume_sizes_gbs" {
     vault    = number
   })
   default = {
-    postgres = 80
-    kafka    = 40
-    minio    = 60
-    vault    = 20
+    postgres = 15
+    kafka    = 15
+    minio    = 110
+    vault    = 10
   }
 }
 

--- a/provisioning/oci/iad-arm/variables.tf
+++ b/provisioning/oci/iad-arm/variables.tf
@@ -63,7 +63,7 @@ variable "ssh_authorized_keys" {
 }
 
 variable "profile" {
-  description = "Perfil de capacidade das VMs A1.Flex. 'poc_arm' (default) = 3 OCPU / 16 GB total, cabe em Always Free A1 (4 OCPU / 24 GB). 'hml_arm' = 6 OCPU / 40 GB total — EXTRAPOLA Always Free, cobra ~$25/mês. Mapeamento em locals.tf."
+  description = "Perfil de capacidade das VMs A1.Flex. 'poc_arm' (default) = 3 OCPU / 16 GB total. 'hml_arm' = 6 OCPU / 40 GB total. ATENÇÃO: Always Free A1 é home-region-only segundo doc Oracle (a tenancy unifesspa-edu-br tem home = GRU); em IAD, ambos perfis são PAYG. Custos estimados: poc_arm ~$39/mês compute (3×$0.01/h + 16×$0.0015/h), hml_arm ~$86/mês compute (6×$0.01/h + 40×$0.0015/h). Mapeamento em locals.tf. Smoke test do gate de validação em README.md pode reverter premissa caso billing mostre Always Free aplicando cross-region."
   type        = string
   default     = "poc_arm"
 

--- a/provisioning/oci/iad-arm/versions.tf
+++ b/provisioning/oci/iad-arm/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 7.7"
+    }
+  }
+}
+
+provider "oci" {
+  region = var.region
+  # Auth via ~/.oci/config (`tenancy_ocid` + `user_ocid` + `fingerprint` + `private_key_path`).
+  # Alternativas: instance principal, resource principal, security token.
+}

--- a/provisioning/oci/iad-arm/versions.tf
+++ b/provisioning/oci/iad-arm/versions.tf
@@ -14,3 +14,44 @@ provider "oci" {
   # Auth via ~/.oci/config (`tenancy_ocid` + `user_ocid` + `fingerprint` + `private_key_path`).
   # Alternativas: instance principal, resource principal, security token.
 }
+
+# ------------------------------------------------------------------------------
+# Provider alias `home_region` para recursos IAM master.
+#
+# IAM master definitions (Dynamic Groups, Policies, Users, Groups,
+# Compartments) só podem ser criadas/alteradas a partir do endpoint IAM da
+# HOME REGION da tenancy — independente da região onde compute/network/storage
+# residem. Tentar criar via endpoint de outra região retorna
+# `NotAuthorizedOrNotFound` (HTTP 404) no apply.
+#
+# A tenancy Uni+ foi criada em sa-saopaulo-1 (GRU) — esse é o home permanente
+# (Oracle permite trocar apenas 1 vez via ticket de suporte). Como o module
+# `iad-arm` aponta o provider default para us-ashburn-1, sem o alias o apply
+# das IAM resources em kms.tf falharia, mesmo com compute/network válidos.
+#
+# A descoberta é dinâmica via data sources — sem variável de input nem
+# hardcode — para o módulo permanecer correto se a home region for trocada
+# no futuro.
+#
+# Refs:
+#   https://docs.oracle.com/iaas/Content/Identity/regions/managingregions.htm
+# ------------------------------------------------------------------------------
+
+data "oci_identity_tenancy" "current" {
+  tenancy_id = var.tenancy_ocid
+}
+
+data "oci_identity_regions" "all" {}
+
+locals {
+  home_region_name = one([
+    for r in data.oci_identity_regions.all.regions :
+    r.name if r.key == data.oci_identity_tenancy.current.home_region_key
+  ])
+}
+
+provider "oci" {
+  alias  = "home_region"
+  region = local.home_region_name
+  # Auth herda do mesmo ~/.oci/config do provider default.
+}


### PR DESCRIPTION
## Resumo

Esqueleto do módulo `provisioning/oci/iad-arm/` que provisiona o lab Uni+ em `us-ashburn-1` sobre `VM.Standard.A1.Flex` (ARM Ampere) — parte da migração descrita no Epic #317.

PR cobre integralmente a Story #323 (Tasks T1.2.1 a T1.2.5). As Tasks de descoberta de OCIDs reais (T1.1.1-T1.1.3) e aplicação efetiva (S1.3) seguem bloqueadas pelo upgrade PAYG da tenancy ainda em processamento.

## O que muda

13 arquivos novos em `provisioning/oci/iad-arm/`, derivados do módulo `standalone` com adaptações para ARM/IAD:

| Arquivo | Mudança principal |
|---|---|
| `compute.tf` | Shape `VM.Standard.E5.Flex` → `VM.Standard.A1.Flex` |
| `locals.tf` | Perfil default `poc_arm` (3 OCPU / 16 GB total — cabe Always Free A1); tag `uniplus_environment = "iad-arm"` |
| `variables.tf` | `region` default `us-ashburn-1`; `vcn_cidr` `10.1.0.0/16`; subnets `10.1.{1,2}.0/24`; `volume_sizes_gbs` total 200 GB (80+40+60+20); `availability_domain` e `image_ocid` como `REPLACE_AFTER_T1_1_2` |
| `dns.tf` | Apex `iad-arm.portaluni.com.br` (paralelo a `standalone.portaluni.com.br` durante coexistência) |
| `network.tf`, `kms.tf`, `storage.tf`, `public_ip.tf`, `outputs.tf` | Naming `uniplus-standalone-*` → `uniplus-iad-arm-*` |
| `terraform.tfvars.example` | Comentários atualizados com comandos de discovery (OCI CLI) para preencher os placeholders |
| `README.md` | Reescrito: diferenças vs `standalone/`, comparativo de custo, placeholders pendentes, próximas Stories |

## Decisões binding (já documentadas no Epic #317)

- **Região:** `us-ashburn-1` (IAD) — capacidade A1 melhor histórica, latência ~140ms BR
- **Shape:** `VM.Standard.A1.Flex` — Always Free 4 OCPU / 24 GB / 200 GB block
- **Profile:** `poc_arm` (3 OCPU / 16 GB) — paridade com `poc` do standalone, custo zero
- **VCN CIDR:** `10.1.0.0/16` — evita conflito com `10.0.0.0/16` do GRU durante migração paralela
- **Block volumes:** 200 GB exatos para caber no Always Free (`postgres 80 + kafka 40 + minio 60 + vault 20`)
- **DNS:** subdomínio paralelo `iad-arm.portaluni.com.br` enquanto GRU continua em `standalone.portaluni.com.br`

## Validação

```bash
cd provisioning/oci/iad-arm
tofu init -backend=false  # OK
tofu validate              # Success! The configuration is valid.
tofu fmt -check -diff      # OK (zero diff)
```

Não foi rodado `tofu plan` porque exige resolução do `data "oci_dns_zones"` em IAD, que depende da Tenancy estar em PAYG e da região assinada (ambos bloqueadores ainda em processamento).

## Próximos passos (Stories desbloqueadas após upgrade PAYG concluir)

1. Story #319 (T1.1.1) — assinar `us-ashburn-1` via `oci iam region-subscription create`
2. Story #319 (T1.1.2) — descobrir AD + imagem aarch64 → substituir os 2 `REPLACE_AFTER_T1_1_2`
3. Story #329 — `tofu apply` + validação de smoke
4. Story #346 — adaptar `bootstrap-standalone.sh` para arm64

## Checklist

- [x] `tofu validate` passa
- [x] `tofu fmt -check` sem diff
- [x] Naming consistente `uniplus-iad-arm-*`
- [x] Profile default cabe em Always Free A1
- [x] Block volumes totalizam ≤200 GB (limite Always Free)
- [x] DNS subdomínio paralelo ao GRU (sem conflito)
- [x] Placeholders explícitos (REPLACE_AFTER_T1_1_2) onde dependem de discovery
- [x] README documenta diferenças vs standalone, custo esperado, comandos de discovery
- [ ] `tofu plan` (bloqueado por PAYG pendente — fica para Story #329)
- [ ] `tofu apply` (Story #329)

Closes #323
Refs #317 #319 #329 #346