### PR TITLE
feat(lab): Traefik + TLS autoassinado + frontend uniplus-web no lab-standalone-single

### DIFF
--- a/apps/keycloak-replica/templates/networkpolicy.yaml
+++ b/apps/keycloak-replica/templates/networkpolicy.yaml
@@ -10,9 +10,27 @@ metadata:
   labels:
     {{- include "keycloak-replica.labels" . | nindent 4 }}
 spec:
+  # matchExpressions (não matchLabels) para EXCLUIR o pod do Job
+  # realm-reconcile — ele herda os mesmos labels name/instance do pod real
+  # do Keycloak (template realm-reconcile-job.yaml usa o helper
+  # keycloak-replica.labels completo), então um podSelector simples por
+  # name+instance também o selecionaria, sujeitando-o ao mesmo egress
+  # restritivo desta policy (só Postgres+DNS) — o Job chama a REST API do
+  # Keycloak via Service de rede (KEYCLOAK_URL=http://<service>.svc...:8080),
+  # não localhost, e essa chamada é egress, não ingress (a regra de ingress
+  # abaixo para uniplus.io/job-role=realm-reconcile cobre só a direção
+  # oposta). Sem essa exclusão, o Job trava/falha em backoffLimit tentando
+  # falar com o próprio Keycloak que deveria reconciliar.
   podSelector:
-    matchLabels:
-      {{- include "keycloak-replica.selectorLabels" . | nindent 6 }}
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values: [{{ include "keycloak-replica.name" . | quote }}]
+      - key: app.kubernetes.io/instance
+        operator: In
+        values: [{{ .Release.Name | quote }}]
+      - key: uniplus.io/job-role
+        operator: DoesNotExist
   policyTypes:
     - Ingress
     - Egress

--- a/apps/unifesspa-geo-api/templates/configmap-custom-ca.yaml
+++ b/apps/unifesspa-geo-api/templates/configmap-custom-ca.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.unifesspaGeoApi.enabled .Values.unifesspaGeoApi.customCA.enabled -}}
+{{- if not .Values.unifesspaGeoApi.customCA.certPEM -}}
+{{- fail "unifesspaGeoApi.customCA.certPEM é obrigatório quando customCA.enabled=true." -}}
+{{- end -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "unifesspaGeoApi.fullname" . }}-custom-ca
+  labels:
+    {{- include "unifesspaGeoApi.labels" . | nindent 4 }}
+data:
+  ca.crt: |
+    {{- .Values.unifesspaGeoApi.customCA.certPEM | nindent 4 }}
+{{- end }}

--- a/apps/unifesspa-geo-api/templates/deployment.yaml
+++ b/apps/unifesspa-geo-api/templates/deployment.yaml
@@ -54,6 +54,31 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.unifesspaGeoApi.podSecurityContext | nindent 8 }}
+      {{- if .Values.unifesspaGeoApi.customCA.enabled }}
+      # initContainer roda update-ca-certificates real (a única forma
+      # confiável de o runtime .NET confiar num certificado extra — ver
+      # comentário completo em values.yaml unifesspaGeoApi.customCA).
+      initContainers:
+        - name: install-custom-ca
+          image: "{{ .Values.unifesspaGeoApi.image.registry }}/{{ .Values.unifesspaGeoApi.image.repository }}:{{ .Values.unifesspaGeoApi.image.tag }}"
+          imagePullPolicy: {{ .Values.unifesspaGeoApi.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -e
+              cp /custom-ca/ca.crt /usr/local/share/ca-certificates/lab-custom-ca.crt
+              update-ca-certificates
+              cp -a /etc/ssl/certs/. /merged-ca-certs/
+          volumeMounts:
+            - name: custom-ca-source
+              mountPath: /custom-ca
+              readOnly: true
+            - name: merged-ca-certs
+              mountPath: /merged-ca-certs
+      {{- end }}
       containers:
         - name: geo-api
           image: "{{ .Values.unifesspaGeoApi.image.registry }}/{{ .Values.unifesspaGeoApi.image.repository }}:{{ .Values.unifesspaGeoApi.image.tag }}"
@@ -145,6 +170,17 @@ spec:
             {{- with .Values.unifesspaGeoApi.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if .Values.unifesspaGeoApi.customCA.enabled }}
+          volumeMounts:
+            # Bundle de CAs já mesclado pelo initContainer install-custom-ca
+            # (sistema + certificado extra) — sobrepõe o bundle default da
+            # imagem, que o container principal (non-root) não pode
+            # atualizar sozinho. Ver comentário completo em values.yaml
+            # unifesspaGeoApi.customCA.
+            - name: merged-ca-certs
+              mountPath: /etc/ssl/certs
+              readOnly: true
+          {{- end }}
           startupProbe:
             httpGet:
               path: /health/live
@@ -166,4 +202,12 @@ spec:
             periodSeconds: {{ .Values.unifesspaGeoApi.readinessProbe.periodSeconds }}
           resources:
             {{- toYaml .Values.unifesspaGeoApi.resources | nindent 12 }}
+      {{- if .Values.unifesspaGeoApi.customCA.enabled }}
+      volumes:
+        - name: custom-ca-source
+          configMap:
+            name: {{ include "unifesspaGeoApi.fullname" . }}-custom-ca
+        - name: merged-ca-certs
+          emptyDir: {}
+      {{- end }}
 {{- end }}

--- a/apps/unifesspa-geo-api/templates/deployment.yaml
+++ b/apps/unifesspa-geo-api/templates/deployment.yaml
@@ -40,6 +40,13 @@ spec:
     metadata:
       labels:
         {{- include "unifesspaGeoApi.labels" . | nindent 8 }}
+      {{- if .Values.unifesspaGeoApi.customCA.enabled }}
+      annotations:
+        # Ver comentário completo em apps/uniplus-api-host/templates/
+        # deployment.yaml — sem isso, rotacionar customCA.certPEM não
+        # dispara rollout, pods já rodando ficam com o bundle antigo.
+        checksum/custom-ca: {{ .Values.unifesspaGeoApi.customCA.certPEM | sha256sum }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "unifesspaGeoApi.serviceAccountName" . }}
       # automountServiceAccountToken=true é necessário quando Provider=vault:

--- a/apps/unifesspa-geo-api/values.yaml
+++ b/apps/unifesspa-geo-api/values.yaml
@@ -76,6 +76,12 @@ unifesspaGeoApi:
     audience: ""
     validateAudience: false
 
+  # === CA customizada (opt-in) — ver comentário completo em
+  # apps/uniplus-api-host/values.yaml customCA. ===
+  customCA:
+    enabled: false
+    certPEM: ""
+
   # === Cifragem (Geo:Encryption — AES-GCM local ou Vault Transit) ===
   # Provider=local exige LocalKey (Base64, 32 bytes) via Secret; Provider=vault
   # exige VaultAddress + KubernetesRole (bound à ServiceAccount deste chart).

--- a/apps/uniplus-api-host/templates/configmap-custom-ca.yaml
+++ b/apps/uniplus-api-host/templates/configmap-custom-ca.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.uniplusApiHost.enabled .Values.uniplusApiHost.customCA.enabled -}}
+{{- if not .Values.uniplusApiHost.customCA.certPEM -}}
+{{- fail "uniplusApiHost.customCA.certPEM é obrigatório quando customCA.enabled=true." -}}
+{{- end -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "uniplusApiHost.fullname" . }}-custom-ca
+  labels:
+    {{- include "uniplusApiHost.labels" . | nindent 4 }}
+data:
+  ca.crt: |
+    {{- .Values.uniplusApiHost.customCA.certPEM | nindent 4 }}
+{{- end }}

--- a/apps/uniplus-api-host/templates/deployment.yaml
+++ b/apps/uniplus-api-host/templates/deployment.yaml
@@ -56,6 +56,16 @@ spec:
     metadata:
       labels:
         {{- include "uniplusApiHost.labels" . | nindent 8 }}
+      {{- if .Values.uniplusApiHost.customCA.enabled }}
+      annotations:
+        # Sem isso, rotacionar customCA.certPEM (ex.: renovar o certificado
+        # autoassinado do lab) só atualiza o ConfigMap — pods já rodando
+        # mantêm o bundle antigo no emptyDir (populado uma vez pelo
+        # initContainer na criação do pod, nunca re-executado depois) até
+        # um restart manual. O checksum muda sempre que o cert muda,
+        # forçando o rollout automático do Deployment.
+        checksum/custom-ca: {{ .Values.uniplusApiHost.customCA.certPEM | sha256sum }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "uniplusApiHost.serviceAccountName" . }}
       # automountServiceAccountToken=true é necessário quando Provider=vault:

