### PR TITLE
feat(keycloak): habilita SMTP transacional via relay Google Workspace

### DIFF
--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -25,6 +25,19 @@
     "xXSSProtection": "1; mode=block",
     "strictTransportSecurity": "max-age=31536000; includeSubDomains"
   },
+{{- if .Values.keycloak.realmImport.smtp.enabled }}
+  "smtpServer": {
+    "host": {{ .Values.keycloak.realmImport.smtp.host | quote }},
+    "port": {{ .Values.keycloak.realmImport.smtp.port | quote }},
+    "from": {{ .Values.keycloak.realmImport.smtp.from | quote }},
+    "fromDisplayName": {{ .Values.keycloak.realmImport.smtp.fromDisplayName | quote }},
+    "ssl": {{ .Values.keycloak.realmImport.smtp.ssl | quote }},
+    "starttls": {{ .Values.keycloak.realmImport.smtp.starttls | quote }},
+    "auth": {{ .Values.keycloak.realmImport.smtp.auth | quote }}{{ if eq (.Values.keycloak.realmImport.smtp.auth | toString) "true" }},
+    "user": {{ .Values.keycloak.realmImport.smtp.user | quote }},
+    "password": "${SMTP_PASSWORD}"{{ end }}
+  },
+{{- end }}
   "clients": [
     {
       "clientId": {{ .Values.keycloak.realmImport.portalClient.clientId | quote }},

--- a/apps/keycloak-replica/templates/networkpolicy.yaml
+++ b/apps/keycloak-replica/templates/networkpolicy.yaml
@@ -65,4 +65,21 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+    {{- if $np.smtp.enabled }}
+    # SMTP submission para relay externo (Keycloak envia e-mail transacional).
+    # Relay (ex.: Google Workspace) usa faixas amplas → liberar a porta para
+    # cidrs com except das redes privadas. Habilitado via networkPolicy.smtp.
+    - to:
+        {{- range $np.smtp.cidrs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+            {{- with $np.smtp.except }}
+            except:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ $np.smtp.port }}
+    {{- end }}
 {{- end }}

--- a/apps/keycloak-replica/values.schema.json
+++ b/apps/keycloak-replica/values.schema.json
@@ -110,6 +110,21 @@
                   "items": { "type": "string" }
                 }
               }
+            },
+            "smtp": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "host": { "type": "string" },
+                "port": { "type": "string" },
+                "from": { "type": "string" },
+                "fromDisplayName": { "type": "string" },
+                "starttls": { "type": "string", "enum": ["true", "false"] },
+                "ssl": { "type": "string", "enum": ["true", "false"] },
+                "auth": { "type": "string", "enum": ["true", "false"] },
+                "user": { "type": "string" }
+              }
             }
           }
         },
@@ -168,7 +183,17 @@
             "traefikNamespace": { "type": "string" },
             "monitoringNamespace": { "type": "string" },
             "dataHostCIDR": { "type": "string" },
