### PR TITLE
feat(bootstrap): detecta arch e baixa Helm aarch64 quando uname -m=aarch64

### DIFF
--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -12,10 +12,16 @@
 # Este script é exclusivo para o ambiente standalone OCI (Ubuntu 24.04 LTS).
 #
 # Pré-requisitos:
-#   - Ubuntu 24.04 LTS
+#   - Ubuntu 24.04 LTS (amd64 ou arm64/aarch64 — arquitetura auto-detectada)
 #   - Não executar como root (usa sudo internamente)
-#   - standalone-data: 4 block volumes OCI anexados (postgres 200GB, kafka 100GB,
-#                      minio 200GB, vault 50GB) — rodar lsblk antes para confirmar
+#   - standalone-data: 4 block volumes OCI anexados — rodar lsblk antes
+#     para confirmar (tamanhos variam entre lab GRU/standalone e IAD/iad-arm)
+#
+# Suporte multi-arch:
+#   amd64 (x86_64)  — lab GRU sobre VM.Standard.E5.Flex
+#   arm64 (aarch64) — lab IAD sobre VM.Standard.A1.Flex (Epic #317)
+#   k3s, ArgoCD e docker.io detectam arquitetura nativamente; apenas o
+#   download tarball do Helm exige variável ARCH explícita.
 # ============================================================================
 
 set -euo pipefail
@@ -52,6 +58,18 @@ log_info()    { echo -e "${BLUE}[INFO]${NC} $*"; }
 log_success() { echo -e "${GREEN}[ OK ]${NC} $*"; }
 log_warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# ============== Arquitetura ==============
+# Auto-detecção da arquitetura do host para downloads de binários multi-arch.
+# Padrão usado pelos releases oficiais (Helm, kubectl, mc, etc.):
+# `uname -m=x86_64` -> `amd64`; `uname -m=aarch64` -> `arm64`.
+# k3s installer e o `kubectl apply` do ArgoCD detectam arquitetura sozinhos
+# (manifest install puxa imagem multi-arch da imagem do controlador).
+case "$(uname -m)" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+    *)       log_error "Arquitetura não suportada: $(uname -m). Esperado x86_64 ou aarch64."; exit 1 ;;
+esac
 
 usage() {
     cat <<EOF
@@ -287,15 +305,15 @@ step_install_helm() {
         return
     fi
 
-    log_info "Instalando Helm $HELM_VERSION..."
-    local helm_tar="/tmp/helm-${HELM_VERSION}-linux-amd64.tar.gz"
-    local helm_sha="/tmp/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum"
-    run "curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o $helm_tar"
-    run "curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum -o $helm_sha"
+    log_info "Instalando Helm $HELM_VERSION (linux-$ARCH)..."
+    local helm_tar="/tmp/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz"
+    local helm_sha="/tmp/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz.sha256sum"
+    run "curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz -o $helm_tar"
+    run "curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz.sha256sum -o $helm_sha"
     run "echo \"\$(awk '{print \$1}' $helm_sha)  $helm_tar\" | sha256sum -c"
-    run "tar -xzf $helm_tar -C /tmp linux-amd64/helm"
-    run "sudo install /tmp/linux-amd64/helm /usr/local/bin/helm"
-    run "rm -rf $helm_tar $helm_sha /tmp/linux-amd64"
+    run "tar -xzf $helm_tar -C /tmp linux-${ARCH}/helm"
+    run "sudo install /tmp/linux-${ARCH}/helm /usr/local/bin/helm"
+    run "rm -rf $helm_tar $helm_sha /tmp/linux-${ARCH}"
     log_success "Helm $HELM_VERSION instalado."
 }
 


### PR DESCRIPTION
## Resumo

Adapta `scripts/bootstrap-standalone.sh` para suportar host arm64 além do amd64 atual. Story #346 (S3.1) do Epic #317 — pré-requisito para o lab IAD/A1 ARM bootstrar corretamente quando o módulo `provisioning/oci/iad-arm/` (PR #374) for aplicado.

## O que muda

Surface mínima: o script tem apenas uma rotina arch-sensível, o `step_install_helm`, que baixa o tarball oficial do Helm com nome contendo `linux-amd64`. Tudo o mais (k3s, ArgoCD, docker.io, lvm2/xfsprogs) já é arch-neutral ou auto-detecta.

| Hunk | Conteúdo |
|---|---|
| Header docstring | Documenta suporte multi-arch e quais binários exigem `${ARCH}` explícito |
| Bloco `case "$(uname -m)"` | Mapeia `x86_64→amd64` / `aarch64→arm64`; aborta com `exit 1` em arch não suportada. Posicionado logo após `log_*` para que `log_error` esteja disponível no caminho de erro |
| `step_install_helm` | 4 ocorrências de `linux-amd64` → `linux-${ARCH}` (tarball, sha256sum, tar -xzf, install, rm) |

29 inserções, 11 deleções, 1 arquivo.

## Validação local

```bash
bash -n scripts/bootstrap-standalone.sh   # OK (sintaxe)
git diff --stat                            # 1 file, 29+/11-
```

`shellcheck` não está instalado local — gate de CI cobre.

Pré-revisão local via `/up-coder-revisar` (qwen2.5-coder:14b + uniplus-rag): **LIMPO**, sem findings.

Cruzamento manual de 7 cenários:
- `set -euo pipefail` + case com `;;` — semântica padrão ✓
- `ARCH` setado antes de qualquer chamador (`step_install_helm` roda muito depois) ✓
- Word splitting em `${ARCH}` — valores são `amd64`/`arm64` sem chars especiais ✓
- `log_error ...; exit 1` no `*)` do case — idiom bash padrão ✓
- Quoting em `case "$(uname -m)"` — command substitution dentro de aspas duplas ✓
- k3s installer auto-detecta arch (`get.k3s.io | sh` lê `uname`) ✓
- ArgoCD via `kubectl apply -f manifests/install.yaml` — kubectl resolve digest multi-arch automaticamente ✓

## Notas

- Não toca em volumes, tamanhos de bloco ou nomes de recursos — esses são parametrizados pelo Tofu e variam entre `standalone/` (GRU) e `iad-arm/` (IAD).
- Não adiciona dry-run específico para arch porque o `case` é puro/idempotente e o script tem `--dry-run` global.
- Mantém compatibilidade total com o lab atual em GRU (amd64).

Closes #346
Refs #317