--- a/apps/uniplus-api-host/templates/deployment.yaml
+++ b/apps/uniplus-api-host/templates/deployment.yaml
@@ -70,6 +70,34 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.uniplusApiHost.podSecurityContext | nindent 8 }}
+      {{- if .Values.uniplusApiHost.customCA.enabled }}
+      # initContainer roda update-ca-certificates real (a única forma
+      # confiável de o runtime .NET confiar num certificado extra — ver
+      # comentário completo em values.yaml uniplusApiHost.customCA).
+      # Mesma imagem do container principal: já tem update-ca-certificates
+      # (Ubuntu). Roda como root só aqui — o container principal continua
+      # non-root (999), consumindo o bundle já pronto via volume compartilhado.
+      initContainers:
+        - name: install-custom-ca
+          image: "{{ .Values.uniplusApiHost.image.registry }}/{{ .Values.uniplusApiHost.image.repository }}:{{ .Values.uniplusApiHost.image.tag }}"
+          imagePullPolicy: {{ .Values.uniplusApiHost.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -e
+              cp /custom-ca/ca.crt /usr/local/share/ca-certificates/lab-custom-ca.crt
+              update-ca-certificates
+              cp -a /etc/ssl/certs/. /merged-ca-certs/
+          volumeMounts:
+            - name: custom-ca-source
+              mountPath: /custom-ca
+              readOnly: true
+            - name: merged-ca-certs
+              mountPath: /merged-ca-certs
+      {{- end }}
       containers:
         - name: api
           image: "{{ .Values.uniplusApiHost.image.registry }}/{{ .Values.uniplusApiHost.image.repository }}:{{ .Values.uniplusApiHost.image.tag }}"
@@ -223,13 +251,24 @@ spec:
             {{- with .Values.uniplusApiHost.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if .Values.uniplusApiHost.kafka.enabled }}
+          {{- if or .Values.uniplusApiHost.kafka.enabled .Values.uniplusApiHost.customCA.enabled }}
           volumeMounts:
+            {{- if .Values.uniplusApiHost.kafka.enabled }}
             # CA cert PEM do broker Kafka self-signed.
             - name: kafka-ca
               mountPath: /etc/uniplus-kafka/ca.crt
               subPath: ca.crt
               readOnly: true
+            {{- end }}
+            {{- if .Values.uniplusApiHost.customCA.enabled }}
+            # Bundle de CAs já mesclado pelo initContainer install-custom-ca
+            # (sistema + certificado extra) — sobrepõe o bundle default da
+            # imagem, que o container principal (non-root) não pode
+            # atualizar sozinho.
+            - name: merged-ca-certs
+              mountPath: /etc/ssl/certs
+              readOnly: true
+            {{- end }}
           {{- end }}
           startupProbe:
             httpGet:
@@ -252,13 +291,22 @@ spec:
             periodSeconds: {{ .Values.uniplusApiHost.readinessProbe.periodSeconds }}
           resources:
             {{- toYaml .Values.uniplusApiHost.resources | nindent 12 }}
-      {{- if .Values.uniplusApiHost.kafka.enabled }}
+      {{- if or .Values.uniplusApiHost.kafka.enabled .Values.uniplusApiHost.customCA.enabled }}
       volumes:
+        {{- if .Values.uniplusApiHost.kafka.enabled }}
         - name: kafka-ca
           secret:
             secretName: {{ include "uniplusApiHost.kafkaSecretName" . }}
             items:
               - key: ca.crt
                 path: ca.crt
+        {{- end }}
+        {{- if .Values.uniplusApiHost.customCA.enabled }}
+        - name: custom-ca-source
+          configMap:
+            name: {{ include "uniplusApiHost.fullname" . }}-custom-ca
+        - name: merged-ca-certs
+          emptyDir: {}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/apps/uniplus-api-host/values.yaml
+++ b/apps/uniplus-api-host/values.yaml
@@ -134,6 +134,25 @@ uniplusApiHost:
     issuerUri: ""               # ex.: https://standalone.portaluni.com.br/auth/realms/uniplus
     audience: uniplus
 
+  # === CA customizada (opt-in) ===
+  # Adiciona um certificado extra ao trust store do container via
+  # initContainer + `update-ca-certificates` — necessário quando oidc.
+  # issuerUri (ou schemaRegistry.url) aponta para um endpoint HTTPS com
+  # certificado não assinado por uma CA pública (ex.: TLS autoassinado de
+  # laboratório). Em produção real (Let's Encrypt via cert-manager) isso
+  # nunca é necessário — deixar enabled=false.
+  #
+  # SSL_CERT_FILE/SSL_CERT_DIR NÃO resolvem isso: funcionam para libcurl/
+  # OpenSSL (usado por `curl`), mas o runtime .NET no Linux não lê essas
+  # env vars para X509Chain/HttpClient — só respeita o bundle do sistema em
+  # /etc/ssl/certs/ca-certificates.crt, daí a necessidade do
+  # update-ca-certificates real via initContainer (descoberto na issue #432
+  # depurando "OIDC discovery respondeu 404" — na verdade uma falha de
+  # validação TLS mal reportada pelo health check da aplicação).
+  customCA:
+    enabled: false
+    certPEM: ""                 # PEM completo do certificado (não a chave privada)
+
   # === CORS (obrigatório fora de Development) ===
   cors:
     allowedOrigins: []          # ex.: ["https://portal.standalone.portaluni.com.br"]

--- a/apps/uniplus-api-portal/templates/configmap-custom-ca.yaml
+++ b/apps/uniplus-api-portal/templates/configmap-custom-ca.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.uniplusApiPortal.enabled .Values.uniplusApiPortal.customCA.enabled -}}
+{{- if not .Values.uniplusApiPortal.customCA.certPEM -}}
+{{- fail "uniplusApiPortal.customCA.certPEM é obrigatório quando customCA.enabled=true." -}}
+{{- end -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "uniplusApiPortal.fullname" . }}-custom-ca
+  labels:
+    {{- include "uniplusApiPortal.labels" . | nindent 4 }}
+data:
+  ca.crt: |
+    {{- .Values.uniplusApiPortal.customCA.certPEM | nindent 4 }}
+{{- end }}

--- a/apps/uniplus-api-portal/templates/deployment.yaml
+++ b/apps/uniplus-api-portal/templates/deployment.yaml
@@ -57,6 +57,13 @@ spec:
     metadata:
       labels:
         {{- include "uniplusApiPortal.labels" . | nindent 8 }}
+      {{- if .Values.uniplusApiPortal.customCA.enabled }}
+      annotations:
+        # Ver comentário completo em apps/uniplus-api-host/templates/
+        # deployment.yaml — sem isso, rotacionar customCA.certPEM não
+        # dispara rollout, pods já rodando ficam com o bundle antigo.
+        checksum/custom-ca: {{ .Values.uniplusApiPortal.customCA.certPEM | sha256sum }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "uniplusApiPortal.serviceAccountName" . }}
       # automountServiceAccountToken=true é necessário quando Provider=vault:

