### PR TITLE
fix(keycloak): sobe imagem composta para 26.6.4-0 (CVEs + migração Postgres)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Não lançado]
 
+### Segurança
+
+- Chart `keycloak-replica` sobe a imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak` de `26.6.1-0` para **`26.6.4-0`** (Keycloak 26.6.4 + JAR `cpf-matcher`). O Keycloak 26.6.4 corrige 8 CVEs — incluindo CVE-2026-11800 (authentication bypass via JWT algorithm confusion), CVE-2026-9099 (privilege escalation group-admin → realm-admin) e CVE-2026-9799/9800 (authorization bypass) — além do bug de migração Postgres `keycloak/keycloak#48438` (restart loop ao migrar schema 26.5→26.6). `appVersion` e `version` do Chart (0.3.0 → 0.3.1) sincronizadas. Imagem publicada em `unifesspa-edu-br/uniplus-keycloak-providers#16`. Issue #392.
+
 ### Removido
 
 - Limpeza do repositório para focar no `standalone-compact` como único ambiente operacional (2026-05-19): removidos `environments/lab-{sp1,sp2,pa1}`, `environments/prod-{sp1,sp2,pa1}` e `environments/standalone/` (nunca provisionados ou já destruídos); `provisioning/oci/standalone/` (VMs destruídas) e `provisioning/oci/iad-arm/` (exploração ARM Phoenix abandonada); `docs/SETUP.md`, `docs/VALIDATION-PLAN.md`, `docs/network-matrix.md` (laboratório multi-DC nunca executado); `scripts/bootstrap-lab.sh` e `scripts/teardown-lab.sh`.

--- a/apps/keycloak-replica/Chart.yaml
+++ b/apps/keycloak-replica/Chart.yaml
@@ -6,12 +6,12 @@ description: |
 type: application
 
 # Versão do chart wrapper Uni+. Bump em qualquer mudança de template/values.
-version: 0.3.0
+version: 0.3.1
 
 # Versão da imagem composta `uniplus-keycloak` empacotada (sincronizar com
 # image.tag). Scheme :<KC-VERSION>-<PATCH-PROVIDERS> — ver
 # unifesspa-edu-br/uniplus-keycloak-providers.
-appVersion: "26.6.1-0"
+appVersion: "26.6.4-0"
 
 home: https://github.com/unifesspa-edu-br/uniplus-infra
 sources:

--- a/apps/keycloak-replica/README.md
+++ b/apps/keycloak-replica/README.md
@@ -59,7 +59,7 @@ O chart codifica estas opções de configuração runtime do Keycloak 26.x:
 
 ## Decisões de design
 
