### PR TITLE
Ignora defaults do ESO nos ExternalSecrets (painel ArgoCD limpo)

### DIFF
--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -85,6 +85,22 @@ spec:
             duration: 5s
             factor: 2
             maxDuration: 3m
+      # O webhook do External Secrets Operator injeta defaults do CRD que os
+      # manifests no Git não listam (conversionStrategy, decodingStrategy,
+      # metadataPolicy, nullBytePolicy, deletionPolicy, engineVersion,
+      # mergePolicy), gerando OutOfSync crônico e benigno que mascara drift
+      # real no painel. Ignoramos esses campos derivados.
+      ignoreDifferences:
+        - group: external-secrets.io
+          kind: ExternalSecret
+          jqPathExpressions:
+            - '.spec.data[].remoteRef.conversionStrategy'
+            - '.spec.data[].remoteRef.decodingStrategy'
+            - '.spec.data[].remoteRef.metadataPolicy'
+            - '.spec.data[].remoteRef.nullBytePolicy'
+            - '.spec.target.deletionPolicy'
+            - '.spec.target.template.engineVersion'
+            - '.spec.target.template.mergePolicy'
 
 ---
 apiVersion: argoproj.io/v1alpha1
@@ -164,3 +180,16 @@ spec:
             duration: 10s
             factor: 2
             maxDuration: 5m
+      # Ver nota no AppSet uniplus-apps: ignora defaults injetados pelo webhook
+      # do External Secrets Operator que geram OutOfSync benigno.
+      ignoreDifferences:
+        - group: external-secrets.io
+          kind: ExternalSecret
+          jqPathExpressions:
+            - '.spec.data[].remoteRef.conversionStrategy'
+            - '.spec.data[].remoteRef.decodingStrategy'
+            - '.spec.data[].remoteRef.metadataPolicy'
+            - '.spec.data[].remoteRef.nullBytePolicy'
+            - '.spec.target.deletionPolicy'
+            - '.spec.target.template.engineVersion'
+            - '.spec.target.template.mergePolicy'


### PR DESCRIPTION
## Sumário

Elimina o **OutOfSync crônico** dos 4 ExternalSecrets no painel do ArgoCD (`grafana-oidc-client-secret`, `loki-s3-creds`, `tempo-s3-creds`, `vault-transit-bootstrap-token`).

## Causa raiz

O webhook do External Secrets Operator injeta defaults do CRD que os manifests no Git não listam. Diff confirmado (live vs `helm template`):

| Campo injetado | Local |
|---|---|
| `conversionStrategy`, `decodingStrategy`, `metadataPolicy`, `nullBytePolicy` | cada `spec.data[].remoteRef` |
| `deletionPolicy: Retain` | `spec.target` |
| `engineVersion: v2`, `mergePolicy: Replace` | `spec.target.template` |

O essencial (de onde puxar do Vault) bate 100% — o diff é só dos defaults derivados. Por isso os apps ficam **Healthy mas OutOfSync** permanentemente.

## Por que resolver (não só ignorar visualmente)

OutOfSync crônico **mascara drift real**: se alguém alterar algo de verdade nesses apps, ninguém percebe no meio do ruído. Painel limpo = sinal confiável.

## Solução

`ignoreDifferences` para `kind: ExternalSecret` nos **dois** ApplicationSets (`uniplus-apps` + `uniplus-platform`) — centralizado, cobre todos os ExternalSecrets atuais e futuros, sem replicar os defaults em cada chart.

## Test plan

- [x] `yamllint` + `make validate` exit 0
- [x] Estrutura validada (ambos AppSets com 7 jqPathExpressions)
- [ ] Pós-merge: re-aplicar ApplicationSets → os 4 ExternalSecrets passam a Synced