--- a/apps/uniplus-api-portal/templates/deployment.yaml
+++ b/apps/uniplus-api-portal/templates/deployment.yaml
@@ -71,6 +71,31 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.uniplusApiPortal.podSecurityContext | nindent 8 }}
+      {{- if .Values.uniplusApiPortal.customCA.enabled }}
+      # initContainer roda update-ca-certificates real (a única forma
+      # confiável de o runtime .NET confiar num certificado extra — ver
+      # comentário completo em values.yaml uniplusApiPortal.customCA).
+      initContainers:
+        - name: install-custom-ca
+          image: "{{ .Values.uniplusApiPortal.image.registry }}/{{ .Values.uniplusApiPortal.image.repository }}:{{ .Values.uniplusApiPortal.image.tag }}"
+          imagePullPolicy: {{ .Values.uniplusApiPortal.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -e
+              cp /custom-ca/ca.crt /usr/local/share/ca-certificates/lab-custom-ca.crt
+              update-ca-certificates
+              cp -a /etc/ssl/certs/. /merged-ca-certs/
+          volumeMounts:
+            - name: custom-ca-source
+              mountPath: /custom-ca
+              readOnly: true
+            - name: merged-ca-certs
+              mountPath: /merged-ca-certs
+      {{- end }}
       containers:
         - name: api
           image: "{{ .Values.uniplusApiPortal.image.registry }}/{{ .Values.uniplusApiPortal.image.repository }}:{{ .Values.uniplusApiPortal.image.tag }}"
@@ -228,13 +253,24 @@ spec:
             {{- with .Values.uniplusApiPortal.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if .Values.uniplusApiPortal.kafka.enabled }}
+          {{- if or .Values.uniplusApiPortal.kafka.enabled .Values.uniplusApiPortal.customCA.enabled }}
           volumeMounts:
+            {{- if .Values.uniplusApiPortal.kafka.enabled }}
             # CA cert PEM do broker Kafka self-signed.
             - name: kafka-ca
               mountPath: /etc/uniplus-kafka/ca.crt
               subPath: ca.crt
               readOnly: true
+            {{- end }}
+            {{- if .Values.uniplusApiPortal.customCA.enabled }}
+            # Bundle de CAs já mesclado pelo initContainer install-custom-ca
+            # (sistema + certificado extra) — sobrepõe o bundle default da
+            # imagem, que o container principal (non-root) não pode
+            # atualizar sozinho.
+            - name: merged-ca-certs
+              mountPath: /etc/ssl/certs
+              readOnly: true
+            {{- end }}
           {{- end }}
           startupProbe:
             httpGet:
@@ -257,13 +293,22 @@ spec:
             periodSeconds: {{ .Values.uniplusApiPortal.readinessProbe.periodSeconds }}
           resources:
             {{- toYaml .Values.uniplusApiPortal.resources | nindent 12 }}
-      {{- if .Values.uniplusApiPortal.kafka.enabled }}
+      {{- if or .Values.uniplusApiPortal.kafka.enabled .Values.uniplusApiPortal.customCA.enabled }}
       volumes:
+        {{- if .Values.uniplusApiPortal.kafka.enabled }}
         - name: kafka-ca
           secret:
             secretName: {{ include "uniplusApiPortal.kafkaSecretName" . }}
             items:
               - key: ca.crt
                 path: ca.crt
+        {{- end }}
+        {{- if .Values.uniplusApiPortal.customCA.enabled }}
+        - name: custom-ca-source
+          configMap:
+            name: {{ include "uniplusApiPortal.fullname" . }}-custom-ca
+        - name: merged-ca-certs
+          emptyDir: {}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -102,6 +102,12 @@ uniplusApiPortal:
     issuerUri: ""               # ex.: https://standalone.portaluni.com.br/auth/realms/uniplus
     audience: uniplus
 
+  # === CA customizada (opt-in) — ver comentário completo em
+  # apps/uniplus-api-host/values.yaml customCA. ===
+  customCA:
+    enabled: false
+    certPEM: ""
+
   # === CORS (obrigatório fora de Development) ===
   # APIs validam no startup que Cors:AllowedOrigins esteja preenchido em
   # ASPNETCORE_ENVIRONMENT=Production. Lista de origins (frontend SPA, ex.:

--- a/apps/uniplus-web/templates/ingressroute.yaml
+++ b/apps/uniplus-web/templates/ingressroute.yaml
@@ -22,7 +22,7 @@ spec:
           port: 8080
   {{- if $.Values.uniplusWeb.ingress.tls.enabled }}
   tls:
-    secretName: {{ printf "%s-tls" (include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app)) }}
+    secretName: {{ $.Values.uniplusWeb.ingress.tls.secretName | default (printf "%s-tls" (include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app))) }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/apps/uniplus-web/values.yaml
+++ b/apps/uniplus-web/values.yaml
@@ -132,6 +132,12 @@ uniplusWeb:
     entryPoint: websecure
     tls:
       enabled: true
+      # Vazio (default): cada app usa seu próprio Secret "<appFullname>-tls"
+      # (criado pelo cert-manager quando certManager.enabled=true — caso de
+      # produção). Setar aqui só quando as 3 SPAs devem compartilhar um
+      # único Secret pré-existente (ex.: certificado wildcard autoassinado
+      # de lab, sem cert-manager).
+      secretName: ""
       certManager:
         enabled: true
         clusterIssuer: letsencrypt-prod

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -3677,11 +3677,13 @@ sistema operacional:
 | Kafka 4.2.0 (KRaft, SASL_SSL+SCRAM-SHA-512) | Docker+systemd (host) | `scripts/lab-standalone-single/setup-kafka.sh` |
 | Vault (single-node, Shamir manual 1/1) | K3s | `platform/vault/` |
 | External Secrets Operator | K3s | `platform/external-secrets/` |
+| Traefik (TLS autoassinado, substitui o Traefik embutido do k3s) | K3s | `platform/traefik/` |
 | Keycloak (realm `uniplus`) | K3s | `apps/keycloak-replica/` |
 | `unifesspa-geo-api` | K3s | `apps/unifesspa-geo-api/` |
 | Apicurio Registry (Schema Registry) | K3s | `apps/apicurio-registry/` |
 | `uniplus-api-host` (Selecao+Ingresso+Configuracao+OrganizacaoInstitucional, ADR-0097) | K3s | `apps/uniplus-api-host/` |
 | `uniplus-api-portal` | K3s | `apps/uniplus-api-portal/` |
+| `uniplus-web` (3 SPAs: portal, selecao, ingresso) | K3s | `apps/uniplus-web/` |
 
 Os charts `apps/uniplus-api-{selecao,ingresso}/` (topologia anterior, "uma API por módulo",
 abandonada pelo [ADR-0097](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md)
@@ -3873,8 +3875,41 @@ Registry documentado em `environments/lab-standalone-single/README.md`) em
 | Hosts | 2 VMs (`k8s-host` + `data-host`) | 1 VM combinando os dois papéis |
 | Deploy | GitOps via ArgoCD | Manual (`helm install/upgrade -f`) |
 | Vault | Shamir 5/3, `service_registration "kubernetes"` | Shamir 1/1 (simplificado) |
-| Kafka nas APIs | Ligado, Apicurio Registry disponível | Ligado desde issue #423, Apicurio Registry disponível (NetworkPolicy desligada — sem Traefik no lab, ver §20.3) |
+| Kafka nas APIs | Ligado, Apicurio Registry disponível | Ligado desde issue #423, Apicurio Registry disponível, NetworkPolicies religadas desde #432 |
+| Ingress/TLS | Traefik + Let's Encrypt via cert-manager (DNS público) | Traefik + TLS autoassinado (`*.192.168.1.65.nip.io`, issue #432 — ver §20.6) |
+| Frontend | `uniplus-web` (3 SPAs) via Traefik | `uniplus-web` (3 SPAs) via Traefik, issue #432 |
 | Provisionamento | OpenTofu (`provisioning/oci/standalone/`) | VM provisionada fora deste repositório (VirtualBox) |
+
+### 20.6 Traefik + TLS autoassinado + frontend (issue #432)
+
+Detalhes completos, comandos e os 3 gotchas reais encontrados na
+implementação em `environments/lab-standalone-single/README.md` (seções
+"Traefik + TLS autoassinado" e "uniplus-web"). Resumo:
+
+1. **k3s já vem com Traefik embutido** (namespace `kube-system`) — precisa
+   desabilitar (`/etc/rancher/k3s/config.yaml` com `disable: [traefik]` +
+   `systemctl restart k3s`) antes de instalar `platform/traefik/`, senão
+   conflito de IngressClass/hostPort.
+2. **Browsers só liberam Web Crypto API (PKCE) em secure context** — HTTP
+   puro, mesmo em LAN privada, não qualifica; TLS autoassinado é
+   obrigatório pro login funcionar pela SPA (não é só sobre "esconder"
+   tráfego). Hostnames via `nip.io` (DNS público que resolve pro IP
+   embutido no nome, mesmo sendo privado).
+3. **NetworkPolicy de egress com hostPort quebra silenciosamente** —
+   `kube-router` avalia egress **depois** do DNAT do CNI portmap (mesma
+   classe de bug do Service `kubernetes`, ver §20.1/kubeApiCidrs); regra de
+   egress precisa apontar pro pod CIDR (`10.42.0.0/16`) + porta interna do
+   Traefik (`8443`), não pro IP da VM + porta externa.
+4. **`.NET` não respeita `SSL_CERT_FILE`/`SSL_CERT_DIR`** pra confiar num
+   certificado extra (funciona só pra `curl`/OpenSSL) — precisa de
+   `initContainer` rodando `update-ca-certificates` de verdade
+   (`customCA.enabled` nos charts `uniplus-api-host`/`uniplus-api-portal`/
+   `unifesspa-geo-api`). **Quarkus/Java** (`apicurio-registry`) resolve com
+   `QUARKUS_TLS_TRUST_ALL=true` — propriedades diferentes por runtime,
+   nenhum dos dois usável em produção real (só lab com cert autoassinado).
+
+Login OIDC completo (SPA → Keycloak → PKCE → token → sessão autenticada)
+validado com browser real via Playwright MCP — não só `curl`.
 
 ---
 

--- a/environments/lab-standalone-single/README.md
+++ b/environments/lab-standalone-single/README.md
@@ -20,9 +20,11 @@ External Secrets Operator, ...) é validado.
 | Vault | `platform/vault/` | Single-node (replicas=1), Shamir manual (1 key share, threshold 1 — simplificado para lab), sem peer PA1/OCI KMS |
 | External Secrets Operator | `platform/external-secrets/` | `ClusterSecretStore vault-default` apontando para o Vault acima; NetworkPolicy habilitada nos dois charts (ver nota abaixo) |
 | Secrets iniciais | `scripts/lab-standalone-single/seed-vault-secrets.sh` | Popula no Vault os paths que os charts de API/Keycloak esperam — ver seção própria abaixo |
