### PR TITLE
feat(lab): liga Apicurio Registry e Kafka no lab-standalone-single

### DIFF
--- a/apps/apicurio-registry/README.md
+++ b/apps/apicurio-registry/README.md
@@ -38,7 +38,7 @@ Apicurio Registry vem com default `QUARKUS_OIDC_AUTH_SERVER_URL=https://auth.api
 - UI: `https://schema-registry.standalone.portaluni.com.br/ui` (login OIDC obrigatório)
 - API V3 (Apicurio nativa): `/apis/registry/v3`
 - API V2 (Confluent SR compat): `/apis/ccompat/v7`
-- Health: `/q/health/{started,live,ready}`
+- Health: `/apis/registry/v3/system/info` (Apicurio 3.2.4 desabilita `/q/health/*` — as probes do `deployment.yaml` usam este endpoint)
 - Metrics: `/q/metrics` (Prometheus, scrape via `serviceMonitor.enabled: true`)
 
 ## Operação

--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -210,6 +210,72 @@
         }
       ]
     },
+    {{/*
+      Composition root pós-ADR-0097 do uniplus-api (absorve Selecao+Ingresso+
+      Configuracao+OrganizacaoInstitucional num único processo). Os clients
+      legados uniplus-api-{selecao,ingresso} abaixo permanecem em uso apenas
+      em standalone-compact (produção real, ainda não migrada pro modelo
+      Host) — não remover/alterar.
+
+      CLIENT.DESCRIPTION no schema do Keycloak é varchar(255) — manter a
+      description abaixo curta (mesmo padrão dos demais clients M2M desta
+      lista) para não estourar o limite e quebrar o realm-reconcile-job com
+      "value too long for type character varying(255)".
+    */}}
+    {
+      "clientId": "uniplus-api-host",
+      "name": "Uni+ API Host — Service Account (M2M)",
+      "description": "Service Account M2M do uniplus-api-host → Apicurio SR. Confidential — secret em secret/standalone/keycloak/clients/uniplus-api-host via kcadm pós-import. Mappers: aud=apicurio-registry + groups=[/users/uniplus]→sr-developer. RUNBOOKS §15.6.",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "frontchannelLogout": false,
+      "redirectUris": [],
+      "webOrigins": [],
+      "attributes": {
+        "access.token.lifespan": "300"
+      },
+      "defaultClientScopes": [
+        "basic",
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "protocolMappers": [
+        {
+          "name": "audience-apicurio-registry",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "apicurio-registry",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "groups-hardcoded-developer",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "groups",
+            "claim.value": "[\"/users/uniplus\"]",
+            "jsonType.label": "JSON",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "access.tokenResponse.claim": "false"
+          }
+        }
+      ]
+    },
     {
       "clientId": "uniplus-api-portal",
       "name": "Uni+ API Portal — Service Account (M2M)",

--- a/apps/uniplus-api-host/templates/deployment.yaml
+++ b/apps/uniplus-api-host/templates/deployment.yaml
@@ -117,9 +117,11 @@ spec:
             # checagem, desligando o transporte Kafka de forma limpa sem
             # disparar a validação fatal "Kafka:BootstrapServers populado mas
             # SchemaRegistry:Url vazio" (ADR-0051). Mesma receita documentada em
-            # uniplus-api/docker/docker-compose.monolito.yml. Omitir a env var
-            # por completo (como nos charts uniplus-api-{selecao,portal}) NÃO
-            # é equivalente aqui: description completa no values.yaml.
+            # uniplus-api/docker/docker-compose.monolito.yml e já replicada em
+            # apps/uniplus-api-portal/templates/deployment.yaml (issue #423).
+            # Omitir a env var por completo (como ainda fazem os charts legados
+            # uniplus-api-{selecao,ingresso}, mantidos só para standalone-compact)
+            # NÃO é equivalente aqui: description completa no values.yaml.
             - name: Kafka__BootstrapServers
               value: {{ if .Values.uniplusApiHost.kafka.enabled }}{{ .Values.uniplusApiHost.kafka.bootstrapServers | quote }}{{ else }}" "{{ end }}
             {{- if .Values.uniplusApiHost.kafka.enabled }}

--- a/apps/uniplus-api-portal/templates/deployment.yaml
+++ b/apps/uniplus-api-portal/templates/deployment.yaml
@@ -106,13 +106,23 @@ spec:
                   key: REDIS_PASSWORD
             - name: Redis__ConnectionString
               value: "{{ .Values.uniplusApiPortal.redis.host }}:{{ .Values.uniplusApiPortal.redis.port }},user={{ .Values.uniplusApiPortal.redis.username }},password=$(REDIS_PASSWORD)"
+            # === Kafka — BootstrapServers SEMPRE setado (nunca omitido). A API
+            # lê via string.IsNullOrWhiteSpace em WolverineOutboxConfiguration
+            # (uniplus-api) — " " (espaço) é tratado como "vazio" por essa
+            # checagem, desligando o transporte Kafka de forma limpa. Omitir a
+            # env var por completo faz o SDK Confluent.Kafka cair no default
+            # localhost:9092 e entrar em loop de reconexão eterno, mantendo o
+            # Kafka health check dentro de /health (readiness) permanentemente
+            # Unhealthy mesmo com o transporte desligado (bug real descoberto
+            # na Task #412, revertida — issue #423). Mesmo padrão já usado em
+            # apps/uniplus-api-host/templates/deployment.yaml.
+            - name: Kafka__BootstrapServers
+              value: {{ if .Values.uniplusApiPortal.kafka.enabled }}{{ .Values.uniplusApiPortal.kafka.bootstrapServers | quote }}{{ else }}" "{{ end }}
             {{- if .Values.uniplusApiPortal.kafka.enabled }}
             # === Kafka (SASL_SSL + SCRAM via .NET nested binding) ===
             # Confluent.Kafka client lê estas env como AdminClientConfig/
             # ProducerConfig.SecurityProtocol/SaslMechanism/SaslUsername/etc
             # quando bind via IConfiguration.GetSection("Kafka").
-            - name: Kafka__BootstrapServers
-              value: {{ .Values.uniplusApiPortal.kafka.bootstrapServers | quote }}
             - name: Kafka__SecurityProtocol
               value: {{ .Values.uniplusApiPortal.kafka.securityProtocol | quote }}
             - name: Kafka__SaslMechanism

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -3679,6 +3679,7 @@ sistema operacional:
 | External Secrets Operator | K3s | `platform/external-secrets/` |
 | Keycloak (realm `uniplus`) | K3s | `apps/keycloak-replica/` |
 | `unifesspa-geo-api` | K3s | `apps/unifesspa-geo-api/` |
+| Apicurio Registry (Schema Registry) | K3s | `apps/apicurio-registry/` |
 | `uniplus-api-host` (Selecao+Ingresso+Configuracao+OrganizacaoInstitucional, ADR-0097) | K3s | `apps/uniplus-api-host/` |
 | `uniplus-api-portal` | K3s | `apps/uniplus-api-portal/` |
 
@@ -3730,10 +3731,24 @@ chart `uniplus-api-host` corrige isso renderizando sempre
 `string.IsNullOrWhiteSpace(" ")=true` em dois pontos do `uniplus-api`
 (`WolverineOutboxConfiguration.cs`, `SelecaoMessagingRegistration.cs`) desliga o Kafka de forma
 limpa sem disparar a validação fatal do módulo Selecao (ADR-0051 do `uniplus-api`). Detalhes em
-`apps/uniplus-api-host/README.md`. O chart `uniplus-api-portal` **ainda não** tem esse fix — continua
-omitindo a env var por completo quando `kafka.enabled=false` (mesmo padrão do `uniplus-api-selecao`
-revertido) — corrigir isso é pré-requisito para religar Kafka no Portal junto da issue
-[#423](https://github.com/unifesspa-edu-br/uniplus-infra/issues/423).
+`apps/uniplus-api-host/README.md`. O chart `uniplus-api-portal` recebeu o mesmo fix na issue
+[#423](https://github.com/unifesspa-edu-br/uniplus-infra/issues/423) — antes disso omitia a env var
+por completo quando `kafka.enabled=false` (mesmo padrão do `uniplus-api-selecao` revertido).
+
+**Apicurio Registry `CrashLoopBackOff` no consumidor (`Connection refused`) mesmo com o Service
+saudável.** O template `apps/apicurio-registry/templates/networkpolicy.yaml` só libera ingress na
+porta 8080 para pods do namespace `traefik` — em produção (`standalone-compact`), todo tráfego
+HTTP ao Apicurio passa pelo Traefik mesmo quando o consumidor está no mesmo cluster
+(`schemaRegistry.url` aponta para o hostname público, não para o Service ClusterIP). O
+`lab-standalone-single` não tem Traefik: `uniplus-api-host`/`uniplus-api-portal` (namespace
+`uniplus`) nunca batem no allow-list da NetworkPolicy do Apicurio, e o
+`SchemaRegistrationHostedService` derruba o pod no boot com `HttpRequestException: Connection
+refused` — apesar do `curl` direto ao Service funcionar normalmente de outro pod do namespace
+`uniplus` (a policy bloqueia especificamente esse tráfego, não é problema de DNS/Service/rota).
+Mesmo racional já aplicado ao `keycloak-replica` neste lab (§20.4): desligar a policy inteira
+(`apicurioRegistry.networkPolicy.enabled: false` em
+`environments/lab-standalone-single/values.yaml`) em vez de reimplementá-la para o caso
+same-namespace — sem fronteira de segurança real a proteger num lab single-node.
 
 ### 20.4 Deploy das APIs de negócio (uniplus-api-host / uniplus-api-portal)
 
@@ -3846,8 +3861,9 @@ escopo de uma Task de lab. Quando a primeira release real existir
 (`ghcr.io/unifesspa-edu-br/uniplus-api-host`), atualizar `image.registry`/`image.repository`/
 `image.tag`/`pullPolicy` no environment e remover o passo 4.
 
-Detalhes completos (banco único com 5 connection strings, Kafka desligado até o Apicurio Registry
-entrar no lab — issue [#423](https://github.com/unifesspa-edu-br/uniplus-infra/issues/423)) em
+Detalhes completos (banco único com 5 connection strings, Kafka + Schema Registry ligados desde a
+issue [#423](https://github.com/unifesspa-edu-br/uniplus-infra/issues/423) — deploy do Apicurio
+Registry documentado em `environments/lab-standalone-single/README.md`) em
 `apps/uniplus-api-host/README.md` e `environments/lab-standalone-single/README.md`.
 
 ### 20.5 Diferenças em relação ao `standalone-compact`
@@ -3857,7 +3873,7 @@ entrar no lab — issue [#423](https://github.com/unifesspa-edu-br/uniplus-infra
 | Hosts | 2 VMs (`k8s-host` + `data-host`) | 1 VM combinando os dois papéis |
 | Deploy | GitOps via ArgoCD | Manual (`helm install/upgrade -f`) |
 | Vault | Shamir 5/3, `service_registration "kubernetes"` | Shamir 1/1 (simplificado) |
-| Kafka nas APIs | Ligado, Apicurio Registry disponível | Desligado até issue #423; `Kafka__BootstrapServers=" "` só no Host, Portal ainda omite a env var (ver §20.3) |
+| Kafka nas APIs | Ligado, Apicurio Registry disponível | Ligado desde issue #423, Apicurio Registry disponível (NetworkPolicy desligada — sem Traefik no lab, ver §20.3) |
 | Provisionamento | OpenTofu (`provisioning/oci/standalone/`) | VM provisionada fora deste repositório (VirtualBox) |
 
 ---

--- a/environments/lab-standalone-single/README.md
+++ b/environments/lab-standalone-single/README.md
@@ -161,14 +161,16 @@ vault kv put secret/standalone/postgres/apicurio username=apicurio password=@<(p
 
 # 3. client_secret do client "apicurio-registry" (já existe no realm.json
 #    desde a issue #152) — recuperar via kcadm dentro do próprio pod do
-#    Keycloak, nunca em argv local
+#    Keycloak. Senha via stdin (sh -c de aspas simples, sem interpolação
+#    local) — nunca em argv local nem do pod.
 KC_ADMIN_PW=$(vault kv get -field=password secret/standalone/keycloak/admin)
-kubectl exec -n uniplus deploy/keycloak-replica -- sh -c "
+printf '%s' "$KC_ADMIN_PW" | kubectl exec -i -n uniplus deploy/keycloak-replica -- sh -c '
+  read -r ADMIN_PW
   /opt/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth \
-    --realm master --user admin --password '$KC_ADMIN_PW'
-  CID=\$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus -q clientId=apicurio-registry --fields id --format csv --noquotes | tail -1)
-  /opt/keycloak/bin/kcadm.sh get clients/\$CID/client-secret -r uniplus --fields value --format csv --noquotes
-" | tail -1 > /tmp/apicurio-cs
+    --realm master --user admin --password "$ADMIN_PW"
+  CID=$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus -q clientId=apicurio-registry --fields id --format csv --noquotes | tail -1)
+  /opt/keycloak/bin/kcadm.sh get clients/$CID/client-secret -r uniplus --fields value --format csv --noquotes
+' | tail -1 > /tmp/apicurio-cs
 vault kv put secret/standalone/keycloak/clients/apicurio-registry client_secret=@/tmp/apicurio-cs
 shred -u /tmp/apicurio-cs
 kill "$PF_PID" 2>/dev/null; unset VAULT_TOKEN VAULT_ADDR ROLE_PW PF_PID KC_ADMIN_PW  # sem exit — o passo 4 segue no mesmo shell

--- a/environments/lab-standalone-single/README.md
+++ b/environments/lab-standalone-single/README.md
@@ -120,6 +120,34 @@ gera segredo novo:
 | `secret/standalone/kafka/admin` | `$DATA_BASE/kafka/.bootstrap-creds` + `/etc/uniplus-kafka/certs/ca.crt` (Task #408) |
 | `secret/standalone/keycloak/clients/uniplus-api-{selecao,portal,ingresso,host}` | `kcadm.sh get clients/.../client-secret` no pod `keycloak-replica` (clients M2M já existentes no realm — selecao/portal/ingresso desde a issue #163, host desde a issue #423) |
 
+**Pré-requisito para o client `uniplus-api-host` (novo na issue #423): o
+Keycloak precisa ter reconciliado o `uniplus-realm.json` atualizado.**
+`--import-realm` do Keycloak só roda no primeiro boot — se o realm `uniplus`
+já existe no banco (lab que já rodou `helm install keycloak-replica` antes
+desta issue), um `helm upgrade` normal com o `uniplus-realm.json` atualizado
+**não** cria o client novo, porque `keycloak.realmReconcile.enabled` é
+`false` por padrão no chart e este `values.yaml` não liga a chave (mesma
+lacuna documentada no RUNBOOKS.md sobre o `realm-reconcile-job`). Sem isso,
+`seed-vault-secrets.sh` aborta em "client_secret de uniplus-api-host veio
+vazio — client existe no realm uniplus?" **antes de escrever qualquer path
+no Vault** (nem os dos outros 3 clients). Rodar antes, num lab que já tinha
+Keycloak deployado:
+
+```bash
+helm upgrade keycloak-replica apps/keycloak-replica/ -f environments/lab-standalone-single/values.yaml \
+  --set keycloak.enabled=true \
+  --set keycloak.networkPolicy.enabled=false \
+  --set keycloak.database.host=192.168.1.65 \
+  --set keycloak.hostname.strict=false \
+  --set keycloak.realmReconcile.enabled=true \
+  --namespace uniplus \
+  --wait --timeout=300s
+```
+
+Num lab **novo** (primeiro `helm install`, seção "uniplus-api-portal"
+abaixo), o client já nasce junto no `--import-realm` inicial — este passo
+extra não é necessário.
+
 **Não cobre** `secret/standalone/postgres/portal` — o role+db Postgres
 dedicado só existe a partir da Task #413, populado dentro do procedimento
 daquela Task, não aqui. Rodar o script de novo depois é seguro —

--- a/environments/lab-standalone-single/README.md
+++ b/environments/lab-standalone-single/README.md
@@ -20,8 +20,9 @@ External Secrets Operator, ...) é validado.
 | Vault | `platform/vault/` | Single-node (replicas=1), Shamir manual (1 key share, threshold 1 — simplificado para lab), sem peer PA1/OCI KMS |
 | External Secrets Operator | `platform/external-secrets/` | `ClusterSecretStore vault-default` apontando para o Vault acima; NetworkPolicy habilitada nos dois charts (ver nota abaixo) |
 | Secrets iniciais | `scripts/lab-standalone-single/seed-vault-secrets.sh` | Popula no Vault os paths que os charts de API/Keycloak esperam — ver seção própria abaixo |
-| uniplus-api-portal | `apps/uniplus-api-portal/` | Deployable autônomo (ADR-0097 do `uniplus-api`); Kafka desligado (issue #423 — ver seção própria abaixo); módulo Portal ainda sem migrations de domínio no código (só schema `wolverine` de infraestrutura) |
-| uniplus-api-host | `apps/uniplus-api-host/` | Composition root do monólito modular (Selecao+Ingresso+Configuracao+OrganizacaoInstitucional, ADR-0097 do `uniplus-api`); imagem buildada localmente (sem publish em GHCR ainda) — ver seção própria abaixo |
+| apicurio-registry | `apps/apicurio-registry/` | Schema Registry (Confluent-compat) para uniplus-api-host/uniplus-api-portal (issue #423) — ver seção própria abaixo |
+| uniplus-api-portal | `apps/uniplus-api-portal/` | Deployable autônomo (ADR-0097 do `uniplus-api`); Kafka+Schema Registry ligados desde a issue #423 — ver seção própria abaixo; módulo Portal ainda sem migrations de domínio no código (só schema `wolverine` de infraestrutura) |
+| uniplus-api-host | `apps/uniplus-api-host/` | Composition root do monólito modular (Selecao+Ingresso+Configuracao+OrganizacaoInstitucional, ADR-0097 do `uniplus-api`); Kafka+Schema Registry ligados desde a issue #423; imagem buildada localmente (sem publish em GHCR ainda) — ver seção própria abaixo |
 
 ## Uso
 
@@ -125,6 +126,76 @@ daquela Task, não aqui. Rodar o script de novo depois é seguro —
 `vault kv put` é idempotente por natureza, sempre reflete a fonte de
 verdade atual (útil inclusive para sincronizar após rotação de um
 client_secret no Keycloak).
+
+## Apicurio Registry
+
+Schema Registry (Confluent-compat) consumido por `uniplus-api-host` e
+`uniplus-api-portal` para registrar/validar schemas Avro dos eventos Kafka
+(ADR-0051 do `uniplus-api`). Chart de referência já validado em produção
+(`environments/standalone-compact/values.yaml`) — no lab, adaptado para o IP
+único da VM e sem Traefik/TLS de edge.
+
+> **Pré-requisito:** `./scripts/lab-standalone-single/seed-vault-secrets.sh`
+> e o Keycloak já devem estar no ar (mesmos pré-requisitos das APIs abaixo).
+
+```bash
+export KUBECONFIG="$HOME/.kube/config"   # ver RUNBOOKS.md §20.3
+
+# 1. Role + database dedicados no Postgres
+sudo docker exec -i uniplus-postgres psql -U postgres -v ON_ERROR_STOP=1 <<SQL
+CREATE ROLE apicurio WITH LOGIN PASSWORD '<senha gerada com openssl rand -hex 32>';
+CREATE DATABASE apicurio WITH OWNER = apicurio ENCODING = 'UTF8' LC_COLLATE = 'C.UTF-8' LC_CTYPE = 'C.UTF-8' TEMPLATE = template0;
+SQL
+
+# 2. A MESMA senha usada acima, no Vault — vault CLI local via port-forward,
+#    mesma higiene de credenciais do RUNBOOKS.md §8.4.3
+kubectl -n vault port-forward vault-0 8200:8200 > /tmp/vault-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null; unset VAULT_TOKEN VAULT_ADDR ROLE_PW' EXIT
+export VAULT_ADDR=http://127.0.0.1:8200
+until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
+read -rsp "Root token: " VAULT_TOKEN; echo
+export VAULT_TOKEN
+read -rsp "Senha do role (a mesma do passo 1): " ROLE_PW; echo
+vault kv put secret/standalone/postgres/apicurio username=apicurio password=@<(printf '%s' "$ROLE_PW")
+
+# 3. client_secret do client "apicurio-registry" (já existe no realm.json
+#    desde a issue #152) — recuperar via kcadm dentro do próprio pod do
+#    Keycloak, nunca em argv local
+KC_ADMIN_PW=$(vault kv get -field=password secret/standalone/keycloak/admin)
+kubectl exec -n uniplus deploy/keycloak-replica -- sh -c "
+  /opt/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth \
+    --realm master --user admin --password '$KC_ADMIN_PW'
+  CID=\$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus -q clientId=apicurio-registry --fields id --format csv --noquotes | tail -1)
+  /opt/keycloak/bin/kcadm.sh get clients/\$CID/client-secret -r uniplus --fields value --format csv --noquotes
+" | tail -1 > /tmp/apicurio-cs
+vault kv put secret/standalone/keycloak/clients/apicurio-registry password=@/tmp/apicurio-cs
+shred -u /tmp/apicurio-cs
+kill "$PF_PID" 2>/dev/null; unset VAULT_TOKEN VAULT_ADDR ROLE_PW PF_PID KC_ADMIN_PW  # sem exit — o passo 4 segue no mesmo shell
+
+# 4. Deploy
+helm install apicurio-registry apps/apicurio-registry/ -f environments/lab-standalone-single/values.yaml --namespace uniplus --wait --timeout=120s
+
+# 5. Validar (readinessProbe real do chart — Apicurio 3.2.4 desabilita /q/health/*)
+kubectl exec -n uniplus deploy/apicurio-registry-apicurio-registry -- curl -s http://localhost:8080/apis/registry/v3/system/info
+```
+
+### NetworkPolicy: ingress só libera o namespace Traefik — desligada no lab
+
+O template `apps/apicurio-registry/templates/networkpolicy.yaml` só libera
+ingress na porta 8080 para pods do namespace `traefik` (produção: todo
+tráfego HTTP ao Apicurio, mesmo vindo de outro Pod do mesmo cluster, passa
+pelo Traefik — `schemaRegistry.url` em `standalone-compact` aponta para o
+hostname público `https://schema-registry.standalone.portaluni.com.br`, não
+para o Service ClusterIP). Este lab não tem Traefik, então
+`uniplus-api-host`/`uniplus-api-portal` (namespace `uniplus`) nunca bateriam
+no allow-list — `Connection refused` no boot do
+`SchemaRegistrationHostedService`, `CrashLoopBackOff` (descoberto na issue #423).
+Mesmo racional já aplicado ao `keycloak-replica` neste lab:
+`apicurioRegistry.networkPolicy.enabled: false` em
+`environments/lab-standalone-single/values.yaml` — sem fronteira de
+segurança real a proteger num lab single-node, a policy restritiva de
+produção só atrapalha.
 
 ## uniplus-api-portal
 
@@ -234,27 +305,28 @@ kubectl create secret generic uniplus-api-portal-encryption-local \
 helm install uniplus-api-portal apps/uniplus-api-portal/ -f environments/lab-standalone-single/values.yaml --namespace uniplus
 ```
 
-### Limitação conhecida: `/health` nunca fica `Healthy` com Kafka desligado (issue #423)
+### Kafka + Schema Registry ligados desde a issue #423
 
 A API roda um `SchemaRegistrationHostedService` no boot que **exige** um
 Schema Registry de fato alcançável quando `Kafka:BootstrapServers` está
 populado (ADR-0051) — um placeholder sintático não basta, a aplicação
-tenta registrar schemas de verdade e derruba o pod. Como o Apicurio
-Registry não roda nesta leva do lab, `kafka.enabled: false`.
+tenta registrar schemas de verdade e derruba o pod. Antes da issue #423 o
+Apicurio Registry não rodava no lab, então o Portal subia com
+`kafka.enabled: false` — mas o template do chart **omitia** por completo a
+env var `Kafka__BootstrapServers` nesse caso (em vez de renderizá-la sempre
+com um valor "vazio" reconhecido pelo SDK), fazendo o Confluent.Kafka cair
+no default `localhost:9092` e entrar em loop de reconexão eterno: o Kafka
+health check dentro de `/health` (readiness, agregado) ficava
+permanentemente `Unhealthy` mesmo com Postgres/Redis/MinIO/Keycloak
+saudáveis (mesmo bug já corrigido antes no `uniplus-api-host` — ver
+RUNBOOKS.md §20.3).
 
-Efeito colateral: o SDK Confluent.Kafka ainda registra um producer ativo
-mesmo sem `Kafka:BootstrapServers` configurado (cai no default
-`localhost:9092`, loop de reconexão eterno), o que mantém o Kafka health
-check dentro de `/health` (readiness, agregado) permanentemente
-`Unhealthy` — mesmo com Postgres/Redis/MinIO/Keycloak saudáveis.
-`/health/live` (dependency-free) responde `Healthy` normalmente, e é a
-forma correta de confirmar que o processo está saudável no lab enquanto a
-issue #423 não é resolvida. `readinessProbe` usa `/health` hardcoded no
-`deployment.yaml` do chart — como o pod nunca fica `Ready`, um
-`helm upgrade` que troque o pod trava em rollout (`RollingUpdate` espera
-o novo pod ficar `Ready` antes de escalar o antigo para baixo); limpar
-manualmente o ReplicaSet antigo (`kubectl delete replicaset <antigo>`) se
-isso acontecer.
+Corrigido na issue #423 em duas frentes: (1) o template do chart passou a
+renderizar `Kafka__BootstrapServers` sempre — valor real quando ligado, `" "`
+(um espaço, `string.IsNullOrWhiteSpace=true`) quando desligado, mesmo padrão
+do `uniplus-api-host`; (2) o Apicurio Registry passou a rodar no lab (seção
+própria acima), permitindo religar `kafka.enabled: true` de fato. `/health`
+confirmado `Healthy` no Portal com Kafka+Schema Registry ligados.
 
 O módulo Portal ainda não tem entidades de domínio implementadas no
 código — `dotnet ef` não gera migrations pendentes, então o banco fica só
@@ -370,11 +442,19 @@ cd ../uniplus-infra   # volta pro repo de infra antes do helm install (chart/val
 helm install uniplus-api-host apps/uniplus-api-host/ -f environments/lab-standalone-single/values.yaml --namespace uniplus
 ```
 
-Validado de ponta a ponta na VM de lab: pod `Running`/`1/1 Ready` já na
-primeira tentativa (diferente do `uniplus-api-selecao` original, que nunca
-ficava `Ready` com Kafka desligado por omissão de env var — ver seção
-acima), `/health`, `/health/live` e `/health/ready` respondendo `Healthy`,
+Validado de ponta a ponta na VM de lab: pod `Running`/`1/1 Ready`,
+`/health`, `/health/live` e `/health/ready` respondendo `Healthy`,
 migrations EF Core aplicadas nos 4 schemas dedicados (`configuracao`: 15
 tabelas, `selecao`: 20, `ingresso`: 5, `organizacao`: 5, além de
 `wolverine`: 8), rotas `/api/organizacao/unidades` e `/api/configuracao/campi`
 respondendo `200 []`.
+
+Kafka + Schema Registry ligados desde a issue #423 (ver seção "Apicurio
+Registry" acima): `SchemaRegistrationHostedService` registra o schema Avro
+do módulo Selecao (`processo_seletivo_events-value`) no Apicurio no boot e
+o Wolverine `KafkaTransport` cria o tópico correspondente — confirmado nos
+logs do pod. Pré-requisito de rede: a NetworkPolicy do Apicurio só libera
+ingress do namespace `traefik` (inexistente neste lab) — sem
+`apicurioRegistry.networkPolicy.enabled: false`, o Host entra em
+`CrashLoopBackOff` no boot (`Connection refused` na chamada ao Schema
+Registry), mesmo com o Service/DNS/Postgres/Redis/Keycloak todos saudáveis.

--- a/environments/lab-standalone-single/README.md
+++ b/environments/lab-standalone-single/README.md
@@ -118,7 +118,7 @@ gera segredo novo:
 | `secret/standalone/redis/default` | `$DATA_BASE/redis/.bootstrap-creds` (Task #406) |
 | `secret/standalone/minio/root` | `$DATA_BASE/minio/.bootstrap-creds` (Task #407) |
 | `secret/standalone/kafka/admin` | `$DATA_BASE/kafka/.bootstrap-creds` + `/etc/uniplus-kafka/certs/ca.crt` (Task #408) |
-| `secret/standalone/keycloak/clients/uniplus-api-{selecao,portal,ingresso}` | `kcadm.sh get clients/.../client-secret` no pod `keycloak-replica` (clients M2M já existentes no realm, issue #163) |
+| `secret/standalone/keycloak/clients/uniplus-api-{selecao,portal,ingresso,host}` | `kcadm.sh get clients/.../client-secret` no pod `keycloak-replica` (clients M2M já existentes no realm — selecao/portal/ingresso desde a issue #163, host desde a issue #423) |
 
 **Não cobre** `secret/standalone/postgres/portal` — o role+db Postgres
 dedicado só existe a partir da Task #413, populado dentro do procedimento
@@ -169,7 +169,7 @@ kubectl exec -n uniplus deploy/keycloak-replica -- sh -c "
   CID=\$(/opt/keycloak/bin/kcadm.sh get clients -r uniplus -q clientId=apicurio-registry --fields id --format csv --noquotes | tail -1)
   /opt/keycloak/bin/kcadm.sh get clients/\$CID/client-secret -r uniplus --fields value --format csv --noquotes
 " | tail -1 > /tmp/apicurio-cs
-vault kv put secret/standalone/keycloak/clients/apicurio-registry password=@/tmp/apicurio-cs
+vault kv put secret/standalone/keycloak/clients/apicurio-registry client_secret=@/tmp/apicurio-cs
 shred -u /tmp/apicurio-cs
 kill "$PF_PID" 2>/dev/null; unset VAULT_TOKEN VAULT_ADDR ROLE_PW PF_PID KC_ADMIN_PW  # sem exit — o passo 4 segue no mesmo shell
 

--- a/environments/lab-standalone-single/values.yaml
+++ b/environments/lab-standalone-single/values.yaml
@@ -106,19 +106,14 @@ clusterSecretStore:
 # então Production rejeitaria o issuerUri http:// abaixo. Development
 # também relaxa a obrigatoriedade de Cors:AllowedOrigins.
 #
-# LIMITAÇÃO CONHECIDA (issue #423): com Kafka desligado, o pod fica
-# `Running` mas nunca `Ready` (0/1) — o SDK Confluent.Kafka da aplicação
-# registra um producer ativo mesmo sem `Kafka:BootstrapServers` configurado
-# (cai no default `localhost:9092`, loop de reconexão eterno), e isso
-# mantém o Kafka health check dentro de `/health` (readiness, agregado)
-# permanentemente Unhealthy — mesmo com todas as outras dependências reais
-# (Postgres, Redis, MinIO, Keycloak) saudáveis. Confirmado via
-# `/health/live` (dependency-free) respondendo Healthy e teste direto de
-# conectividade. `readinessProbe` usa `/health` hardcoded no
-# deployment.yaml do chart (não configurável via values sem alterar o
-# contrato usado em produção, onde esse comportamento é desejado). Resolve
-# quando a issue #423 (Apicurio Registry no lab) permitir religar Kafka
-# com Schema Registry real.
+# Kafka ligado desde a issue #423 (Apicurio Registry no lab) — antes disso
+# o pod ficava `Running` mas nunca `Ready` (0/1): com Kafka desligado, o SDK
+# Confluent.Kafka registrava um producer ativo mesmo sem
+# `Kafka:BootstrapServers` configurado (cai no default `localhost:9092`,
+# loop de reconexão eterno), mantendo o Kafka health check dentro de
+# `/health` (readiness, agregado) permanentemente Unhealthy. O template do
+# chart também foi corrigido para sempre renderizar `Kafka__BootstrapServers`
+# (nunca omitir), mesmo padrão já usado em uniplus-api-host.
 # ============================================================================
 uniplusApiPortal:
   enabled: true
@@ -131,7 +126,14 @@ uniplusApiPortal:
   redis:
     host: 192.168.1.65
   kafka:
-    enabled: false
+    enabled: true
+    bootstrapServers: 192.168.1.65:9092
+  schemaRegistry:
+    url: http://apicurio-registry-apicurio-registry.uniplus.svc.cluster.local:8080/apis/ccompat/v7
+    authType: OAuthBearer
+    oauth:
+      tokenEndpoint: http://keycloak-replica.uniplus.svc.cluster.local:8080/auth/realms/uniplus/protocol/openid-connect/token
+      clientId: uniplus-api-portal
   storage:
     endpoint: 192.168.1.65:9000
 
@@ -195,14 +197,21 @@ uniplusApiHost:
   redis:
     host: 192.168.1.65
 
-  # Desligado — mesma razão documentada no values.yaml do chart: sem
-  # Apicurio Registry no lab (issue #423), e o módulo Selecao (co-hospedado
-  # aqui) exige Schema Registry alcançável no boot quando Kafka está
-  # configurado. Kafka__BootstrapServers é sempre renderizado com " "
-  # (espaço) pelo template, não omitido — ver comentário completo no
-  # values.yaml do chart.
+  # Ligado desde a issue #423 (Apicurio Registry no lab) — o módulo Selecao
+  # (co-hospedado aqui) exige Schema Registry alcançável no boot quando
+  # Kafka está configurado. Kafka__BootstrapServers é sempre renderizado
+  # (nunca omitido) pelo template — ver comentário completo no values.yaml
+  # do chart.
   kafka:
-    enabled: false
+    enabled: true
+    bootstrapServers: 192.168.1.65:9092
+
+  schemaRegistry:
+    url: http://apicurio-registry-apicurio-registry.uniplus.svc.cluster.local:8080/apis/ccompat/v7
+    authType: OAuthBearer
+    oauth:
+      tokenEndpoint: http://keycloak-replica.uniplus.svc.cluster.local:8080/auth/realms/uniplus/protocol/openid-connect/token
+      clientId: uniplus-api-host
 
   storage:
     endpoint: 192.168.1.65:9000
@@ -232,3 +241,39 @@ uniplusApiHost:
 
   otel:
     enabled: false
+
+# ============================================================================
+# Apicurio Registry — Schema Registry para uniplus-api-host/uniplus-api-portal
+# (issue #423). Referência direta: environments/standalone-compact/values.yaml
+# (já validado em produção real), adaptado pro IP/hostnames do lab.
+# ============================================================================
+apicurioRegistry:
+  enabled: true
+
+  storage:
+    host: 192.168.1.65
+
+  oidc:
+    # In-cluster (mesmo padrão do resto do lab — sem Traefik/TLS de edge,
+    # Keycloak servido só via Service ClusterIP HTTP).
+    issuerUri: http://keycloak-replica.uniplus.svc.cluster.local:8080/auth/realms/uniplus
+
+  ingress:
+    enabled: false # acesso via kubectl port-forward, mesmo padrão do resto do lab
+
+  # DESLIGADA — mesmo racional já aplicado ao keycloak-replica neste lab.
+  # A ingress rule do chart só libera a porta 8080 para pods do namespace
+  # `traefik` (produção: todo tráfego HTTP ao Apicurio, mesmo intra-cluster,
+  # passa pelo Traefik — ver schemaRegistry.url em standalone-compact, que
+  # usa o hostname público https://schema-registry.standalone.portaluni.com.br,
+  # não o Service ClusterIP). Este lab não tem Traefik (ingress.enabled=false
+  # em todo o arquivo), então uniplus-api-host/uniplus-api-portal (namespace
+  # uniplus) nunca bateriam no allow-list — Connection refused no boot do
+  # SchemaRegistrationHostedService, CrashLoopBackOff (issue #423). Sem
+  # NetworkPolicy real fazendo falta num lab single-node sem fronteira de
+  # segurança a proteger, ao contrário de standalone-compact.
+  networkPolicy:
+    enabled: false
+
+  serviceMonitor:
+    enabled: false # sem Prometheus Operator no lab

--- a/scripts/lab-standalone-single/seed-vault-secrets.sh
+++ b/scripts/lab-standalone-single/seed-vault-secrets.sh
@@ -2,7 +2,7 @@
 # scripts/lab-standalone-single/seed-vault-secrets.sh
 #
 # Popula no Vault do lab (platform/vault/, Task #409) os secrets que os
-# charts uniplus-api-{selecao,portal,ingresso} e keycloak-replica esperam
+# charts uniplus-api-{selecao,portal,ingresso,host} e keycloak-replica esperam
 # nos vaultPaths default (ver apps/uniplus-api-*/values.yaml
 # externalSecrets.*.vaultPath). Lê as credenciais das fontes de verdade já
 # existentes nesta VM — nunca gera segredo novo — e apenas sincroniza o
@@ -97,7 +97,7 @@ done
 
 log_info "Recuperando client_secrets M2M do Keycloak (deploy/$KEYCLOAK_DEPLOYMENT -n $KEYCLOAK_NAMESPACE)..."
 declare -A client_secrets
-for client in uniplus-api-selecao uniplus-api-portal uniplus-api-ingresso; do
+for client in uniplus-api-selecao uniplus-api-portal uniplus-api-ingresso uniplus-api-host; do
     if $DRY_RUN; then
         log_warn "Dry-run: client_secret de $client seria recuperado via kcadm.sh"
         client_secrets[$client]="DRY-RUN-PLACEHOLDER"
@@ -150,6 +150,7 @@ printf '%s' "$kafka_pw" > "$tmpdir/kafka_pw"
 printf '%s' "${client_secrets[uniplus-api-selecao]}" > "$tmpdir/oidc_selecao"
 printf '%s' "${client_secrets[uniplus-api-portal]}" > "$tmpdir/oidc_portal"
 printf '%s' "${client_secrets[uniplus-api-ingresso]}" > "$tmpdir/oidc_ingresso"
+printf '%s' "${client_secrets[uniplus-api-host]}" > "$tmpdir/oidc_host"
 cp "$KAFKA_CA_CERT" "$tmpdir/ca_crt" 2>/dev/null || sudo cp "$KAFKA_CA_CERT" "$tmpdir/ca_crt"
 # Fallback via sudo deixa ca_crt dono root — chown de volta pro usuário atual
 # antes do chmod não-privilegiado abaixo (senão "Operation not permitted"
@@ -190,9 +191,12 @@ vault kv put secret/standalone/keycloak/clients/uniplus-api-portal \
 
 vault kv put secret/standalone/keycloak/clients/uniplus-api-ingresso \
     client_secret=@/tmp/vault-seed/oidc_ingresso >/dev/null
+
+vault kv put secret/standalone/keycloak/clients/uniplus-api-host \
+    client_secret=@/tmp/vault-seed/oidc_host >/dev/null
 REMOTE_SCRIPT
 
 unset redis_pw minio_user minio_pw kafka_pw vault_root_token client_secrets
 
-log_success "Secrets populados no Vault: redis/default, minio/root, kafka/admin, keycloak/clients/uniplus-api-{selecao,portal,ingresso}."
+log_success "Secrets populados no Vault: redis/default, minio/root, kafka/admin, keycloak/clients/uniplus-api-{selecao,portal,ingresso,host}."
 log_warn "secret/standalone/postgres/{selecao,portal,ingresso} pendente — populado dentro das Tasks #412/#413/#414."


### PR DESCRIPTION
## Resumo

Sobe o Apicurio Registry no `lab-standalone-single` e religa Kafka + Schema Registry em `uniplus-api-host`/`uniplus-api-portal`, corrigindo antes a lacuna do chart do Portal que fazia `/health` (readiness) ficar permanentemente `Unhealthy` mesmo com Kafka desligado.

## Issue relacionada

Closes #423

## Motivação

Descoberto na Task #412 (revertida): quando `Kafka__BootstrapServers` é omitido por completo do Deployment (em vez de renderizado com `" "`), o SDK Confluent.Kafka cai no default `localhost:9092` e entra em loop de reconexão eterno, mantendo o Kafka health check dentro de `/health` permanentemente `Unhealthy`. O chart `uniplus-api-host` já tinha esse fix (Task #427); o `uniplus-api-portal` não. Corrigir isso era pré-requisito para religar Kafka de verdade — o que por sua vez exige um Schema Registry alcançável no boot (`SchemaRegistrationHostedService`, ADR-0051 do `uniplus-api`), daí a necessidade de subir o Apicurio Registry no lab.

## Alterações principais

- `apps/uniplus-api-portal/templates/deployment.yaml` — renderiza `Kafka__BootstrapServers` sempre (paridade com `uniplus-api-host`), nunca omite a env var.
- `apps/uniplus-api-host/templates/deployment.yaml` — corrige comentário desatualizado que ainda listava o Portal entre os charts que omitem a env var.
- `apps/keycloak-replica/files/uniplus-realm.json` — novo client OIDC `uniplus-api-host` (Service Account M2M, mesmo padrão dos clients `uniplus-api-{portal,selecao,ingresso}` já existentes).
- `environments/lab-standalone-single/values.yaml` — liga `apicurioRegistry` (referência direta de `standalone-compact`, já validado em produção) e `kafka.enabled: true` + `schemaRegistry.*` no Host e no Portal.
- `docs/RUNBOOKS.md` §20 e `environments/lab-standalone-single/README.md` — documentam o deploy do Apicurio no lab e o gotcha de NetworkPolicy descoberto durante a implementação (ver abaixo).
- `apps/apicurio-registry/README.md` — corrige endpoint de health documentado (Apicurio 3.2.4 desabilita `/q/health/*`; as probes do chart usam `/apis/registry/v3/system/info`).

### Gotcha descoberto durante a implementação: NetworkPolicy do Apicurio bloqueava o lab

O template `apps/apicurio-registry/templates/networkpolicy.yaml` só libera ingress na porta 8080 para pods do namespace `traefik` — em produção, todo tráfego HTTP ao Apicurio passa pelo Traefik mesmo vindo do mesmo cluster (`schemaRegistry.url` em `standalone-compact` aponta para o hostname público, não para o Service ClusterIP). O `lab-standalone-single` não tem Traefik: o `uniplus-api-host` caiu em `CrashLoopBackOff` no boot (`HttpRequestException: Connection refused` no `SchemaRegistrationHostedService`) apesar do Service/DNS/rota estarem saudáveis (confirmado via `curl` direto de outro pod do mesmo namespace). Mesmo racional já aplicado ao `keycloak-replica` neste lab: `apicurioRegistry.networkPolicy.enabled: false` em vez de reimplementar a policy para o caso same-namespace.

## Como testar

```bash
git fetch origin task/423-apicurio-registry
git checkout task/423-apicurio-registry

make validate        # yaml-lint + helm-lint + markdown-lint + schema-validate
make helm-template    # render de todos os charts × standalone-compact
```

Deploy real no lab (procedimento completo em `environments/lab-standalone-single/README.md`, seção "Apicurio Registry"):

```bash
helm upgrade apicurio-registry apps/apicurio-registry/ -f environments/lab-standalone-single/values.yaml -n uniplus --wait
helm upgrade uniplus-api-host apps/uniplus-api-host/ -f environments/lab-standalone-single/values.yaml -n uniplus --wait
helm upgrade uniplus-api-portal apps/uniplus-api-portal/ -f environments/lab-standalone-single/values.yaml -n uniplus --wait

kubectl exec -n uniplus deploy/uniplus-api-host -- curl -s http://localhost:8080/health
kubectl exec -n uniplus deploy/uniplus-api-portal -- curl -s http://localhost:8080/health
```

## Evidências

### `make validate` + `make helm-template` limpos

```
make validate: EXIT 0 (yamllint, helm lint, markdownlint, schema-validate)
make helm-template: EXIT 0 — todos os charts × standalone-compact renderizando OK
```

### Validado ponta a ponta na VM de lab (`192.168.1.65`)

```
$ kubectl get pods -n uniplus
apicurio-registry-apicurio-registry-6bdb476d4f-wj7sc     1/1     Running
uniplus-api-host-uniplus-api-host-b4974fdf9-rn5m2        1/1     Running
uniplus-api-portal-uniplus-api-portal-6b56798c5f-p78sj   1/1     Running

$ kubectl exec -n uniplus uniplus-api-host-... -- curl -s http://localhost:8080/health
Healthy
$ kubectl exec -n uniplus uniplus-api-portal-... -- curl -s http://localhost:8080/health
Healthy
```

### Schema registrado + tópico Kafka criado (critério de aceite "publish/consume testado ponta a ponta")

```
[Information] Registrando 1 schema(s) Avro no Schema Registry no startup.
[Information] Schema Avro registrado/confirmado. Subject=processo_seletivo_events-value SchemaId=1
[Information] Initializing the Wolverine KafkaTransport
[Information] Created Kafka topic processo_seletivo_events
```

## Documentação

- [x] README atualizado (`environments/lab-standalone-single/README.md`, `apps/apicurio-registry/README.md`)
- [ ] OpenAPI atualizado — N/A (mudança de infra, sem contrato HTTP novo)
- [ ] ADR criado — N/A (aplica ADR-0051/ADR-0097 já existentes, não decide arquitetura nova)
- [x] RUNBOOKS atualizado (§20.1, §20.3, §20.4, §20.5)
- [ ] CHANGELOG atualizado — repo não mantém CHANGELOG separado

## Checklist

- [x] Build executado e limpo — N/A (repo de infra, sem build de aplicação)
- [x] Testes executados e verdes (suíte completa) — `make validate` + `make helm-template`
- [x] Lint/format executado — yamllint, helm lint, markdownlint
- [x] Segurança revisada (OWASP top 10) — N/A direto; NetworkPolicy desligada é decisão documentada e justificada para o lab (sem fronteira de segurança real a proteger num single-node)
- [ ] Observabilidade revisada — `serviceMonitor.enabled: false` no lab (sem Prometheus Operator), consistente com o resto do ambiente
- [x] Documentação atualizada
- [ ] ADR criada/atualizada — N/A
- [x] Sem secrets no diff
- [x] Compatibilidade revisada (backward compat) — mudança aditiva; `standalone-compact` (produção) não é tocado
- [ ] Rollback documentado — `helm rollback`/`kafka.enabled: false` reverte; não crítico para um ambiente de lab
- [x] Critérios de aceite da issue atendidos
- [x] Auto-revisão do PR aplicada