-            "dataHostPort": { "type": "integer", "minimum": 1, "maximum": 65535 }
+            "dataHostPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "smtp": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+                "cidrs": { "type": "array", "items": { "type": "string" } },
+                "except": { "type": "array", "items": { "type": "string" } }
+              }
+            }
           }
         },
         "serviceMonitor": {

--- a/apps/keycloak-replica/values.yaml
+++ b/apps/keycloak-replica/values.yaml
@@ -104,6 +104,26 @@ keycloak:
       redirectUris: []
       webOrigins:
         - "+"
+    # Servidor SMTP do realm — envio de e-mail transacional (reset de senha,
+    # verificação de e-mail, "executar ações por e-mail"). Desabilitado por
+    # padrão; cada environment habilita e aponta o relay. Reconciliado pelo
+    # Job realm-reconcile (ADR-010) — o bloco smtpServer faz parte da
+    # representação do realm e é sempre atualizado pelo keycloak-config-cli.
+    smtp:
+      enabled: false
+      host: ""
+      port: "587"
+      from: ""
+      fromDisplayName: "Uni+ — Unifesspa"
+      # STARTTLS na porta submission (587). ssl=true só para SMTPS (465).
+      starttls: "true"
+      ssl: "false"
+      # auth=false quando o relay autoriza por allowlist de IP (sem
+      # credencial a custodiar). Se o relay exigir login, setar auth=true,
+      # preencher `user` e injetar ${SMTP_PASSWORD} via ExternalSecret
+      # (entrada em oidcClientSecrets.clients) — ver files/uniplus-realm.json.
+      auth: "false"
+      user: ""
 
   # Realm reconcile — Job Helm hook (post-install,post-upgrade) que
   # executa keycloak-config-cli (adorsys) para reconciliar o realm
@@ -206,6 +226,20 @@ keycloak:
     monitoringNamespace: observability-prometheus
     dataHostCIDR: ""
     dataHostPort: 5432
+    # Egress SMTP para relay externo (envio de e-mail transacional do KC).
+    # Desabilitado por padrão; habilitar no environment que configura o
+    # smtpServer. Relays como o Google Workspace (smtp-relay.gmail.com) usam
+    # faixas de IP amplas/dinâmicas, então liberamos a porta submission para
+    # `cidrs` com `except` das redes privadas (evita egress lateral interno).
+    smtp:
+      enabled: false
+      port: 587
+      cidrs:
+        - 0.0.0.0/0
+      except:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
 
   # ServiceMonitor — desligado até platform/observability/prometheus/
   # aterrissar (issue #26).

--- a/environments/standalone-compact/values.yaml
+++ b/environments/standalone-compact/values.yaml
@@ -781,6 +781,31 @@ keycloak:
       webOrigins:
         - "+"
 
+    # SMTP via Google Workspace relay (issue #390). Autenticação por allowlist
+    # de IP no Workspace (o egress do cluster sai com 137.131.131.6) — sem
+    # credencial, então auth=false e nenhum secret no Vault. STARTTLS na 587.
+    # Aplicado ao realm vivo pelo Job realm-reconcile (smtpServer faz parte da
+    # representação do realm). Depende de: (1) egress liberado via
+    # networkPolicy.smtp abaixo; (2) JAVA_OPTS preferIPv4Stack em extraEnv
+    # (o pod resolve o relay em IPv6 e o cluster não tem egress IPv6);
+    # (3) admin do Workspace autorizar o IP 137.131.131.6/32 no relay service.
+    smtp:
+      enabled: true
+      host: smtp-relay.gmail.com
+      port: "587"
+      from: noreply@unifesspa.edu.br
+      fromDisplayName: "Uni+ — Unifesspa"
+      starttls: "true"
+      ssl: "false"
+      auth: "false"
+
+  # Força IPv4 no JVM do Keycloak. Sem isso o pod resolve smtp-relay.gmail.com
+  # pelo registro AAAA e falha com "Network is unreachable" (cluster sem egress
+  # IPv6). Necessário para o envio SMTP funcionar (issue #390).
+  extraEnv:
+    - name: JAVA_OPTS_APPEND
+      value: "-Djava.net.preferIPv4Stack=true"
+
   # Realm reconcile via keycloak-config-cli (Story #177) — habilitado em
   # standalone para fechar o gap descoberto durante o smoke #181: clients
   # M2M com mappers ausentes em realm vivo (Keycloak 26.x skipa re-import).
@@ -834,6 +859,12 @@ keycloak:
     # environments/standalone/README.md, seção provider-specifics).
     dataHostCIDR: 10.2.2.11/32
     dataHostPort: 5432
+    # Egress para o relay SMTP externo (issue #390). Google Workspace usa
+    # faixas amplas → libera a porta submission para 0.0.0.0/0 com except das
+    # redes privadas (mantém o bloqueio de egress lateral interno).
+    smtp:
+      enabled: true
+      port: 587
 
   # ServiceMonitor desligado até platform/observability/prometheus/ subir.
   serviceMonitor:


### PR DESCRIPTION
## O que muda

Habilita o envio de e-mail transacional do Keycloak (realm `uniplus`) no `standalone-compact` — reset de senha, verificação de e-mail e "executar ações por e-mail". Hoje o realm não tem `smtpServer`, então essas ações não funcionam.

**Backend:** Google Workspace relay `smtp-relay.gmail.com:587` (STARTTLS), autenticado por **allowlist de IP** no Workspace → `auth: false`, sem credencial no Vault.

## Três peças (chart `apps/keycloak-replica/`)

1. **`networkPolicy.smtp`** — libera egress TCP `587` para o relay. O egress do pod hoje só permite `5432` (Postgres no data-host) + `53` (DNS); o relay ficava inalcançável. `except` das redes privadas evita abrir egress lateral interno.
2. **`extraEnv JAVA_OPTS_APPEND=-Djava.net.preferIPv4Stack=true`** — o pod resolvia `smtp-relay.gmail.com` pelo registro AAAA e falhava com `Network is unreachable` (cluster sem egress IPv6).
3. **Bloco `smtpServer`** condicional no `files/uniplus-realm.json`, aplicado ao realm vivo pelo Job `realm-reconcile` (ADR-010).

Knobs values-driven **desligados por padrão**; habilitados só em `environments/standalone-compact/`. `values.schema.json` estendido (`realmImport.smtp`, `networkPolicy.smtp`).

## Validação local

- `make helm-lint` ✅
- `make schema-validate` ✅
- `make yaml-lint` ✅ (warnings pré-existentes em loki/otelcol, não tocados)
- Render conferido: `uniplus-realm.json` é JSON válido com `smtpServer` (auth false, sem user/password); egress com `587` + `except`; `JAVA_OPTS_APPEND` no deployment.

## Diagnóstico que motivou o PR

Egress do cluster sai com IP `137.131.131.6`. O **node** alcança `smtp-relay.gmail.com:587` (IPv4 `142.250.0.28`), mas o **pod** não, por causa da NetworkPolicy de egress (só 5432+DNS) — confirmado com teste de conexão.

## ⚠️ Pendências pós-merge (fora deste repo)

Para o SMTP funcionar de ponta a ponta:

1. **Google Workspace Admin** — habilitar o *SMTP relay service* (Apps → Google Workspace → Gmail → Routing), autorizar o IP **`137.131.131.6/32`** e exigir **TLS**.
2. Após sync do ArgoCD + config do Workspace: validar em **Keycloak Admin → Realm settings → Email → Test connection**.

Por isso o PR referencia (`Refs #390`) em vez de fechar a issue — ela só fecha após a validação ao vivo.

Refs #390