+| Traefik | `platform/traefik/` | HTTPS autoassinado, único ingress controller do lab (substitui o Traefik embutido do k3s, desabilitado) — ver seção própria abaixo |
 | apicurio-registry | `apps/apicurio-registry/` | Schema Registry (Confluent-compat) para uniplus-api-host/uniplus-api-portal (issue #423) — ver seção própria abaixo |
 | uniplus-api-portal | `apps/uniplus-api-portal/` | Deployable autônomo (ADR-0097 do `uniplus-api`); Kafka+Schema Registry ligados desde a issue #423 — ver seção própria abaixo; módulo Portal ainda sem migrations de domínio no código (só schema `wolverine` de infraestrutura) |
 | uniplus-api-host | `apps/uniplus-api-host/` | Composition root do monólito modular (Selecao+Ingresso+Configuracao+OrganizacaoInstitucional, ADR-0097 do `uniplus-api`); Kafka+Schema Registry ligados desde a issue #423; imagem buildada localmente (sem publish em GHCR ainda) — ver seção própria abaixo |
+| uniplus-web | `apps/uniplus-web/` | 3 SPAs Angular (portal, selecao, ingresso), issue #432 — ver seção própria abaixo |
 
 ## Uso
 
@@ -155,13 +157,132 @@ daquela Task, não aqui. Rodar o script de novo depois é seguro —
 verdade atual (útil inclusive para sincronizar após rotação de um
 client_secret no Keycloak).
 
+## Traefik + TLS autoassinado
+
+Issue #432. Todo acesso ao lab era via `kubectl exec`/`kubectl port-forward`
+até então — funciona para health checks server-to-server, mas o
+`uniplus-web` (SPA Angular) roda no **browser do usuário**: precisa de um
+hostname de fato alcançável, **e HTTPS de verdade** — browsers só liberam a
+Web Crypto API (necessária pro PKCE do `keycloak-js`) em *secure contexts*
+(HTTPS ou `localhost`); `http://<host>`, mesmo em LAN privada, não
+qualifica. Confirmado via Playwright: `window.isSecureContext=false`,
+`crypto.subtle` indisponível, login trava com "Web Crypto API is not
+available" mesmo com toda a infra saudável.
+
+TLS real (Let's Encrypt via cert-manager) exigiria DNS público apontando
+pro lab, que não existe — solução: certificado **autoassinado** cobrindo
+`*.192.168.1.65.nip.io` ([nip.io](https://nip.io) resolve qualquer IP
+embutido no hostname via DNS público, mesmo IP privado — a conexão TCP em
+si continua sendo LAN-local; funciona tanto pra esta VM quanto pro browser
+de quem estiver na mesma rede).
+
+### k3s já vem com Traefik embutido — precisa desabilitar antes
+
+K3s instala seu próprio Traefik por padrão (namespace `kube-system`,
+`Service traefik` tipo `LoadBalancer` já mapeando a porta 80/443 da VM).
+Conflita com `platform/traefik/` (mesma IngressClass, mesmos hostPorts) e,
+mais importante, o objetivo do lab é validar **o chart real** do Uni+, não
+o default do k3s. Desabilitar antes de instalar o nosso:
+
+```bash
+sudo mkdir -p /etc/rancher/k3s
+printf 'disable:\n  - traefik\n' | sudo tee /etc/rancher/k3s/config.yaml
+sudo systemctl restart k3s
+# aguardar ~15s — o addon-manager do k3s desinstala o Traefik embutido
+# sozinho (jobs helm-delete-traefik*), sem precisar limpar nada manualmente
+```
+
+### Gerar o certificado autoassinado (uma vez, fora do Git)
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -keyout tls.key -out tls.crt -days 825 \
+  -subj "/CN=uniplus-lab" \
+  -addext "subjectAltName=DNS:*.192.168.1.65.nip.io,DNS:192.168.1.65.nip.io"
+
+kubectl create secret tls uniplus-wildcard-nip-io-tls \
+  --cert=tls.crt --key=tls.key -n uniplus
+shred -u tls.crt tls.key   # a chave privada nunca entra no Git
+```
+
+A **parte pública** do certificado (não a chave) é reaproveitada como YAML
+anchor `&labSelfSignedCA` no topo de `values.yaml` deste environment — ver
+seção "Confiar no certificado autoassinado" abaixo.
+
+### Deploy do Traefik
+
+```bash
+helm dependency update platform/traefik/
+helm install traefik platform/traefik/ -f environments/lab-standalone-single/values.yaml \
+  --namespace traefik --create-namespace --wait --timeout=180s
+```
+
+`ports.web.hostPort: 80` + `ports.websecure.hostPort: 443` bindam direto na
+VM (via DNAT do CNI portmap plugin — não aparece em `ss -tlnp`, mas
+funciona; confirmar com `curl` direto). `ports.web.http.redirections: null`
+mantém a porta 80 servindo em paralelo (sem redirect forçado pra 443) —
+útil para smoke tests via `curl` sem `-k`/`-v` que não precisam de secure
+context.
+
+### Confiar no certificado autoassinado (server-to-server)
+
+Chamadas server-to-server que validam o `iss` claim de tokens do Keycloak
+(Host/Portal validando bearer tokens, Apicurio validando tokens ao
+registrar schema) **também precisam confiar no certificado** — não só o
+browser. Dois mecanismos diferentes, por runtime:
+
+- **.NET** (`uniplus-api-host`, `uniplus-api-portal`, `unifesspa-geo-api`):
+  `SSL_CERT_FILE`/`SSL_CERT_DIR` **não funcionam** — funcionam para
+  `curl`/libcurl (que lê essas env vars via OpenSSL), mas o runtime .NET no
+  Linux só confia no bundle do sistema
+  (`/etc/ssl/certs/ca-certificates.crt`). Solução: `customCA.enabled: true`
+  nos 3 charts — um `initContainer` roda `update-ca-certificates` de
+  verdade (mesma imagem da app, tem a ferramenta; roda como root só ali,
+  container principal continua non-root) e compartilha o bundle atualizado
+  via `emptyDir` montado em `/etc/ssl/certs` no container principal. Ver
+  comentário completo em `apps/uniplus-api-host/values.yaml` `customCA`.
+- **Quarkus/Java** (`apicurio-registry`): `extraEnv: QUARKUS_TLS_TRUST_ALL=true`
+  (registro de TLS unificado — a propriedade antiga
+  `QUARKUS_OIDC_TLS_TRUST_ALL` foi testada primeiro e **não funcionou**
+  nesta versão do Quarkus/Apicurio). `trust-all` só é aceitável porque é
+  cert autoassinado de lab — nunca usar em produção real.
+
+### Hostnames deste lab
+
+| Serviço | Hostname |
+|---|---|
+| Keycloak | `keycloak.192.168.1.65.nip.io` |
+| Apicurio Registry | `apicurio.192.168.1.65.nip.io` |
+| uniplus-api-host | `api-host.192.168.1.65.nip.io` |
+| uniplus-api-portal | `api-portal.192.168.1.65.nip.io` |
+| unifesspa-geo-api | `api-geo.192.168.1.65.nip.io` |
+| uniplus-web (portal) | `portal.192.168.1.65.nip.io` |
+| uniplus-web (selecao) | `selecao.192.168.1.65.nip.io` |
+| uniplus-web (ingresso) | `ingresso.192.168.1.65.nip.io` |
+
+### Gotcha: NetworkPolicy de egress com hostPort — DNAT acontece antes da avaliação
+
+Ao religar `apicurioRegistry.networkPolicy.enabled: true` (agora que
+Traefik existe de verdade), a regra de egress `oidcIssuerCIDR:
+192.168.1.65/32` (apontando pro IP da VM, porta 443) **nunca batia** —
+`Connection refused` do pod do Apicurio para `keycloak.192.168.1.65.nip.io`,
+apesar de um `curl` direto de outro pod (sem NetworkPolicy própria)
+funcionar normalmente. Causa: o `hostPort` do Traefik é implementado via
+DNAT (CNI portmap, `iptables -t nat`), e o `kube-router` (NetworkPolicy
+controller do k3s) avalia egress **depois** do DNAT — o destino real
+pós-DNAT é o IP do **pod** do Traefik (`10.42.0.x`), não o IP da VM (mesma
+classe de bug já documentada para o Service `kubernetes` do apiserver, ver
+seção "NetworkPolicy: kubeApiCidrs" acima, aqui via hostPort em vez de
+kube-proxy). Fix: `oidcIssuerCIDR: 10.42.0.0/16` (pod CIDR do cluster) +
+`oidcIssuerPort: 8443` (containerPort real do entryPoint `websecure` do
+Traefik, não a porta externa 443).
+
 ## Apicurio Registry
 
 Schema Registry (Confluent-compat) consumido por `uniplus-api-host` e
 `uniplus-api-portal` para registrar/validar schemas Avro dos eventos Kafka
 (ADR-0051 do `uniplus-api`). Chart de referência já validado em produção
-(`environments/standalone-compact/values.yaml`) — no lab, adaptado para o IP
-único da VM e sem Traefik/TLS de edge.
+(`environments/standalone-compact/values.yaml`) — no lab, adaptado para o
+Traefik + TLS autoassinado da issue #432 (seção própria acima).
 
 > **Pré-requisito:** `./scripts/lab-standalone-single/seed-vault-secrets.sh`
 > e o Keycloak já devem estar no ar (mesmos pré-requisitos das APIs abaixo).
@@ -210,22 +331,23 @@ helm install apicurio-registry apps/apicurio-registry/ -f environments/lab-stand
 kubectl exec -n uniplus deploy/apicurio-registry-apicurio-registry -- curl -s http://localhost:8080/apis/registry/v3/system/info
 ```
 
-### NetworkPolicy: ingress só libera o namespace Traefik — desligada no lab
+### NetworkPolicy: ingress só libera o namespace Traefik — religada na issue #432
 
 O template `apps/apicurio-registry/templates/networkpolicy.yaml` só libera
 ingress na porta 8080 para pods do namespace `traefik` (produção: todo
 tráfego HTTP ao Apicurio, mesmo vindo de outro Pod do mesmo cluster, passa
 pelo Traefik — `schemaRegistry.url` em `standalone-compact` aponta para o
-hostname público `https://schema-registry.standalone.portaluni.com.br`, não
-para o Service ClusterIP). Este lab não tem Traefik, então
-`uniplus-api-host`/`uniplus-api-portal` (namespace `uniplus`) nunca bateriam
-no allow-list — `Connection refused` no boot do
-`SchemaRegistrationHostedService`, `CrashLoopBackOff` (descoberto na issue #423).
-Mesmo racional já aplicado ao `keycloak-replica` neste lab:
-`apicurioRegistry.networkPolicy.enabled: false` em
-`environments/lab-standalone-single/values.yaml` — sem fronteira de
-segurança real a proteger num lab single-node, a policy restritiva de
-produção só atrapalha.
+hostname público, não para o Service ClusterIP). Na issue #423 este lab
+ainda não tinha Traefik, então a policy ficava `enabled: false`
+(`uniplus-api-host`/`uniplus-api-portal` nunca bateriam no allow-list —
+`Connection refused` no boot do `SchemaRegistrationHostedService`). Desde a
+issue #432 o Traefik existe de fato (seção acima) — a policy volta a
+`enabled: true`, `schemaRegistry.url`/`oidc.issuerUri` do Host/Portal agora
+apontam pro hostname do Traefik (`apicurio.192.168.1.65.nip.io`,
+`keycloak.192.168.1.65.nip.io`) em vez do Service ClusterIP direto, igual
+à produção real. Ver também o gotcha de NetworkPolicy+hostPort+DNAT na
+seção "Traefik + TLS autoassinado" acima — `oidcIssuerCIDR`/`oidcIssuerPort`
+não apontam pro IP da VM, e sim pro pod CIDR + porta interna do Traefik.
 
 ## uniplus-api-portal
 
@@ -251,15 +373,13 @@ follow-up para criá-lo).
 > `seed-vault-secrets.sh` não roda sozinho dentro do `bootstrap.sh` por essa razão.
 > `apps/keycloak-replica/` vem **desabilitado** por padrão e este `values.yaml` não liga
 > `keycloak.enabled`. `networkPolicy.enabled=true` é default do chart — sem `dataHostCIDR` (não
-> setado neste environment) o `fail` do template bloqueia o render; mesmo com ele setado, o
-> ingress só libera Traefik/Prometheus/o Job `realm-reconcile`, não os pods de
-> `uniplus-api-host`/`uniplus-api-portal` que também precisam falar com o Keycloak (OIDC
-> discovery/JWKS) — sem regra própria no chart para isso, desligar a policy inteira
-> (`networkPolicy.enabled=false`) é mais simples que reimplementá-la via `kubectl patch`
-> pós-install. `KC_HOSTNAME_STRICT=true` também é
-> default do chart, mas `hostname.url` vazio faz o Deployment omitir `KC_HOSTNAME` inteiro — sem
-> hostname público neste lab, `hostname.strict=false` evita o Keycloak falhar validando um
-> hostname que não existe). Role+database `keycloak` no Postgres e os secrets
+> setado neste environment) o `fail` do template bloqueia o render. **Desde a issue #432** o
+> Traefik existe de verdade no lab (seção "Traefik + TLS autoassinado" acima), então a policy
+> fica **religada** (`networkPolicy.enabled=true`, ingress via `keycloak.192.168.1.65.nip.io`) em
+> vez do antigo `networkPolicy.enabled=false` (workaround só pela ausência de Traefik). `hostname.url`
+> aponta pro hostname do Traefik (`https://keycloak.192.168.1.65.nip.io/auth`) — precisa bater com
+> o que o browser bate, senão o `iss` claim dos tokens não confere com o esperado pelos clients.
+> Role+database `keycloak` no Postgres e os secrets
 > `secret/standalone/postgres/keycloak`/`secret/standalone/keycloak/admin` no Vault também não são
 > criados por `bootstrap.sh` nem `seed-vault-secrets.sh` — o `ExternalSecret` do chart consome os
 > dois via `envFrom` (ver pré-requisitos completos em `apps/keycloak-replica/README.md`):
@@ -287,12 +407,14 @@ follow-up para criá-lo).
 > vault kv put secret/standalone/keycloak/admin username=admin password=@<(printf '%s' "$KC_ADMIN_PW")
 > kill "$PF_PID" 2>/dev/null; unset VAULT_TOKEN VAULT_ADDR KC_DB_PW KC_ADMIN_PW PF_PID
 >