-- **Imagem composta `uniplus-keycloak` + `start --import-realm`** (sem rebuild custom): a imagem `ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0` é Keycloak 26.6.1 upstream + JAR `cpf-matcher` (SPI institucional), com health/metrics built-in. `start` (sem `--optimized`) deixa o Keycloak fazer auto-build na primeira inicialização — `startupProbe.failureThreshold: 60` (×10s = 10min) absorve a janela. Standalone usa a mesma imagem que vai pra HML/PROD para garantir production parity.
+- **Imagem composta `uniplus-keycloak` + `start --import-realm`** (sem rebuild custom): a imagem `ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0` é Keycloak 26.6.4 upstream + JAR `cpf-matcher` (SPI institucional), com health/metrics built-in. `start` (sem `--optimized`) deixa o Keycloak fazer auto-build na primeira inicialização — `startupProbe.failureThreshold: 60` (×10s = 10min) absorve a janela. Standalone usa a mesma imagem que vai pra HML/PROD para garantir production parity.
 - **Realm import idempotente**: `--import-realm` em 26.x **não re-importa** se o realm já existir, preservando mudanças via Admin UI. Para forçar reimport: `kc.sh import` explícito (não automático).
 - **`uniplus-portal` é public client (SPA + PKCE)**: realm JSON declara `"publicClient": true` sem `client_secret`. Browsers não podem custodiar segredo; PKCE substitui o secret em fluxos de Authorization Code (`code_verifier` gerado pelo SPA garante a posse do code). Para futuros clients confidenciais (ex.: backend BFF, Vault UI integration #34), criar entradas separadas no realm com seus próprios secrets via Vault.
 - **Sem PV**: estado durável vive todo no Postgres. `/tmp` em emptyDir.

--- a/apps/keycloak-replica/values.yaml
+++ b/apps/keycloak-replica/values.yaml
@@ -28,7 +28,7 @@ keycloak:
     # Standalone usa a MESMA imagem que vai pra HML/PROD para garantir que o
     # smoke E2E valida exatamente o binário de produção (production parity).
     # Sincronizar com appVersion do Chart.yaml.
-    tag: "26.6.1-0"
+    tag: "26.6.4-0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []
@@ -128,7 +128,7 @@ keycloak:
       # diferentes podem falhar em migrations de schema). Versões em
       # https://quay.io/repository/adorsys/keycloak-config-cli?tab=tags
       # 6.5.0-26.5.4 é a tag mais recente disponível; KC 26.6.x ainda sem
-      # tag pareada upstream. Mesma major do KC vivo (26.6.1) → admin API
+      # tag pareada upstream. Mesma major do KC vivo (26.6.4) → admin API
       # estável (`/admin/realms/{realm}/clients/{id}/protocol-mappers/models`
       # não muda). Quando adorsys publicar `*-26.6.x`, abrir follow-up.
       tag: "6.5.0-26.5.4"
@@ -224,7 +224,7 @@ keycloak:
     periodSeconds: 5
 
   # SecurityContext do Pod e do container. Imagem oficial
-  # quay.io/keycloak/keycloak:26.6.1 roda como UID 1000.
+  # quay.io/keycloak/keycloak:26.6.4 roda como UID 1000.
   podSecurityContext:
     fsGroup: 1000
   containerSecurityContext:

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1659,7 +1659,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: kc-import
-          image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0
+          image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0
           args:
             - import
             - --override=true
@@ -2639,7 +2639,7 @@ kc exec -n uniplus -i deploy/keycloak-replica-uniplus-standalone -- bash -c '
     --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" >/dev/null
 
   # 1.1 Criar grupos /admins/kafka e /users/uniplus (idempotente — ignora se existem).
-  # NOTA: container ghcr.io/.../uniplus-keycloak:26.6.1-0 herda RHEL 9 minimal
+  # NOTA: container ghcr.io/.../uniplus-keycloak:26.6.4-0 herda RHEL 9 minimal
   # do upstream Keycloak e NÃO tem awk/jq/python — usar grep+cut. Pattern para
   # extrair ID por name no CSV.
   for GP in "admins/kafka" "users/uniplus"; do


### PR DESCRIPTION
## O que muda

Sobe o chart `keycloak-replica` da imagem composta **`26.6.1-0` → `26.6.4-0`** (Keycloak 26.6.1 → 26.6.4).

| Arquivo | Mudança |
|---|---|
| `apps/keycloak-replica/values.yaml` | `image.tag` `26.6.1-0` → `26.6.4-0` (+ comentários) |
| `apps/keycloak-replica/Chart.yaml` | `appVersion` `26.6.1-0` → `26.6.4-0`; `version` `0.3.0` → `0.3.1` |
| `apps/keycloak-replica/README.md`, `docs/RUNBOOKS.md` | refs de versão alinhadas |
| `CHANGELOG.md` | entrada em **Segurança** |

## Por quê — segurança + migração

O **Keycloak 26.6.4** (última estável) corrige cumulativamente:

- **8 CVEs**, vários críticos para um IdP: **CVE-2026-11800** (authentication bypass via JWT algorithm confusion), **CVE-2026-9099** (privilege escalation group-admin → realm-admin), **CVE-2026-9799/9800** (authorization bypass), entre outros;
- o bug de migração Postgres [keycloak/keycloak#48438](https://github.com/keycloak/keycloak/issues/48438) (restart loop ao migrar schema 26.5→26.6; corrigido no 26.6.3, incluído no 26.6.4).

**HML/PROD usam Postgres** — estavam expostos tanto aos CVEs quanto ao bug de migração. A imagem `26.6.4-0` já está publicada no GHCR (via `uniplus-keycloak-providers#16`).

## Validação

- `helm lint` (chart): **0 falhas**;
- `make schema-validate`: **EXIT 0**;
- `make helm-lint`: **EXIT 0**;
- `helm template` (env `standalone-compact`): renderiza `image: "ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0"` e `app.kubernetes.io/version: "26.6.4-0"`.

## Rollout

Este PR só atualiza o GitOps — o **ArgoCD reconcilia** a mudança no cluster. Como é um upgrade de patch dentro da linha 26.6.x (26.6.1 → 26.6.4), a migração de schema no Postgres já inclui o fix do #48438; observar o rollout do StatefulSet do Keycloak (auto-build na primeira inicialização; `startupProbe` cobre a janela).

Closes #392