-> # 0c. Deploy
+> # 0c. Deploy — repassando TODOS os --set que o release já usava (não só o
+> # novo), senão helm upgrade reverte silenciosamente aos defaults do chart
+> # tudo que ficou de fora (lição da regressão de NetworkPolicy da Epic #395)
 > helm install keycloak-replica apps/keycloak-replica/ -f environments/lab-standalone-single/values.yaml \
 >   --set keycloak.enabled=true \
->   --set keycloak.networkPolicy.enabled=false \
 >   --set keycloak.database.host=192.168.1.65 \
 >   --set keycloak.hostname.strict=false \
+>   --set keycloak.realmReconcile.enabled=true \
 >   --namespace uniplus --create-namespace \
 >   --wait --timeout=300s
 > ```
@@ -384,15 +506,13 @@ lab abaixo.
 > `seed-vault-secrets.sh` não roda sozinho dentro do `bootstrap.sh` por essa razão.
 > `apps/keycloak-replica/` vem **desabilitado** por padrão e este `values.yaml` não liga
 > `keycloak.enabled`. `networkPolicy.enabled=true` é default do chart — sem `dataHostCIDR` (não
-> setado neste environment) o `fail` do template bloqueia o render; mesmo com ele setado, o
-> ingress só libera Traefik/Prometheus/o Job `realm-reconcile`, não os pods de
-> `uniplus-api-host`/`uniplus-api-portal` que também precisam falar com o Keycloak (OIDC
-> discovery/JWKS) — sem regra própria no chart para isso, desligar a policy inteira
-> (`networkPolicy.enabled=false`) é mais simples que reimplementá-la via `kubectl patch`
-> pós-install. `KC_HOSTNAME_STRICT=true` também é
-> default do chart, mas `hostname.url` vazio faz o Deployment omitir `KC_HOSTNAME` inteiro — sem
-> hostname público neste lab, `hostname.strict=false` evita o Keycloak falhar validando um
-> hostname que não existe). Role+database `keycloak` no Postgres e os secrets
+> setado neste environment) o `fail` do template bloqueia o render. **Desde a issue #432** o
+> Traefik existe de verdade no lab (seção "Traefik + TLS autoassinado" acima), então a policy
+> fica **religada** (`networkPolicy.enabled=true`, ingress via `keycloak.192.168.1.65.nip.io`) em
+> vez do antigo `networkPolicy.enabled=false` (workaround só pela ausência de Traefik). `hostname.url`
+> aponta pro hostname do Traefik (`https://keycloak.192.168.1.65.nip.io/auth`) — precisa bater com
+> o que o browser bate, senão o `iss` claim dos tokens não confere com o esperado pelos clients.
+> Role+database `keycloak` no Postgres e os secrets
 > `secret/standalone/postgres/keycloak`/`secret/standalone/keycloak/admin` no Vault também não são
 > criados por `bootstrap.sh` nem `seed-vault-secrets.sh` — o `ExternalSecret` do chart consome os
 > dois via `envFrom` (ver pré-requisitos completos em `apps/keycloak-replica/README.md`):
@@ -420,12 +540,14 @@ lab abaixo.
 > vault kv put secret/standalone/keycloak/admin username=admin password=@<(printf '%s' "$KC_ADMIN_PW")
 > kill "$PF_PID" 2>/dev/null; unset VAULT_TOKEN VAULT_ADDR KC_DB_PW KC_ADMIN_PW PF_PID
 >
-> # 0c. Deploy
+> # 0c. Deploy — repassando TODOS os --set que o release já usava (não só o
+> # novo), senão helm upgrade reverte silenciosamente aos defaults do chart
+> # tudo que ficou de fora (lição da regressão de NetworkPolicy da Epic #395)
 > helm install keycloak-replica apps/keycloak-replica/ -f environments/lab-standalone-single/values.yaml \
 >   --set keycloak.enabled=true \
->   --set keycloak.networkPolicy.enabled=false \
 >   --set keycloak.database.host=192.168.1.65 \
 >   --set keycloak.hostname.strict=false \
+>   --set keycloak.realmReconcile.enabled=true \
 >   --namespace uniplus --create-namespace \
 >   --wait --timeout=300s
 > ```
@@ -483,8 +605,57 @@ Kafka + Schema Registry ligados desde a issue #423 (ver seção "Apicurio
 Registry" acima): `SchemaRegistrationHostedService` registra o schema Avro
 do módulo Selecao (`processo_seletivo_events-value`) no Apicurio no boot e
 o Wolverine `KafkaTransport` cria o tópico correspondente — confirmado nos
-logs do pod. Pré-requisito de rede: a NetworkPolicy do Apicurio só libera
-ingress do namespace `traefik` (inexistente neste lab) — sem
-`apicurioRegistry.networkPolicy.enabled: false`, o Host entra em
-`CrashLoopBackOff` no boot (`Connection refused` na chamada ao Schema
-Registry), mesmo com o Service/DNS/Postgres/Redis/Keycloak todos saudáveis.
+logs do pod. `schemaRegistry.url`/`oidc.issuerUri` apontam pro hostname do
+Traefik (issue #432) — `apicurioRegistry.networkPolicy`/`keycloak.networkPolicy`
+voltaram a `enabled: true`, e o Host precisa confiar no certificado
+autoassinado (`customCA.enabled: true`) pra validar o JWKS via HTTPS — ver
+seção "Traefik + TLS autoassinado" acima pros dois gotchas reais
+encontrados (DNAT+NetworkPolicy, SSL_CERT_FILE não funciona pro .NET).
+
+## uniplus-web
+
+Issue #432. 3 SPAs Angular (portal, selecao, ingresso) — 1 chart, 1
+Deployment por app, imagens já publicadas em GHCR (`v0.2.1`, confirmadas
+pull-áveis via `docker manifest inspect`) — sem build local necessário,
+diferente do `uniplus-api-host`.
+
+> **Pré-requisito:** Traefik + TLS autoassinado + os 5 backends (Keycloak,
+> Apicurio, Host, Portal, Geo API) já no ar (seções acima). O client OIDC
+> público `uniplus-portal` (compartilhado pelas 3 SPAs) precisa existir no
+> realm — ver `keycloak.realmImport.portalClient` no `values.yaml` deste
+> environment.
+
+```bash
+export KUBECONFIG="$HOME/.kube/config"
+
+helm install uniplus-web apps/uniplus-web/ -f environments/lab-standalone-single/values.yaml \
+  --namespace uniplus --wait --timeout=180s
+```
+
+`ingress.tls.certManager.enabled` **precisa** ser explicitamente `false`
+neste `values.yaml` — ao contrário dos outros charts (default `false`), o
+default do `uniplus-web` é `certManager.enabled: true` (produção real usa
+Let's Encrypt); sem o override, o `helm upgrade` falha com
+`no matches for kind "Certificate" in version "cert-manager.io/v1"`
+(CRD inexistente no lab).
+
+### Validação: login OIDC real via browser (Playwright)
+
+Confirmado ponta a ponta com um browser de verdade (não só `curl`), usando
+um usuário de teste temporário criado via `kcadm.sh` e removido depois:
+
+1. `https://portal.192.168.1.65.nip.io/` carrega sem erro de Web Crypto
+   (`window.isSecureContext === true`, `crypto.subtle` disponível).
+2. Clicar em rota protegida ("Meu Perfil") redireciona pro Keycloak com
+   `code_challenge`/`code_challenge_method=S256` (PKCE gerado client-side
+   de verdade) e `redirect_uri` batendo com o registrado no client.
+3. Login com usuário/senha → tela de completar perfil (primeiro acesso) →
+   redirect de volta pro `redirect_uri` com o `code`.
+4. SPA troca o `code` pelo token (via `fragment` response mode) e mostra o
+   nome do usuário logado no cabeçalho — sessão autenticada confirmada.
+
+Nota sobre Playwright especificamente: o browser headless rejeita o
+certificado autoassinado por padrão (`net::ERR_CERT_AUTHORITY_INVALID`,
+igual a um usuário real veria um aviso antes de "Avançar mesmo assim") —
+contornado via CDP (`Security.setIgnoreCertificateErrors`), não uma
+limitação do fix em si.

--- a/environments/lab-standalone-single/README.md
+++ b/environments/lab-standalone-single/README.md
@@ -194,6 +194,20 @@ sudo systemctl restart k3s
 
 ### Gerar o certificado autoassinado (uma vez, fora do Git)
 
+> **O par certificado/chave já foi gerado para este lab — a parte pública
+> já está commitada** como YAML anchor `&labSelfSignedCA` no topo de
+> `values.yaml` deste environment (consumida por `customCA.certPEM` nos 3
+> charts .NET). **Rodar o comando abaixo de novo gera um par NOVO,
+> diferente do anchor já commitado** — o `Secret` no cluster passaria a
+> servir um certificado que os charts `customCA` **não confiam**, quebrando
+> OIDC discovery/JWKS/schema-registry via HTTPS silenciosamente (o Traefik
+> sobe normal, os pods também, só a validação TLS falha). Só rodar este
+> comando ao criar um lab **novo** (IP diferente) ou ao rotacionar o
+> certificado deste — em ambos os casos, **atualizar o anchor
+> `&labSelfSignedCA` com o novo `tls.crt`** e reaplicar `helm upgrade` nos
+> 3 charts .NET (`uniplus-api-host`, `uniplus-api-portal`,
+> `unifesspa-geo-api`) depois.
+
 ```bash
 openssl req -x509 -newkey rsa:2048 -nodes -keyout tls.key -out tls.crt -days 825 \
   -subj "/CN=uniplus-lab" \
@@ -201,6 +215,10 @@ openssl req -x509 -newkey rsa:2048 -nodes -keyout tls.key -out tls.crt -days 825
 
 kubectl create secret tls uniplus-wildcard-nip-io-tls \
   --cert=tls.crt --key=tls.key -n uniplus
+
+# Copiar o conteúdo de tls.crt (só a parte pública) pro anchor
+# &labSelfSignedCA no topo de environments/lab-standalone-single/values.yaml
+# ANTES de descartar — sem isso, customCA.certPEM fica com o cert antigo.
 shred -u tls.crt tls.key   # a chave privada nunca entra no Git
 ```
 

--- a/environments/lab-standalone-single/values.yaml
+++ b/environments/lab-standalone-single/values.yaml
@@ -227,6 +227,22 @@ unifesspaGeoApi:
     enabled: true
     certPEM: *labSelfSignedCA
 
+  # Chart default é networkPolicy.enabled=true — sem override explícito
+  # aqui, um helm install novo (sem --reuse-values de um release já
+  # existente) bate no fail guard de dataHostCIDR/oidcIssuerCIDR (issuer
+  # não é mais *.svc.cluster.local desde que passou a apontar pro Traefik).
+  # Mesmo padrão do apicurioRegistry.networkPolicy acima, incluindo o
+  # gotcha de DNAT+hostPort (oidcIssuerCIDR aponta pro pod CIDR do Traefik,
+  # não pro IP da VM — ver seção "Traefik + TLS autoassinado" no README).
+  networkPolicy:
+    enabled: true
+    dataHostCIDR: 192.168.1.65/32
+    keycloakService: keycloak-replica
+    keycloakNamespace: uniplus
+    keycloakPort: 8080
+    oidcIssuerCIDR: 10.42.0.0/16
+    oidcIssuerPort: 8443
+
 # ============================================================================
 # External Secrets Operator — lê defaults de platform/external-secrets/values.yaml
 # (replicaCount=1, NetworkPolicy on). Aqui só liga o ClusterSecretStore,

--- a/environments/lab-standalone-single/values.yaml
+++ b/environments/lab-standalone-single/values.yaml
@@ -17,6 +17,37 @@
 # aqui também, e não há nem sequer um provider de nuvem no lab. Shamir
 # manual, single-node.
 
+# Certificado público (não a chave privada) do TLS autoassinado do Traefik
+# deste lab (issue #432) — CN=uniplus-lab, SAN=*.192.168.1.65.nip.io,
+# gerado uma vez via `openssl req -x509` e custodiado como Secret
+# `uniplus-wildcard-nip-io-tls` no namespace uniplus (não versionado — só
+# a parte pública, inerte, entra no Git). YAML anchor reaproveitado pelos
+# blocos `customCA.certPEM` de uniplusApiHost/uniplusApiPortal/
+# unifesspaGeoApi abaixo, que precisam confiar nesse certificado pra
+# validar tokens do Keycloak (ver comentário completo em
+# apps/uniplus-api-host/values.yaml `customCA`).
+_labSelfSignedCA: &labSelfSignedCA |
+  -----BEGIN CERTIFICATE-----
+  MIIDRjCCAi6gAwIBAgIUGvSmq0tvsazacgWSMy54Hx2qeJ4wDQYJKoZIhvcNAQEL
+  BQAwFjEUMBIGA1UEAwwLdW5pcGx1cy1sYWIwHhcNMjYwNzEwMTkwODE1WhcNMjgx
+  MDEyMTkwODE1WjAWMRQwEgYDVQQDDAt1bmlwbHVzLWxhYjCCASIwDQYJKoZIhvcN
+  AQEBBQADggEPADCCAQoCggEBAI9tj7llTp1jXaBU3+BBhTo/KfVo7obhIKnUZxLP
+  fYSh5yUqV11Gz9dXJD39JPo08MIypcyarfRIbhFx9OpI2P7kHS/nVTphezHQrkTv
+  N/CIsGSWUYjTH9dB4cuX0tDh/QjKEZxNejcIhyipdpQFfnQHECsnwsYtj9cyi1+l
+  jun9PHsK4KP3sChO59cjS/DRHlxPnx+i2SVyIRsQNWQh8aZVIEYyqhGU73lWVfks
+  DFaAr4iem5Kwx+LwQk4HvAteV1Ep6uAS1ygC6WFVCUtCHr8kn+i3pQYs/0GKaa/D
+  YEoEX24dy/uZarJbSVWZWFoyATnjAV3sMLV4VDqPbbk68K8CAwEAAaOBizCBiDAd
+  BgNVHQ4EFgQUBYMgd1W+tx3H/E/iJphqhIo6k1YwHwYDVR0jBBgwFoAUBYMgd1W+
+  tx3H/E/iJphqhIo6k1YwDwYDVR0TAQH/BAUwAwEB/zA1BgNVHREELjAsghUqLjE5
+  Mi4xNjguMS42NS5uaXAuaW+CEzE5Mi4xNjguMS42NS5uaXAuaW8wDQYJKoZIhvcN
+  AQELBQADggEBAFYAYU9GvgsFWja0gmkc7vNmbI215pNIWWBoOII+zW7u+93JOIiy
+  /8zGFnaJ92w1vX2HlGHXfcqlQgMfogPKlrevwIFTOjvHw59GMUDt2yz3nTo1xcc5
+  E+LReaVrC3tmA+pUsGycswDXWAI8d3N5AigJe239iOL+skb8LbpWXr4zpkuLc8Fk
+  Q2Gii3SO4BvliedSWG+l8isP6xcy2ooTcA+rSzb9Dl2TKx3BC2Vzr0ffPbxBnN+x
+  SENl7Fk9W9tikSfDGspnaEAOaUvQCiVv04pvDxR9bxioijf1jTV6GpT/n0B375ZM
+  0PC4G8MHn7GolEt4eww6KMZXOJNM3t+9gwc=
+  -----END CERTIFICATE-----
+
 vault:
   enabled: true
 
@@ -83,6 +114,120 @@ serviceMonitor:
   enabled: false # sem Prometheus Operator no lab
 
 # ============================================================================
+# Traefik (chart platform/traefik/, release `traefik` — issue #432).
+# hostPort 80+443 bindam direto na VM (mesmo padrão do standalone-compact,
+# que usa hostPort por ser single-host com IP público — aqui é IP privado
+# da VM de lab, mas o mecanismo é idêntico).
+#
+# TLS autoassinado (secret uniplus-wildcard-nip-io-tls, criado uma vez via
+# `kubectl create secret tls` — CN=uniplus-lab, SAN=*.192.168.1.65.nip.io,
+# não gerenciado pelo cert-manager nem versionado no Git). Sem cert-manager/
+# Let's Encrypt (exigiria DNS público que o lab não tem) — descoberto na
+# implementação que HTTP puro não é opção real: browsers só liberam a Web
+# Crypto API (necessária pro PKCE do keycloak-js na SPA) em secure contexts
+# (HTTPS ou localhost); `http://<host-real>` mesmo em LAN privada NÃO
+# qualifica, então o login OIDC pela SPA travava com "Web Crypto API is not
+# available" mesmo com toda a infra saudável (confirmado via
+# window.isSecureContext=false). O aviso de certificado não confiável do
+# browser é esperado — usuário aceita manualmente ("Avançar"); uma vez
+# aceito, o canal é TLS de verdade e a secure context é satisfeita.
+#
+# ports.web.http.redirections: null desliga o redirect HTTP→HTTPS default
+# do chart wrapper — mantém :80 servindo em paralelo (útil para smoke tests
+# via curl que não precisam de secure context), sem forçar todo mundo por
+# :443. Mesmo racional documentado em environments/standalone-compact/
+# values.yaml (lá é sobre o ACME HTTP-01 challenge).
+# ============================================================================
+traefik:
+  service:
+    type: NodePort
+  ports:
+    web:
+      hostPort: 80
+      http:
+        redirections: null
+    websecure:
+      hostPort: 443
+
+# ============================================================================
+# Keycloak — ingress via Traefik (issue #432). Demais chaves (enabled,
+# database.host, hostname.strict, networkPolicy) historicamente aplicadas
+# via --set ad-hoc no helm install/upgrade (ver
+# environments/lab-standalone-single/README.md) — persistidas aqui só a
+# partir de agora porque são as que este PR muda de fato; deploy usa
+# `--reuse-values` para não arriscar reverter o que não está neste arquivo
+# (mesma lição da regressão de NetworkPolicy documentada em #423).
+#
+# hostname.url precisa bater com o host do IngressRoute abaixo — token
+# issuer (`iss` claim) e os endpoints do discovery document (`authorization_
+# endpoint`, `token_endpoint`, ...) são derivados de KC_HOSTNAME. Se
+# divergir do host real batido pelo browser, o fluxo de login OIDC quebra
+# (redirect_uri mismatch / iss não bate com o esperado pelo cliente).
+#
+# networkPolicy.enabled volta a `true` agora que existe Traefik de fato no
+# namespace `traefik` (era `false` desde #423 só pela ausência dele —
+# ver apicurioRegistry.networkPolicy abaixo pro mesmo racional).
+keycloak:
+  hostname:
+    url: https://keycloak.192.168.1.65.nip.io/auth
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    host: keycloak.192.168.1.65.nip.io
+    tls:
+      enabled: true
+      secretName: uniplus-wildcard-nip-io-tls
+  networkPolicy:
+    enabled: true
+    dataHostCIDR: 192.168.1.65/32
+
+  # realmReconcile precisa estar ligado para o realm-reconcile-job aplicar
+  # o portalClient abaixo num Keycloak que já tinha o realm importado antes
+  # desta issue — --import-realm só roda no primeiro boot (gotcha já
+  # documentado na issue #423/memória feedback_keycloak_realm_reconcile_gated).
+  realmReconcile:
+    enabled: true
+
+  realmImport:
+    # Client OIDC público (SPA), compartilhado pelas 3 apps do uniplus-web —
+    # mesmo pattern de standalone-compact (story #162): 1 client, 1
+    # redirectUri por subdomain. webOrigins fica "+" (default do chart,
+    # deriva automaticamente dos redirectUris).
+    portalClient:
+      rootUrl: https://portal.192.168.1.65.nip.io
+      redirectUris:
+        - https://portal.192.168.1.65.nip.io/*
+        - https://selecao.192.168.1.65.nip.io/*
+        - https://ingresso.192.168.1.65.nip.io/*
+
+# ============================================================================
+# unifesspa-geo-api — ingress via Traefik (issue #432). Demais chaves
+# aplicadas via --set ad-hoc no deploy original (Task #397) — mesmo
+# racional do bloco keycloak acima, deploy usa --reuse-values.
+# ============================================================================
+unifesspaGeoApi:
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    host: api-geo.192.168.1.65.nip.io
+    tls:
+      enabled: true
+      secretName: uniplus-wildcard-nip-io-tls
+
+  # Via Traefik desde a issue #432 — keycloak.networkPolicy voltou a ficar
+  # habilitada (só libera ingress do namespace traefik), então a chamada
+  # direta ao Service ClusterIP in-cluster passa a tomar connection
+  # refused. Mesmo racional dos outros charts neste arquivo.
+  oidc:
+    issuerUri: https://keycloak.192.168.1.65.nip.io/auth/realms/uniplus
+
+  # Sem isso, HttpClient rejeita o certificado autoassinado do Keycloak —
+  # ver comentário completo em apps/uniplus-api-host/values.yaml.
+  customCA:
+    enabled: true
+    certPEM: *labSelfSignedCA
+
+# ============================================================================
 # External Secrets Operator — lê defaults de platform/external-secrets/values.yaml
 # (replicaCount=1, NetworkPolicy on). Aqui só liga o ClusterSecretStore,
 # que fica desligado por default até o Vault estar init+unsealed com a
@@ -128,21 +273,35 @@ uniplusApiPortal:
   kafka:
     enabled: true
     bootstrapServers: 192.168.1.65:9092
+  # schemaRegistry.url e oidc.issuerUri apontam pro Traefik (issue #432),
+  # não mais pro Service ClusterIP in-cluster — mesmo padrão de
+  # standalone-compact (schemaRegistry.url usa o hostname público, nunca
+  # o Service direto). Necessário porque apicurioRegistry.networkPolicy e
+  # keycloak.networkPolicy voltaram a ficar habilitadas (só liberam
+  # ingress do namespace `traefik`) agora que o Traefik existe de fato no
+  # lab — chamada direta ao Service ClusterIP tomaria connection refused.
   schemaRegistry:
-    url: http://apicurio-registry-apicurio-registry.uniplus.svc.cluster.local:8080/apis/ccompat/v7
+    url: https://apicurio.192.168.1.65.nip.io/apis/ccompat/v7
     authType: OAuthBearer
     oauth:
-      tokenEndpoint: http://keycloak-replica.uniplus.svc.cluster.local:8080/auth/realms/uniplus/protocol/openid-connect/token
+      tokenEndpoint: https://keycloak.192.168.1.65.nip.io/auth/realms/uniplus/protocol/openid-connect/token
       clientId: uniplus-api-portal
   storage:
     endpoint: 192.168.1.65:9000
 
   oidc:
-    issuerUri: http://keycloak-replica.uniplus.svc.cluster.local:8080/auth/realms/uniplus
+    issuerUri: https://keycloak.192.168.1.65.nip.io/auth/realms/uniplus
+
+  # Sem isso, HttpClient rejeita o certificado autoassinado do Keycloak —
+  # ver comentário completo em apps/uniplus-api-host/values.yaml.
+  customCA:
+    enabled: true
+    certPEM: *labSelfSignedCA
 
   cors:
     allowedOrigins:
       - http://192.168.1.65:4200
+      - https://portal.192.168.1.65.nip.io
 
   encryption:
     provider: local
@@ -154,8 +313,16 @@ uniplusApiPortal:
           name: uniplus-api-portal-encryption-local
           key: LOCAL_KEY
 
+  # Ligado desde a issue #432 — o browser do usuário (frontend uniplus-web)
+  # precisa de um hostname de fato alcançável, diferente das chamadas
+  # server-to-server que já funcionavam via Service ClusterIP.
   ingress:
-    enabled: false
+    enabled: true
+    entryPoint: websecure
+    host: api-portal.192.168.1.65.nip.io
+    tls:
+      enabled: true
+      secretName: uniplus-wildcard-nip-io-tls
 
   networkPolicy:
     enabled: false
@@ -206,22 +373,33 @@ uniplusApiHost:
     enabled: true
     bootstrapServers: 192.168.1.65:9092
 
+  # Ver comentário em uniplusApiPortal.schemaRegistry — mesmo racional
+  # (Traefik em vez de Service ClusterIP, issue #432).
   schemaRegistry:
-    url: http://apicurio-registry-apicurio-registry.uniplus.svc.cluster.local:8080/apis/ccompat/v7
+    url: https://apicurio.192.168.1.65.nip.io/apis/ccompat/v7
     authType: OAuthBearer
     oauth:
-      tokenEndpoint: http://keycloak-replica.uniplus.svc.cluster.local:8080/auth/realms/uniplus/protocol/openid-connect/token
+      tokenEndpoint: https://keycloak.192.168.1.65.nip.io/auth/realms/uniplus/protocol/openid-connect/token
       clientId: uniplus-api-host
 
   storage:
     endpoint: 192.168.1.65:9000
 
   oidc:
-    issuerUri: http://keycloak-replica.uniplus.svc.cluster.local:8080/auth/realms/uniplus
+    issuerUri: https://keycloak.192.168.1.65.nip.io/auth/realms/uniplus
+
+  # Sem isso, HttpClient rejeita o certificado autoassinado do Keycloak
+  # (validação real de X509Chain, não a fake-404 que curl -k mascarava) —
+  # ver comentário completo em apps/uniplus-api-host/values.yaml.
+  customCA:
+    enabled: true
+    certPEM: *labSelfSignedCA
 
   cors:
     allowedOrigins:
       - http://192.168.1.65:4200
+      - https://selecao.192.168.1.65.nip.io
+      - https://ingresso.192.168.1.65.nip.io
 
   encryption:
     provider: local
@@ -233,8 +411,14 @@ uniplusApiHost:
           name: uniplus-api-host-encryption-local
           key: LOCAL_KEY
 
+  # Ligado desde a issue #432 — mesmo racional do uniplus-api-portal.
   ingress:
-    enabled: false
+    enabled: true
+    entryPoint: websecure
+    host: api-host.192.168.1.65.nip.io
+    tls:
+      enabled: true
+      secretName: uniplus-wildcard-nip-io-tls
 
   networkPolicy:
     enabled: false
@@ -254,26 +438,120 @@ apicurioRegistry:
     host: 192.168.1.65
 
   oidc:
-    # In-cluster (mesmo padrão do resto do lab — sem Traefik/TLS de edge,
-    # Keycloak servido só via Service ClusterIP HTTP).
-    issuerUri: http://keycloak-replica.uniplus.svc.cluster.local:8080/auth/realms/uniplus
+    # Via Traefik desde a issue #432 (precisa bater com o `iss` claim dos
+    # tokens emitidos pelo Keycloak, que também usa esse hostname desde
+    # que keycloak.hostname.url mudou — ver bloco keycloak: acima).
+    issuerUri: https://keycloak.192.168.1.65.nip.io/auth/realms/uniplus
 
+  # Sem isso, o Quarkus rejeita o certificado TLS autoassinado do Keycloak
+  # ao buscar o JWKS ("OIDC Server is not available" — mesma causa raiz do
+  # customCA no uniplus-api-host/portal, mecanismo diferente porque aqui é
+  # a JVM, não o runtime .NET). QUARKUS_TLS_TRUST_ALL (registro de TLS
+  # unificado, não QUARKUS_OIDC_TLS_TRUST_ALL — propriedade antiga
+  # descontinuada nesta versão do Quarkus, testado empiricamente na VM de
+  # lab). trust-all é aceitável só porque é lab HTTP autoassinado — NUNCA
+  # usar em produção real (Let's Encrypt via cert-manager não precisa disso).
+  extraEnv:
+    - name: QUARKUS_TLS_TRUST_ALL
+      value: "true"
+
+  # Ligado desde a issue #432 — Traefik real existe no lab agora, então dá
+  # pra expor a UI/API do Apicurio num hostname de verdade em vez de só
+  # kubectl port-forward.
   ingress:
-    enabled: false # acesso via kubectl port-forward, mesmo padrão do resto do lab
+    enabled: true
+    entryPoint: websecure
+    host: apicurio.192.168.1.65.nip.io
+    tls:
+      enabled: true
+      secretName: uniplus-wildcard-nip-io-tls
 
-  # DESLIGADA — mesmo racional já aplicado ao keycloak-replica neste lab.
-  # A ingress rule do chart só libera a porta 8080 para pods do namespace
-  # `traefik` (produção: todo tráfego HTTP ao Apicurio, mesmo intra-cluster,
-  # passa pelo Traefik — ver schemaRegistry.url em standalone-compact, que
-  # usa o hostname público https://schema-registry.standalone.portaluni.com.br,
-  # não o Service ClusterIP). Este lab não tem Traefik (ingress.enabled=false
-  # em todo o arquivo), então uniplus-api-host/uniplus-api-portal (namespace
-  # uniplus) nunca bateriam no allow-list — Connection refused no boot do
-  # SchemaRegistrationHostedService, CrashLoopBackOff (issue #423). Sem
-  # NetworkPolicy real fazendo falta num lab single-node sem fronteira de
-  # segurança a proteger, ao contrário de standalone-compact.
+  # RELIGADA na issue #432 — estava desligada desde #423 só pela ausência
+  # de Traefik no lab (a ingress rule do chart só libera a porta 8080 para
+  # pods do namespace `traefik`; sem Traefik, uniplus-api-host/portal
+  # nunca bateriam no allow-list — Connection refused no boot do
+  # SchemaRegistrationHostedService). Agora que o Traefik existe de fato
+  # (release `traefik` no namespace `traefik`, issue #432), o allow-list
+  # volta a fazer sentido — chamadas server-to-server (Host/Portal→Apicurio)
+  # passam a ir via Traefik também, igual à produção real.
   networkPolicy:
-    enabled: false
+    enabled: true
+    dataHostCIDR: 192.168.1.65/32
+    keycloakService: keycloak-replica
+    keycloakNamespace: uniplus
+    keycloakPort: 8080
+    # Guard do chart exige oidcIssuerCIDR não-vazio sempre que oidc.enabled=true
+    # (default do chart). NÃO aponta pro IP da VM (192.168.1.65) — o
+    # hostPort do Traefik é implementado via DNAT (CNI portmap), e o
+    # kube-router avalia egress DEPOIS do DNAT (mesmo bug documentado em
+    # networkPolicy.kubeApiCidrs do Service kubernetes, aqui via hostPort
+    # em vez de kube-proxy): o destino real pós-DNAT é o IP do POD do
+    # Traefik (10.42.0.x), não o IP da VM — uma regra com 192.168.1.65/32
+    # nunca bate, egress fica bloqueado (Connection refused mesmo com a
+    # regra "certa" no papel). Usa o pod CIDR do cluster + a porta real do
+    # container (8443, entryPoint websecure — não a porta externa 443;
+    # atualizado na issue #432 quando o lab passou a usar TLS).
+    oidcIssuerCIDR: 10.42.0.0/16
+    oidcIssuerPort: 8443
 
   serviceMonitor:
     enabled: false # sem Prometheus Operator no lab
+
+# ============================================================================
+# uniplus-web — 3 SPAs Angular (portal, selecao, ingresso), 1 chart, 1
+# Deployment por app (issue #432). Imagens já publicadas em GHCR (v0.2.1,
+# confirmadas pull-áveis) — sem build local necessário, diferente do
+# uniplus-api-host. TLS autoassinado (secret uniplus-wildcard-nip-io-tls,
+# ver comentário completo no bloco traefik: acima) — browsers só liberam a
+# Web Crypto API (PKCE do keycloak-js) em secure context, HTTP puro não
+# qualifica mesmo em LAN privada. replicas=1 (chart default é 2 —
+# desnecessário/desperdício num lab single-node de 1 VM).
+# ============================================================================
+uniplusWeb:
+  enabled: true
+
+  ingress:
+    entryPoint: websecure
+    tls:
+      enabled: true
+      secretName: uniplus-wildcard-nip-io-tls
+      # Default do chart é true (produção real usa Let's Encrypt) — sem
+      # cert-manager no lab, desligar explicitamente ou o template tenta
+      # criar um Certificate cert-manager.io/v1 inexistente no cluster
+      # (CRD not found).
+      certManager:
+        enabled: false
+
+  apps:
+    portal:
+      enabled: true
+      replicas: 1
+      host: portal.192.168.1.65.nip.io
+      runtimeConfig:
+        apiUrl: https://api-portal.192.168.1.65.nip.io
+        keycloak:
+          url: https://keycloak.192.168.1.65.nip.io/auth
+
+    selecao:
+      enabled: true
+      replicas: 1
+      host: selecao.192.168.1.65.nip.io
+      runtimeConfig:
+        apiUrl: https://api-host.192.168.1.65.nip.io
+        keycloak:
+          url: https://keycloak.192.168.1.65.nip.io/auth
+
+    ingresso:
+      enabled: true
+      replicas: 1
+      host: ingresso.192.168.1.65.nip.io
+      runtimeConfig:
+        apiUrl: https://api-host.192.168.1.65.nip.io
+        keycloak:
+          url: https://keycloak.192.168.1.65.nip.io/auth
+
+  # traefikNamespace/monitoringNamespace ficam nos defaults do chart
+  # (traefik/monitoring) — o primeiro já bate com o release deste lab,
+  # o segundo é inerte (sem Prometheus Operator aqui).
+  networkPolicy:
+    enabled: true


### PR DESCRIPTION
## Resumo

Sobe Traefik com TLS autoassinado no `lab-standalone-single`, expõe os 5 backends já deployados (Keycloak, Apicurio, Host, Portal, Geo API) via hostnames HTTPS reais, e sobe as 3 SPAs do `uniplus-web` (portal, selecao, ingresso). Login OIDC completo (SPA → Keycloak → PKCE → token → sessão autenticada) validado ponta a ponta com um browser real via Playwright.

## Issue relacionada

Closes #432

## Motivação

Todo acesso ao lab era via `kubectl exec`/`kubectl port-forward` — suficiente para health checks server-to-server, mas o `uniplus-web` roda no browser do usuário: precisa de um hostname de fato alcançável **e HTTPS de verdade**, já que browsers só liberam a Web Crypto API (necessária pro PKCE do `keycloak-js`) em secure context. HTTP puro, mesmo em LAN privada, não qualifica — confirmado via Playwright (`window.isSecureContext=false`) antes do fix.

## Alterações principais

- `platform/traefik/` deployado no lab (HTTPS real, hostPort 80+443, TLS autoassinado `*.192.168.1.65.nip.io`) — substitui o Traefik embutido do k3s (desabilitado via `/etc/rancher/k3s/config.yaml`).
- `ingress.enabled=true` + `entryPoint=websecure` nos 5 charts backend (`keycloak-replica`, `apicurio-registry`, `uniplus-api-host`, `uniplus-api-portal`, `unifesspa-geo-api`).
- NetworkPolicies de `keycloak-replica`/`apicurio-registry` religadas (estavam `enabled: false` desde a issue #423 só pela ausência de Traefik).
- Novo client OIDC público `uniplus-portal` (compartilhado pelas 3 SPAs, já parametrizado no `uniplus-realm.json` desde a issue #152 — só faltava configurar via `realmImport.portalClient`).
- Deploy do `uniplus-web` (3 SPAs) apontando `runtime-config.json` pros hostnames do Traefik.
- Nova capacidade `customCA` nos charts `uniplus-api-host`/`uniplus-api-portal`/`unifesspa-geo-api` (initContainer + `update-ca-certificates`) — necessária porque o runtime .NET não confia no certificado autoassinado via `SSL_CERT_FILE`/`SSL_CERT_DIR` (isso só funciona pra `curl`/OpenSSL).
- `QUARKUS_TLS_TRUST_ALL=true` no Apicurio (Quarkus/Java — mecanismo diferente do .NET) para o mesmo problema de confiança de certificado.
- `docs/RUNBOOKS.md` §20.1/§20.5/§20.6 e `environments/lab-standalone-single/README.md` atualizados.

### Gotchas reais descobertos durante a implementação

1. **k3s já vem com Traefik embutido** (namespace `kube-system`, Service `LoadBalancer` já mapeando 80/443) — conflita com `platform/traefik/`; precisa desabilitar via `disable: [traefik]` no `config.yaml` do k3s + restart, antes de instalar o chart real.
2. **NetworkPolicy de egress com hostPort quebra silenciosamente**: `kube-router` avalia egress **depois** do DNAT do CNI portmap (mesma classe de bug já documentada para o Service `kubernetes` do apiserver) — o destino pós-DNAT é o IP do *pod* do Traefik (`10.42.0.x`), não o IP da VM. Regra de egress corrigida para `10.42.0.0/16:8443` (pod CIDR + porta interna do entryPoint `websecure`).
3. **`.NET` não respeita `SSL_CERT_FILE`/`SSL_CERT_DIR`** para confiar em CA extra — só funciona para `curl`. Sem isso, o erro reportado pela aplicação é enganoso ("OIDC discovery respondeu 404", na verdade uma falha de validação TLS). Resolvido com `initContainer` rodando `update-ca-certificates` de verdade.
4. **Playwright rejeita o certificado autoassinado por padrão** (mesmo comportamento que um usuário real veria antes de clicar "Avançar mesmo assim") — contornado via CDP `Security.setIgnoreCertificateErrors`, não é uma limitação do fix em si.

## Como testar

```bash
git fetch origin task/432-traefik-frontend
git checkout task/432-traefik-frontend

make validate        # yaml-lint + helm-lint + markdown-lint + schema-validate
make helm-template    # render de todos os charts × standalone-compact (produção não é tocada)
```

Deploy real no lab (procedimento completo em `environments/lab-standalone-single/README.md`, seções "Traefik + TLS autoassinado" e "uniplus-web").

## Evidências

### `make validate` + `make helm-template` limpos (inclusive produção `standalone-compact`)

```
make validate: EXIT 0
make helm-template: EXIT 0 — nenhum erro/regressão em standalone-compact
```

### Validado ponta a ponta na VM de lab (`192.168.1.65`)

```
$ kubectl get pods -n uniplus
apicurio-registry-apicurio-registry-...   1/1   Running
keycloak-replica-...                       1/1   Running
unifesspa-geo-api-unifesspa-geo-api-...    1/1   Running
uniplus-api-host-uniplus-api-host-...      1/1   Running
uniplus-api-portal-uniplus-api-portal-...  1/1   Running
uniplus-web-uniplus-web-ingresso-...       1/1   Running
uniplus-web-uniplus-web-portal-...         1/1   Running
uniplus-web-uniplus-web-selecao-...        1/1   Running

$ kubectl get pods -n traefik
traefik-...   1/1   Running
```

### Todos os 8 hostnames HTTPS confirmados de fora do cluster/VM (desta máquina, sem SSH/port-forward)

```
portal.192.168.1.65.nip.io      -> 200
selecao.192.168.1.65.nip.io     -> 200
ingresso.192.168.1.65.nip.io    -> 200
api-portal.../health            -> Healthy
api-host.../health              -> Healthy
api-geo.../health                -> Healthy
keycloak.../.well-known/...     -> 200 (issuer=https://keycloak.192.168.1.65.nip.io/auth/realms/uniplus)
apicurio.../system/info         -> 200
```

### Login OIDC completo via browser real (Playwright), não só curl

1. `https://portal.192.168.1.65.nip.io/` carrega sem erro de Web Crypto (`isSecureContext=true`, `crypto.subtle` disponível).
2. Navegação para rota protegida ("Meu Perfil") redireciona pro Keycloak com `code_challenge`/PKCE real e `redirect_uri` correto.
3. Login com usuário de teste temporário (criado e removido via `kcadm.sh`) → completar perfil (primeiro acesso) → redirect de volta com `code`.
4. SPA troca o código pelo token e mostra "Lab SmokeTest / @lab-smoke-test" no cabeçalho, com botão de logout — sessão autenticada confirmada.

## Documentação

- [x] README atualizado (`environments/lab-standalone-single/README.md`)
- [ ] OpenAPI atualizado — N/A (infra, sem contrato HTTP novo)
- [ ] ADR criado — N/A (aplica padrões já estabelecidos, não decide arquitetura nova)
- [x] RUNBOOKS atualizado (§20.1, §20.5, §20.6)
- [ ] CHANGELOG atualizado — repo não mantém CHANGELOG separado

## Checklist

- [x] Testes executados e verdes — `make validate` + `make helm-template` (inclusive produção)
- [x] Lint/format executado — yamllint, helm lint, markdownlint
- [x] Segurança revisada — chave privada TLS nunca versionada (só a parte pública, via YAML anchor); `QUARKUS_TLS_TRUST_ALL`/`customCA` documentados como *lab-only*, nunca produção
- [x] Documentação atualizada
- [x] Sem secrets no diff
- [x] Compatibilidade revisada — mudança aditiva; `standalone-compact` (produção) não é tocado (confirmado via `make helm-template`)
- [x] Critérios de aceite da issue atendidos
- [x] Auto-revisão do PR aplicada
