### PR TITLE
docs(runbooks): planeja ambiente HML real e corrige bug de unseal do Vault

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1001,7 +1001,9 @@ echo "Init output em $INIT_FILE — exportar para gestor institucional e shred."
 
 Cada vez que o Pod do Vault reinicia (upgrade K3s, manutenção da VM, OOMKill etc.) o Vault sobe `Sealed=true` e exige 3 das 5 unseal keys para destravar. **Não é one-shot — é um procedimento operacional recorrente em standalone.**
 
-> **Pré-requisito**: HashiCorp `vault` CLI instalada na workstation do operador (`brew install vault` / pacote oficial). Os blocos abaixo evitam expandir as unseal keys em argv de `kubectl exec` (que vazaria via `/proc/<pid>/cmdline`, `ps`, auditoria) — em vez disso, conectamos `vault` CLI local ao Vault via port-forward e passamos cada share por **stdin** (`vault operator unseal -`).
+> **Pré-requisito**: HashiCorp `vault` CLI instalada na workstation do operador (`brew install vault` / pacote oficial). O bloco abaixo evita expandir as unseal keys em argv de `kubectl exec` (que vazaria via `/proc/<pid>/cmdline`, `ps`, auditoria) — em vez disso, conectamos `vault` CLI local ao Vault via port-forward.
+>
+> **Correção 2026-07-12** (achado no spike de PathPrefix, ver `docs/validacao/spike-pathprefix-hml-2026-07-12.md`): a versão anterior deste procedimento orientava `printf '%s\n' "$K" | vault operator unseal -`, presumindo que `-` faz o Vault CLI ler a key via stdin. **Isso está errado** — o Vault CLI não suporta essa convenção; `-` é tratado como valor literal da key e falha com `Error unsealing: ... 'key' must be a valid hex or base64 string` (confirmado empiricamente contra Vault 1.21.2). O jeito correto — e mais simples — é usar o prompt interativo mascarado nativo do próprio `vault operator unseal` (sem argumento nenhum): a key nunca toca variável de shell, argv ou stdin explícito, só o prompt `Unseal Key (will be hidden):`.
 
 ```bash
 # 1) Port-forward local do Vault + apontar a CLI (mesmo pattern de §8.4.3)
@@ -1009,32 +1011,25 @@ sudo kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml \
   -n vault port-forward platform-vault-uniplus-standalone-0 8200:8200 \
   > /tmp/vault-pf.log 2>&1 &
 PF_PID=$!
-trap 'kill "$PF_PID" 2>/dev/null; unset K1 K2 K3 VAULT_ADDR' EXIT
+trap 'kill "$PF_PID" 2>/dev/null; unset VAULT_ADDR' EXIT
 export VAULT_ADDR=http://127.0.0.1:8200
 
 # Aguardar port-forward subir
 until curl -s --max-time 1 "$VAULT_ADDR/v1/sys/health" >/dev/null 2>&1; do sleep 1; done
 
-# 2) Ler 3 das 5 keys do gestor institucional (sem echo, sem history).
-#    Cada `read -rs` desabilita o eco (chave não aparece no terminal) e
-#    NÃO vai para ~/.bash_history.
-read -rsp "Unseal Key 1: " K1; echo
-read -rsp "Unseal Key 2: " K2; echo
-read -rsp "Unseal Key 3: " K3; echo
+# 2) Unseal com 3 das 5 keys do gestor institucional — rodar o comando
+#    3 vezes, uma por key. Cada chamada pede "Unseal Key (will be
+#    hidden): " no próprio terminal (requer TTY interativo real — não
+#    rodar isso via pipe/redirecionamento). Colar/digitar uma key por vez.
+vault operator unseal
+vault operator unseal
+vault operator unseal
 
-# 3) Unseal via stdin do `vault operator unseal -` — chave NÃO entra em argv,
-#    invisível em /proc/<pid>/cmdline. Após 3 shares válidas, Sealed=false.
-for K in "$K1" "$K2" "$K3"; do
-  printf '%s\n' "$K" | vault operator unseal -
-done
-unset K K1 K2 K3
-history -c 2>/dev/null || true
-
-# 4) Confirmar:
+# 3) Confirmar:
 vault status | grep Sealed
 # Esperado: Sealed          false
 
-# trap EXIT ao sair do shell encerra port-forward + cleanup das envs
+# trap EXIT ao sair do shell encerra port-forward
 ```
 
 #### 8.4.3 Configuração inicial pós-unseal (Kubernetes auth + ESO role)

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -16,6 +16,7 @@
 - [8. Bootstrap e Teardown — Ambiente Standalone OCI](#8-bootstrap-e-teardown--ambiente-standalone-oci)
 - [9. Data services no data-host (standalone)](#9-data-services-no-data-host-standalone)
 - [20. Ambiente de laboratório — host único (`lab-standalone-single`)](#20-ambiente-de-laboratório--host-único-lab-standalone-single)
+- [21. Ambiente de homologação real — host único (`hml-standalone-single`) — planejamento](#21-ambiente-de-homologação-real--host-único-hml-standalone-single--planejamento)
 
 ## 1. Procedimentos Rotineiros
 
@@ -3905,6 +3906,290 @@ implementação em `environments/lab-standalone-single/README.md` (seções
 
 Login OIDC completo (SPA → Keycloak → PKCE → token → sessão autenticada)
 validado com browser real via Playwright MCP — não só `curl`.
+
+## 21. Ambiente de homologação real — host único (`hml-standalone-single`) — planejamento
+
+> **Status: planejamento, pré-bootstrap.** Ao contrário das seções 8–9 (`standalone-compact`, em
+> operação) e 20 (`lab-standalone-single`, implementado), esta seção descreve um ambiente **ainda
+> não provisionado**. A VM de destino (`192.168.21.134`, Ubuntu 24.04.4, 6 vCPU/31 GB RAM, 97 GB
+> disco) é real, dedicada e reservada exclusivamente para este HML, mas hoje só tem Docker
+> instalado — sem k3s/kubectl/helm. Diferente do lab (VirtualBox, `nip.io`, TLS autoassinado), esta
+> VM é **alcançável apenas via VPN/rede interna da UNIFESSPA**, sem IP público. Objetivo desta
+> seção: consolidar os hostnames DNS e o desenho de roteamento Traefik que servem de base ao pedido
+> formal de rede à CTIC — o passo-a-passo de bootstrap (equivalente ao §20.2) só é escrito depois
+> que a rede estiver disponível.
+
+### 21.1 Topologia
+
+Mesmo modelo do `standalone-compact` (§8–9) — K3s numa VM + dados stateful (Postgres, Kafka,
+MinIO, Redis) via Docker+systemd — mas hoje comprimido numa única VM (só há 1 VM disponível),
+igual ao `lab-standalone-single` (§20.1). Diferente do lab, o objetivo aqui é validar acesso real
+de usuários institucionais, não só a mecânica dos charts — por isso TLS via certificado confiável
+(não autoassinado) é obrigatório **antes de qualquer usuário real acessar o ambiente para
+homologação**. Um certificado temporário (autoassinado ou importado manualmente) só é aceitável
+durante o bootstrap administrativo (smoke tests internos da equipe), nunca para a fase de
+homologação com usuários — ver §21.2, item 2.
+
+### 21.2 Hostnames DNS a solicitar à CTIC
+
+| # | Hostname | Tipo | Aponta para | Papel |
+|---|---|---|---|---|
+| 1 | `uniplus-hml.unifesspa.edu.br` | A (canônico) | `192.168.21.134` | Frontends SPA (`/portal`, `/ingresso`, `/selecao`; `/publicacoes` reservada — ver §21.3) |
+| 2 | `uniplus-api-hml.unifesspa.edu.br` | CNAME → `uniplus-hml...` | — | APIs backend (`/api/portal`, `/api/ingresso`, `/api/selecao`, `/api/publicacoes`) |
+| 3 | `uniplus-oidc-hml.unifesspa.edu.br` | CNAME → `uniplus-hml...` | — | Keycloak (`/auth`) |
+| 4 | `geo-api-hml.unifesspa.edu.br` | CNAME → `uniplus-hml...` | — | `unifesspa-geo-api` |
+| 5 | `grafana-hml.unifesspa.edu.br` | CNAME → `uniplus-hml...` | — | Observabilidade (dashboards) |
+| 6 | `kafka-ui-hml.unifesspa.edu.br` | CNAME → `uniplus-hml...` | — | Admin UI do Kafka (AKHQ) |
+| 7 | `apicurio-hml.unifesspa.edu.br` | CNAME → `uniplus-hml...` | — | Apicurio Registry (Schema Registry) |
+| 8 | `redis-ui-hml.unifesspa.edu.br` | CNAME → `uniplus-hml...` | — | Admin UI do Redis (RedisInsight, atrás de BasicAuth) |
+| 9 | `minio-hml.unifesspa.edu.br` | CNAME → `uniplus-hml...` | — | MinIO Console |
+
+**Recomendação, não requisito técnico rígido:** só `uniplus-hml.unifesspa.edu.br` precisa ser
+registro `A` (apontando pro IP da VM); os outros 8 podem ser `CNAME` para ele — reduz a uma única
+mudança uma eventual troca de IP futura (mesmo padrão já usado no `standalone-compact`, que mistura
+`A` canônico e `CNAME`s — ver a tabela de hosts em §8.3.1). Tecnicamente `A` individuais em todos
+também funcionam sem diferença de comportamento (Traefik distingue por SNI/`Host` header de
+qualquer forma); se a CTIC preferir só `A` por política interna da zona, isso é aceitável — não é
+uma exigência técnica deste lado.
+
+Admin UIs e Grafana ganham host próprio em vez de subpath de `uniplus-hml` porque (a) é o padrão
+já validado em `standalone-compact` para essas ferramentas (`kafka-ui` §14, `schema-registry`
+§15, `redis-ui` §16, `minio` §12 — ver a tabela de hosts em §8.3.1), (b) os charts já suportam
+`Host(...)`-only sem qualquer mudança de template, e (c) evita concorrência de `PathPrefix` com as
+rotas de negócio do host raiz.
+
+**Perguntas obrigatórias à CTIC, junto com a lista:**
+
+1. **Resolução** — o IP `192.168.21.134` é privado/VPN; os registros devem resolver só dentro da
+   rede/VPN institucional (split-horizon DNS), nunca numa zona pública apontando para IP privado.
+   Existe zona interna própria para isso, ou a zona `unifesspa.edu.br` já é só interna?
+2. **TLS (bloqueante) — três alternativas independentes, não uma escolha binária:** o único
+   mecanismo hoje implementado em `platform/cert-manager` é o desafio **HTTP-01** (dois
+   `ClusterIssuer` — `letsencrypt-staging` e `letsencrypt-prod` —, ambos HTTP-01; usado em
+   `standalone-compact` porque aquela VM tem IP público, ver §5.5.2 do `docs/ARCHITECTURE.md`).
+   HTTP-01 exige a porta 80 alcançável pelos servidores da Let's Encrypt a partir da internet
+   pública **E** que o próprio hostname resolva publicamente para esse ponto de entrada — não
+   basta abrir a porta 80 num NAT/DNAT, o registro DNS do host também precisaria deixar de ser
+   só-interno (conflita diretamente com a pergunta 1 acima, "resolução só dentro da VPN"). Não
+   implementado hoje para nenhum outro desafio, e esta VM é VPN-only sem esse ponto de entrada
+   público, então HTTP-01 **não serve para este ambiente** sem abrir mão do modelo VPN-only só
+   para essa finalidade — por isso as opções abaixo (DNS-01/PKI) são preferíveis. Perguntar à CTIC, cada
+   uma como opção independente:
+   - **(a) DNS-01 automatizado** — a zona `unifesspa.edu.br` (ou uma subzona delegada) suporta
+     atualização dinâmica (RFC2136/TSIG) para o cert-manager provisionar o desafio? **Atenção:**
+     mesmo que os hostnames de aplicação (§21.2) resolvam só internamente/VPN (split-horizon), o
+     desafio DNS-01 exige que o registro `TXT _acme-challenge.<host>` fique visível aos
+     validadores **públicos** da Let's Encrypt — ou seja, é necessária uma zona autoritativa
+     pública (ou delegação pública específica de `_acme-challenge`) além da view interna, não
+     apenas atualização da zona privada.
+   - **(b) AC SSL Corporativa ICPEdu/RNP** — a UNIFESSPA participa do programa ICPEdu Corporativo
+     da RNP (cadeia GlobalSign, reconhecida nativamente pelos navegadores)? Se sim, emitir
+     certificado Standard com SANs para os hosts do §21.2 (em vez de wildcard).
+   - **(c) PKI interna** — existe CA interna (ex. AD CS) da qual possamos emitir certificado? Se
+     sim, **em quais dispositivos essa CA raiz já é confiável por padrão** — só máquinas
+     institucionais gerenciadas, ou também navegadores de usuários externos à rede gerenciada?
+     Se a raiz já for amplamente confiável no público-alvo deste HML, (c) pode ser **solução
+     definitiva**, não apenas paliativa.
+   Sem viabilidade de (a), (b) ou (c) com confiança ampla, o ambiente sobe com certificado
+   manual/importado — aceitável só como paliativo explícito de bring-up administrativo (nunca
+   para a fase de homologação com usuários reais), já que um certificado importado manualmente
+   não passa a ser confiável para navegadores externos só por ter sido instalado.
+3. **TTL baixo (300s)** enquanto o ambiente está em bring-up, para permitir troca de IP sem espera
+   de propagação longa.
+
+#### 21.2.1 Matriz de fluxos de rede (complemento obrigatório ao pedido de DNS)
+
+Uma lista de hostnames sozinha não constitui um pedido formal de rede — falta a direção e a porta
+de cada fluxo. Completar pelo menos esta matriz antes de enviar à CTIC:
+
+| # | Origem | Destino | Protocolo/Porta | Motivo |
+|---|---|---|---|---|
+| 1 | Rede institucional/VPN (usuários finais) | `192.168.21.134` | TCP/443 | HTTPS via Traefik — todo tráfego de aplicação |
+| 2 | Internet pública (validadores Let's Encrypt) | Ponto de entrada público a definir (NAT/DNAT/LB na borda da CTIC que encaminhe para `192.168.21.134`) | TCP/80 | Só se HTTP-01 for adotado. **`192.168.21.134` é IP privado, não roteável da internet pública** — HTTP-01 exigiria a CTIC criar um ponto de entrada público (NAT/DNAT/LB) que hoje não existe; isso é, na prática, abrir mão do modelo VPN-only só para esta porta/finalidade. Redirect HTTP→HTTPS interno (sem HTTP-01) usa origem rede institucional/VPN, não internet pública |
+| 3 | Estações administrativas (via VPN) | `192.168.21.134` | TCP/22 | SSH administrativo |
+| 4 | `192.168.21.134` | Resolvedor DNS institucional | UDP+TCP/53 | Resolução de nomes |
+| 5 | `192.168.21.134` | Servidor(es) DNS autoritativo(s) da zona | UDP/53 (padrão do cert-manager para RFC2136; TCP/53 se a configuração exigir) | Só se DNS-01/TSIG (item 2a) for adotado |
+| 6 | `192.168.21.134` (saída) | ver lista de FQDNs confirmados abaixo | TCP/443 (HTTPS) e TCP/80 ou 443 (apt, conforme `sources.list` da VM) | Bootstrap do host, pull de charts/imagens de container, emissão de certificado |
+
+Ponto de partida — completar com outros fluxos que a CTIC exigir (ex. monitoramento externo,
+backup fora da VM).
+
+**FQDNs de egress confirmados por busca no repositório** (não é uma lista fechada — ver ressalva
+abaixo):
+
+- **Bootstrap do host**: `get.k3s.io`, `get.helm.sh`, `raw.githubusercontent.com`
+  (`scripts/bootstrap-standalone.sh`).
+- **Registries de imagem de container**: `ghcr.io` (imagens Uni+); `docker.io` (`postgres`,
+  `redis`, e as imagens usadas por `apps/apicurio-registry`, `apps/clamav-scanner`,
+  `apps/kafka-ui`, `apps/redis-ui` — `registry: docker.io` nos respectivos `values.yaml`);
+  `quay.io` (`keycloak-config-cli` usado por `apps/keycloak-replica`; e MinIO/`mc`, usados em
+  `scripts/bootstrap-standalone.sh` — a imagem principal do Keycloak é a composta própria em
+  `ghcr.io/unifesspa-edu-br/uniplus-keycloak`, já coberta pelo item `ghcr.io` acima).
+- **Repositórios Helm dos charts wrapper**: `charts.jetstack.io`, `charts.external-secrets.io`,
+  `grafana.github.io`, `prometheus-community.github.io`, `open-telemetry.github.io`,
+  `traefik.github.io`, `helm.releases.hashicorp.com` (declarados nos `Chart.yaml` de
+  `platform/*`).
+- **ACME (Let's Encrypt)**: `acme-staging-v02.api.letsencrypt.org`,
+  `acme-v02.api.letsencrypt.org` (`platform/cert-manager/values.yaml`) — só se HTTP-01/DNS-01
+  público for adotado.
+- **APT**: repositórios configurados no `sources.list` da VM (ex. `archive.ubuntu.com`/
+  `security.ubuntu.com` ou mirror institucional) — porta e protocolo dependem da configuração
+  real da VM, não verificados neste documento.
+
+**Ressalva explícita:** esta lista foi obtida por busca textual no repositório (scripts + valores
+declarados), não por observação de tráfego real nem auditoria das dependências transitivas dos
+charts upstream (subcharts do `kube-prometheus-stack`, `grafana/*`, `traefik/traefik` etc. podem
+puxar imagens adicionais de `registry.k8s.io` ou outros registries não referenciados
+diretamente neste repositório). Recomenda-se complementar o pedido com uma política de egress
+HTTPS mais ampla (ou um proxy/mirror interno) em vez de depender de uma lista de FQDNs
+fechada, e confirmar via observação real do tráfego durante o primeiro bootstrap.
+
+### 21.3 Roteamento Traefik
+
+| Host | Path | Backend (chart) | `PathPrefix`? | Mudança necessária |
+|---|---|---|---|---|
+| `uniplus-hml...` | `/portal`, `/ingresso`, `/selecao` | `apps/uniplus-web` (3 Deployments) | Sim | **Código** — `templates/ingressroute.yaml` hoje só suporta `Host(...)` |
+| `uniplus-hml...` | `/publicacoes` | — | — | **Não criar rota** — não existe SPA de Publicações em `uniplus-web` ainda; ativar só quando o 4º Deployment existir |
+| `uniplus-api-hml...` | `/api/portal` | `apps/uniplus-api-portal` | Sim | **Código** — idem. Hoje o Portal só tem endpoint-esqueleto (`/api/portal/ping`) — API de negócio ainda não implementada |
+| `uniplus-api-hml...` | `/api/ingresso`, `/api/selecao`, `/api/publicacoes` | `apps/uniplus-api-host` (composition root — Selecao+Ingresso+Configuracao+OrganizacaoInstitucional+Publicacoes, [ADR-0097](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md)/[ADR-0105](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0105-modulo-publicacoes-registro-central-dos-atos.md) do `uniplus-api`) | Sim | **Código** (IngressRoute) + **chart** (`templates/deployment.yaml` injeta só 5 connection strings — falta `ConnectionStrings__PublicacoesDb`) + registrar no ApplicationSet (ver nota abaixo) + **imagem publicada** — não há build do Host publicado em GHCR ainda. `/api/ingresso` é reserva de rota: módulo Ingresso ainda sem controller HTTP implementado |
+| `uniplus-oidc-hml...` | `/auth` | `apps/keycloak-replica` | Sim (já suportado) | Só `values.yaml` |
+| `geo-api-hml...` | `/` | `apps/unifesspa-geo-api` | Não | Só `values.yaml` + registrar no ApplicationSet (ver nota abaixo) |
+| `grafana-hml...` | `/` | `platform/observability/grafana` | Não (`pathPrefix: ""`) | `values.yaml` — o template já suporta os dois modos (subpath e subdomínio); **falta provisionar o `Certificate`/`secretName`** que a IngressRoute referencia — o chart não cria o certificado sozinho |
+| `kafka-ui-hml...`, `apicurio-hml...`, `redis-ui-hml...`, `minio-hml...` | `/` | charts respectivos | Não | Só `values.yaml` |
+
+**Nota sobre o ApplicationSet:** registrar `apps/uniplus-api-host` e `apps/unifesspa-geo-api` em
+`argocd/applicationset.yaml` **não é uma mudança pontual**. O generator combina cada item da lista
+com **todo cluster gerenciado** — ou seja, adicionar os dois à lista compartilhada cria uma
+`Application` desses charts em **todo** cluster registrado, não só no futuro cluster HML. Como os
+dois charts vêm com `enabled: false` por default, o Helm renderiza zero manifests nos clusters que
+não sobrescreverem isso (ex. `standalone-compact`) — resultando em `Application`s vazias/no-op
+espalhadas por todo cluster que não precisa delas (ruído operacional no ArgoCD, não uma falha de
+sync — a proteção `allowEmpty: false` existe para impedir prune acidental de todos os recursos de
+uma Application que **já estava populada**, não para bloquear uma Application que nasce vazia por
+design). Ainda assim, esse ruído por si só já justifica não fazer a mudança pontual: este HML
+precisa de um mecanismo por ambiente (Applications específicas do cluster HML, ou overrides
+explícitos por cluster no generator) — desenho a definir antes da implementação, não resolvido por
+este documento.
+
+**`uniplus-api-hml.../api/{ingresso,selecao,publicacoes}` é servido pelo `uniplus-api-host`, não
+pelos charts legados `apps/uniplus-api-{selecao,ingresso}`** — decisão deliberada, já que este HML
+existe para validar a arquitetura-alvo (ADR-0097/ADR-0105) antes de migrar `standalone-compact`
+(nota: a seção 20 descreve o Host com 4 módulos porque antecede o ADR-0105 — este documento já
+reflete os 5 módulos atuais do `uniplus-api`). Os charts legados continuam ativos só em
+`standalone-compact` até depreciação formal. Os módulos `Configuracao` e `OrganizacaoInstitucional`
+(também internos ao Host) ficam reservados/não roteados por enquanto — **sem novo workload**
+(mesmo Service), mas ainda exigem decisão própria de roteamento, CORS e autorização quando forem
+habilitados.
+
+**Política de prefixo de path é por backend, não uma regra universal:**
+
+- **APIs .NET e Keycloak** — preservar o path completo no Traefik (sem `StripPrefix`) está
+  correto, porque os controllers já registram a rota com o prefixo completo (ex.
+  `[Route("api/portal/ping")]`, `[Route("api/publicacoes")]`). Aplicar `UsePathBase` no pipeline
+  ASP.NET Core removeria esse prefixo de `Request.Path` e tenderia a produzir 404 — além disso,
+  uma única chamada global de `UsePathBase` não serve bases diferentes (`/api/portal`,
+  `/api/selecao`, `/api/ingresso`, `/api/publicacoes`) no mesmo host. **Não aplicar
+  `UsePathBase`** — os controllers já esperam o path prefixado, o Traefik só precisa encaminhá-lo
+  sem alterar.
+
+**Rotas transversais (sem prefixo de módulo) — decisão de dono no roteamento, não mudança de
+código.** Investigação em `uniplus-api` (SHA `778e380`) confirmou que todas as rotas de negócio
+dos módulos hospedados no Host (Selecao, Configuracao, OrganizacaoInstitucional, Publicacoes) já
+nascem 100% prefixadas (`api/{modulo}/...`, disciplina manual por controller, sem convenção
+central que force isso — ver nota abaixo). Ingresso não tem endpoint algum ainda (só esqueleto de
+domínio/infra). Só 10 rotas (depois de remover `/api/_smoke/*`, ver adiante) não têm prefixo
+algum, porque são registradas uma vez no Host e replicadas identicamente no Portal (mesmo pacote
+compartilhado `Unifesspa.UniPlus.Infrastructure.Core`):
+
+| Rota | Origem | Decisão de roteamento |
+|---|---|---|
+| `GET /api/auth/me` | `AuthEndpointsExtensions` | **Host é o dono** — única `IngressRoute` (`PathPrefix(/api/auth)`) aponta pro Service do Host. A cópia do Portal não fica alcançável externamente sob o host compartilhado (Portal hoje só tem o `ping` dummy, não há necessidade real de identidade própria) |
+| `GET /api/profile/me` | `ProfileEndpointsExtensions` | Idem — Host é o dono (`PathPrefix(/api/profile)`) |
+| `GET /openapi/{modulo}.json` × 5 | `Program.cs` + `ModuleApiGroupingConvention` | Idem — Host é o dono (`PathPrefix(/openapi)`); doc do Portal (se um dia existir) só via port-forward/uso interno |
+| `GET/POST /api/_smoke/*` × 3 | `SmokeEndpointsExtensions` | **Removidas do código** — [uniplus-api#829](https://github.com/unifesspa-edu-br/uniplus-api/issues/829), não precisam mais de decisão de roteamento |
+| `GET /health`, `/health/live`, `/health/ready` | `Program.cs` (`MapHealthChecks`) | **Sem rota no Traefik** — liveness/readiness do Kubernetes batem direto no IP do pod, nunca através do Ingress; não há necessidade de exposição externa |
+
+Autenticação/perfil são preocupação transversal por natureza (não pertencem a nenhum módulo de
+negócio específico) — faz sentido o Host, como composition root, ser o dono canônico. Só
+reconsiderar se um módulo/deployable diferente (Portal, Ingresso) precisar de semântica de
+auth/perfil genuinamente independente da do Host — não é o caso hoje.
+
+**Nota**: o prefixo `api/{modulo}` dos controllers de negócio é 100% manual (`[Route("api/{modulo}")]`
+por classe) — não há `IControllerModelConvention` nem classe base que force isso. O teste
+existente (`RoteamentoSemColisaoTests.cs`, `tests/Unifesspa.UniPlus.Host.IntegrationTests/`) só
+garante "existe pelo menos uma rota com esse prefixo" e ausência de colisão, não "100% das rotas
+do módulo respeitam o prefixo" — considerar uma issue própria em `uniplus-api` para (a) uma
+convenção que derive o prefixo automaticamente do namespace (mesmo padrão já usado por
+`ModuleApiGroupingConvention` para `GroupName`) e/ou (b) tornar esse teste exaustivo. Não é
+bloqueante para este documento.
+- **Angular (`uniplus-web`)** — "preservar o prefixo" **não resolve sozinho** aqui, e o
+  inventário de mudanças é maior do que só o build. Hoje o Nginx do `uniplus-web` serve o
+  conteúdo na raiz (`docker/nginx.conf`) e o runtime-config é buscado num caminho fixo
+  (`RUNTIME_CONFIG_PATH` em `runtime-config.provider.ts`) — `--base-href=/portal/` no build,
+  sozinho, não é suficiente. Também precisam de revisão: a configuração do Nginx para servir cada
+  SPA sob seu subpath, e os redirects OIDC do client-side (`silentCheckSsoRedirectUri` e a URI de
+  logout em `auth.service.ts`), que hoje presumem a SPA na raiz do domínio. Dependência cross-repo
+  real (repositório `uniplus-web`), não resolvida por este documento.
+- **Keycloak** — `redirectUris`/`webOrigins` dos clients do realm atualizados para os hosts
+  `*-hml.unifesspa.edu.br` via `environments/<env>/values.yaml` — sem mudança de template.
+
+### 21.4 Observabilidade
+
+Só o **Grafana** é exposto via Traefik (host dedicado `grafana-hml...`, OIDC real contra
+`uniplus-oidc-hml...`, mesmo padrão de `standalone-compact` — ver `environments/standalone-compact/values.yaml`,
+bloco `grafana.oidc`). **Prometheus, Loki, Tempo e o OTel Collector não têm `IngressRoute` em
+nenhum chart do repositório — nenhum pedido de DNS é necessário para eles.** Isso é o **estado
+desejado** para este HML, não uma garantia já imposta pelos defaults do repositório: o OTel
+Collector, por exemplo, configura `hostPort` 4317/4318 em
+`platform/observability/otelcol/values.yaml` (exposição potencial, dependendo do que o
+`values.yaml` do ambiente sobrescrever — o `environments/<env-hml>/values.yaml` deve remover
+explicitamente esse `hostPort`, não confiar só em `NetworkPolicy` para compensar), e a
+`NetworkPolicy` do Prometheus vem **desligada por padrão** no chart wrapper
+(`platform/observability/prometheus/values.yaml`). O `environments/<env-hml>/values.yaml` deste
+ambiente precisa habilitar/reforçar explicitamente essas proteções (mesmo nível ou mais estrito
+que `standalone-compact`) — não presumir que "sem
+IngressRoute" já implica isolamento de rede. Acesso de operação continua sendo via túnel VPN +
+`kubectl port-forward`/`exec`. Registrar isso explicitamente no pedido à CTIC evita que a ausência
+desses 4 nomes na lista do §21.2 seja lida como omissão.
+
+**CORS não pode ficar de fora do desenho.** Os charts de API já esperam `cors.allowedOrigins`
+configurável (ex. `apps/uniplus-api-portal/values.yaml`) — o `environments/<env-hml>/values.yaml`
+precisa listar os novos hosts de frontend (`uniplus-hml...`) como origem permitida em cada API,
+senão o SPA sobe mas as chamadas às APIs falham por CORS.
+
+### 21.5 Fora de escopo deste documento
+
+Registrado para rastreabilidade, não desenvolvido aqui — cada um é um documento/decisão à parte:
+
+- **Custódia do Vault** — o `standalone-compact` real hoje usa **Shamir manual (5 shares/3
+  threshold)**, não auto-unseal Transit. Auto-unseal Transit depende de alcançar em rede outro
+  Vault Transit + credencial — não de hardware TPM local (a hipótese de que a ausência de vTPM
+  bloquearia Transit estava incorreta e foi removida desta seção). O que fica pendente de decisão
+  para este HML é: seguir o mesmo padrão Shamir manual do `standalone-compact` (aceitando operação
+  manual de unseal/custódia de chaves), ou avaliar se há um Vault Transit alcançável em rede a
+  partir desta VM que justifique auto-unseal — decisão técnica separada, fora do escopo deste
+  documento.
+- **GitOps vs. bootstrap script** — registrar `apps/uniplus-api-host` e `apps/unifesspa-geo-api`
+  no `argocd/applicationset.yaml` não é pontual (ver nota em §21.3) — o desenho do mecanismo por
+  ambiente fica como decisão arquitetural separada, não resolvida aqui.
+- **K3s EOL** — `scripts/bootstrap-standalone.sh` pina `v1.31.4+k3s1` (Kubernetes 1.31 é EOL desde
+  novembro/2025); atualização de versão é pré-requisito técnico do bootstrap, fora do escopo de
+  DNS/roteamento deste documento.
+
+### 21.6 Suposições e verificações pendentes
+
+Para não conferir a este documento uma precisão que ele não tem:
+
+- **Especificações da VM** (IP `192.168.21.134`, SO Ubuntu 24.04.4, 6 vCPU/31 GB RAM, 97 GB disco,
+  Docker já instalado, ausência de IP público, VPN-only, dedicação exclusiva a este HML, ausência
+  de vTPM) — conforme relatado/levantado por SSH em sessão anterior, **não re-verificadas nesta
+  revisão documental**. Reconfirmar antes do bootstrap.
+- **Capacidade de rede da CTIC** — existência de DNS interno/split-horizon, suporte a
+  RFC2136/TSIG, adesão da UNIFESSPA ao ICPEdu Corporativo, compatibilidade de registro CAA e
+  aceitação de TTL 300s — dependem de resposta da CTIC, não de decisão deste time.
+- **Os 9 hostnames propostos não retornam registro DNS hoje** (verificado durante revisão) —
+  esperado, já que ainda não foram solicitados; não deve ser lido como indício de que já existem
+  ou não numa view DNS interna específica.
 
 ---
 

--- a/docs/validacao/spike-pathprefix-hml-2026-07-12.md
+++ b/docs/validacao/spike-pathprefix-hml-2026-07-12.md
@@ -1,0 +1,204 @@
+# Spike — Roteamento Host+PathPrefix sem StripPrefix (uniplus-api-host / Publicações)
+
+> **Plano:** validação exploratória antes da cascata formal de issues (Epic → Features → Stories →
+> Tasks) do ambiente HML real (`docs/RUNBOOKS.md §21`).
+> **Data:** 2026-07-12
+> **VM alvo:** `192.168.21.134` (real, dedicada, VPN-only) — ambiente permanece identificado como
+> **spike**, não como HML operacional. Nenhum PR foi aberto para o conteúdo deste spike em si
+> (chart e values ficaram fora do repositório, ver seção "O que NÃO foi commitado").
+> **SHAs congelados:** `uniplus-infra@9fd7258` · `uniplus-api@778e380` (ambos `origin/main`)
+
+## Resultado: PASS — gate fechado com evidência conjunta
+
+| # | Critério do gate | Status | Evidência |
+|---|---|---|---|
+| 1 | `IngressRoute` live com `Host && PathPrefix`, sem middleware | PASS | `kubectl get ingressroute -o yaml` — ver seção 4 |
+| 2 | Publicações inicializada com migrations reais | PASS | 5 `DbContext` sem migration pendente no boot (log) |
+| 3 | Path completo → 200 direto no Service (port-forward) | PASS | seção 3 |
+| 3b | Path sem prefixo → 404 direto no Service | PASS | seção 3 |
+| 4 | Requisição externa (fora da VM) respondendo 200 | PASS | seção 5 |
+| 4b | Host incorreto / path sem prefixo → 404 (assinatura do Traefik, não da app) | PASS | seção 5 |
+| 5 | Mesmo `CorrelationId` no cliente e no log do Host | PASS | seção 6 |
+| 6 | Log do Host mostrando o `RequestPath` completo (`/api/publicacoes/...`) | PASS | seção 6 |
+| 7 | Controles negativos não alcançam a aplicação | PASS | seção 5 (sem `x-correlation-id`, sem vendor content-type) |
+| 8 | Resultado preservado após restart do pod | PASS | seção 7 |
+
+---
+
+## 1. Escopo e decisões do spike
+
+- **Alvo:** só o módulo Publicações (`GET /api/publicacoes/tipos-ato`, `GET /api/publicacoes/atos`
+  — rotas reais, com regra de negócio e migrations). Portal ficou fora do deploy (só tem
+  `/api/portal/ping` dummy) — usado como controle negativo de path.
+- **Direto na VM real**, sem Docker Compose local prévio.
+- **Imagem buildada na própria VM** a partir do SHA fixado (`docker/Dockerfile.host`).
+- **Nenhum PR antes do spike** — `ConnectionStrings__PublicacoesDb` via `extraEnv` temporário,
+  `IngressRoute` como manifesto avulso fora do repositório, ingress nativo do chart desligado.
+- **K3s `v1.31.4+k3s1` (EOL) não bloqueou o spike** — decisão explícita do plano, já que a VM é
+  dedicada e sem tráfego real; atualização fica como pré-requisito antes de a VM virar HML
+  persistente.
+- **Fundação replicada integralmente do `lab-standalone-single`** (Vault, ESO, Traefik+TLS
+  autoassinado, Keycloak, Kafka, Apicurio Registry) — decisão tomada **durante** a execução: a
+  tentativa inicial de reduzir escopo (desligar Kafka/Schema Registry) esbarrou num gotcha já
+  documentado no próprio `values.yaml` do lab (Kafka desligado deixa o pod `Running` mas nunca
+  `Ready`; o módulo Selecao, co-hospedado no mesmo processo, exige Schema Registry alcançável no
+  boot quando Kafka está configurado). Replicar a fundação completa (já validada) foi mais rápido
+  e seguro do que depurar uma combinação nova.
+
+## 2. Achados/bugs encontrados e corrigidos durante o spike
+
+Nenhum destes bloqueia o veredito do gate (todos contornados/corrigidos), mas são achados reais
+que valem registro para as issues formais:
+
+1. **DNS quebrado dentro de containers Docker** — `/etc/resolv.conf` do host (systemd-resolved)
+   lista `192.168.21.13` como nameserver IPv4, mas esse endereço está inalcançável
+   (`Destination Host Unreachable`) — só a resolução IPv6 funciona no host. Docker extrai
+   nameservers do arquivo "legacy" e usa o primeiro (o quebrado), causando falha de `apt-get`
+   dentro do build. **Corrigido**: `/etc/docker/daemon.json` com `dns: ["1.1.1.1", "8.8.8.8"]` +
+   restart do Docker.
+2. **Mesmo problema no CoreDNS do cluster** — `forward . /etc/resolv.conf` no `Corefile` herdava o
+   mesmo nameserver quebrado, causando `SERVFAIL` ao resolver hostnames `nip.io` de dentro de
+   pods. **Corrigido**: patch no ConfigMap `coredns` (`forward . 1.1.1.1 8.8.8.8`) + restart do
+   deployment. **Ambos os achados são específicos desta VM/rede** (não necessariamente presentes
+   em outra VM) — mas o padrão de correção (DNS explícito, não confiar no `/etc/resolv.conf` do
+   host) vale a pena documentar como pré-requisito de bootstrap.
+3. **Bug real e pré-existente em `scripts/lab-standalone-single/bootstrap.sh`** — o passo de
+   unseal do Vault usa `vault operator unseal -` esperando ler a chave via stdin, mas o Vault CLI
+   **não suporta essa convenção** (`-` é passado literalmente como a chave, que falha a validação
+   hex/base64: `Error unsealing: 'key' must be a valid hex or base64 string`). Corrigido
+   manualmente para este spike (chave passada como argumento posicional, conforme a própria
+   mensagem de erro do Vault orienta). **Corrigido no repositório em 2026-07-12** — o mesmo bug
+   também estava documentado como procedimento oficial em `docs/RUNBOOKS.md §8.4.2` (unseal manual
+   do `standalone-compact`, produção real); ambos corrigidos: o script passa a chave como
+   argumento posicional, o runbook passou a usar o prompt interativo mascarado nativo do
+   `vault operator unseal` (sem `-`, sem pipe).
+4. **Timeout de 60s do Postgres no primeiro boot** — o pull da imagem `postgis/postgis:18-3.6`
+   (~1-2GB, primeira vez) mais o ciclo padrão `initdb`+restart dos entrypoints oficiais do Postgres
+   excedeu o timeout fixo do script. Sem impacto real (Postgres ficou saudável poucos segundos
+   depois) — re-rodar o script (idempotente) resolveu. Vale considerar aumentar o timeout ou
+   adicionar retry no script, mas não é bloqueante.
+
+## 3. Validação direta no Service (port-forward, sem Traefik)
+
+```
+GET /api/publicacoes/tipos-ato  → 200, content-type: application/vnd.uniplus.tipo-ato.v1+json
+GET /api/publicacoes/atos       → 200, content-type: application/vnd.uniplus.ato-normativo.v1+json
+GET /tipos-ato (sem prefixo)    → 404
+GET /atos (sem prefixo)         → 404
+GET /health/live                → 200
+```
+
+## 4. IngressRoute aplicado (manifesto avulso, fora do repositório)
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: spike-uniplus-api-host-pathprefix
+  namespace: uniplus
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`uniplus-api-hml.192.168.21.134.nip.io`) && PathPrefix(`/api/publicacoes`)
+      kind: Rule
+      services:
+        - name: uniplus-api-host-uniplus-api-host
+          port: 8080
+  tls:
+    secretName: uniplus-wildcard-nip-io-tls
+```
+
+Confirmado via `kubectl get ingressroute -o yaml`: objeto live idêntico ao aplicado, **sem**
+`middlewares` (sem `StripPrefix`).
+
+## 5. Prova externa diferencial (de fora da VM, via VPN)
+
+| Caso | Resultado | Assinatura |
+|---|---|---|
+| Host correto + `/api/publicacoes/tipos-ato` | `200` | `content-type: application/vnd.uniplus.tipo-ato.v1+json`, `x-correlation-id` ecoado |
+| Host correto + `/api/publicacoes/atos` | `200` | `content-type: application/vnd.uniplus.ato-normativo.v1+json`, `x-correlation-id` ecoado |
+| Host **incorreto** + path válido | `404` | `content-type: text/plain`, sem `x-correlation-id`, sem `link` — 404 do **Traefik**, requisição nunca chegou na app |
+| Host correto + `/api/portal/ping` (fora do `PathPrefix`) | `404` | mesma assinatura acima — 404 do Traefik |
+
+## 6. Rastreamento por Correlation ID no log da aplicação
+
+Requisição externa com `X-Correlation-Id: 39858c04-638a-40e2-af0d-e32acc881d4c`:
+
+```
+[23:14:57 Information] HTTP GET /api/publicacoes/tipos-ato respondeu 200 em 4.3998ms
+  RequestPath: "/api/publicacoes/tipos-ato"
+  CorrelationId: "39858c04-638a-40e2-af0d-e32acc881d4c"
+
+[23:14:57 Information] HTTP GET /api/publicacoes/atos respondeu 200 em 7.4039ms
+  RequestPath: "/api/publicacoes/atos"
+  CorrelationId: "39858c04-638a-40e2-af0d-e32acc881d4c"
+```
+
+`CorrelationId` do log bate exatamente com o header enviado pelo cliente; `RequestPath` mostra o
+path **completo**, confirmando que o Traefik não removeu o prefixo (`StripPrefix` de fato ausente).
+
+## 7. Resiliência pós-restart
+
+```bash
+kubectl rollout restart deployment/uniplus-api-host-uniplus-api-host -n uniplus
+kubectl rollout status deployment/uniplus-api-host-uniplus-api-host -n uniplus --timeout=120s
+# deployment "uniplus-api-host-uniplus-api-host" successfully rolled out
+```
+
+Nova requisição externa (`X-Correlation-Id: 458e50eb-4ddf-4e8b-bcae-edaf32e0ff29`) →
+`200`, mesmo vendor media type. Resultado não era coincidência de estado.
+
+## 8. O que NÃO foi commitado (fica só nesta VM de spike)
+
+- `environments/_spike-pathprefix-hml/values.yaml` (worktree detached descartável, não commitado).
+- `IngressRoute spike-uniplus-api-host-pathprefix` (manifesto avulso, aplicado via `kubectl apply`,
+  fora do Git).
+- `ConnectionStrings__PublicacoesDb` via `extraEnv` (paliativo — o chart real precisa ganhar essa
+  connection string nativamente).
+- Certificado autoassinado `*.192.168.21.134.nip.io` (gerado só para este spike, chave privada já
+  destruída — `shred -u`).
+
+## 9. O que isso desbloqueia (para a cascata formal de issues)
+
+Confirmado tecnicamente viável, sem ambiguidade: `Host() && PathPrefix()` sem `StripPrefix` é o
+padrão correto para expor APIs de negócio do `uniplus-api-host` sob um host único, preservando o
+path completo que os controllers já esperam. As issues formais podem agora assumir isso como fato
+validado (não mais suposição), e focar em:
+
+- Suporte a `PathPrefix` nos templates `IngressRoute` de `apps/uniplus-web`,
+  `apps/uniplus-api-{portal,host}` (hoje só `Host()`), incluindo as regras para as rotas
+  transversais (`/api/auth`, `/api/profile`, `/openapi` — Host é o dono; ver §21.3 e item 10
+  abaixo).
+- `ConnectionStrings__PublicacoesDb` nativo no chart `apps/uniplus-api-host`.
+- ~~Correção do bug de `vault operator unseal -`~~ — **feito** (item 10).
+- Mecanismo por-ambiente no `argocd/applicationset.yaml` (achado de rodada anterior de revisão).
+- ~~Atualização da versão do K3s (EOL)~~ — **feito** (item 10).
+- Trabalho cross-repo no `uniplus-web` (Angular) para path-based routing — não coberto por este
+  spike, esforço médio já mapeado em `docs/RUNBOOKS.md §21.3`.
+
+## 10. Atualizações pós-spike (2026-07-12)
+
+Fechamento de pontas soltas decidido em conversa após o gate, antes da cascata formal de issues:
+
+- **Rotas transversais** — decisão de dono registrada em `docs/RUNBOOKS.md §21.3` (tabela
+  completa): Host é dono de `/api/auth`, `/api/profile`, `/openapi/*`; `/health*` não precisa de
+  rota no Traefik (probes do K8s batem direto no pod); `/api/_smoke/*` está sendo removido do
+  código ([uniplus-api#829](https://github.com/unifesspa-edu-br/uniplus-api/issues/829)).
+- **Bug do `vault operator unseal -` corrigido** em dois lugares: `scripts/lab-standalone-single/bootstrap.sh`
+  (chave como argumento posicional) e `docs/RUNBOOKS.md §8.4.2` (procedimento de produção real do
+  `standalone-compact` — trocado pelo prompt interativo mascarado nativo do `vault`, sem `-`/pipe).
+- **K3s e Helm atualizados** em `scripts/lab-standalone-single/bootstrap.sh` e
+  `scripts/bootstrap-standalone.sh`: `K3S_VERSION` de `v1.31.4+k3s1` (EOL nov/2025) para
+  `v1.36.2+k3s1` (mais recente estável, mai/2026); `HELM_VERSION` de `v3.16.4` para `v3.21.2`
+  (última minor da série 3.x — **não** Helm 4, que é major version nova sem validação de
+  compatibilidade com os charts deste repo). `ARGOCD_VERSION` **não** atualizado — v2.14→v3.x é
+  salto de major com guia de migração dedicado, avaliação própria fica fora do escopo desta
+  rodada.
+- **VM do spike derrubada por completo** (Opção A — volta ao estado antes do spike): K3s
+  desinstalado, Vault/ESO/Traefik/Keycloak/Apicurio/uniplus-api-host desinstalados, serviços
+  systemd de dados parados/removidos, `/var/lib/uniplus` apagado, imagens Docker removidas. Disco
+  confirmado de volta a 12G usado / 81G livre, idêntico ao preflight original (§ deste documento
+  não repete os comandos — só o registro de que a VM está limpa para um bootstrap novo). Mantido
+  de propósito: `/etc/docker/daemon.json` (fix de DNS), já que é correção real, não resquício do
+  spike.

--- a/scripts/bootstrap-standalone.sh
+++ b/scripts/bootstrap-standalone.sh
@@ -31,8 +31,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # ============== Versões pinadas ==============
-K3S_VERSION="v1.31.4+k3s1"
-HELM_VERSION="v3.16.4"
+# K3s/Helm atualizados em 2026-07-12 (mesmo racional do
+# scripts/lab-standalone-single/bootstrap.sh — ver comentário lá e
+# docs/validacao/spike-pathprefix-hml-2026-07-12.md). K3s 1.31.4 estava
+# EOL desde nov/2025.
+K3S_VERSION="v1.36.2+k3s1"
+HELM_VERSION="v3.21.2"
+# ArgoCD NÃO atualizado agora — v2.14→v3.x é salto de major version com
+# guia de migração dedicado (breaking changes documentados pelo upstream,
+# ver https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.14-3.0/),
+# não uma troca de pin compatível por padrão. standalone-compact é
+# produção real — avaliar a migração como trabalho dedicado à parte, não
+# como parte desta atualização de rotina.
 ARGOCD_VERSION="v2.14.3"
 
 # ============== Defaults ==============

--- a/scripts/lab-standalone-single/bootstrap.sh
+++ b/scripts/lab-standalone-single/bootstrap.sh
@@ -47,8 +47,19 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 export KUBECONFIG="$HOME/.kube/config"
 
 # ============== Versões pinadas ==============
-K3S_VERSION="v1.31.4+k3s1"
-HELM_VERSION="v3.16.4"
+# Atualizado em 2026-07-12: v1.31.4+k3s1 estava EOL desde nov/2025 (achado
+# durante o spike de PathPrefix, ver docs/validacao/spike-pathprefix-hml-
+# 2026-07-12.md). K3s 1.36.2+k3s1 é a mais recente estável (release
+# 2026-05-27) — bootstrap é sempre from-scratch (sem upgrade de cluster
+# vivo), então o salto de minor version não tem caminho de migração a
+# validar. Helm fica na última minor da série 3.x (3.21.2, jun/2026) —
+# Helm 4 já é a série estável atual, mas é major version nova, sem
+# validação de compatibilidade com os charts deste repo; não trocar sem
+# avaliação própria. Reconfirmar ambas em https://docs.k3s.io/release-notes
+# e https://github.com/helm/helm/releases antes do próximo bootstrap —
+# release cadence de ambos é rápida.
+K3S_VERSION="v1.36.2+k3s1"
+HELM_VERSION="v3.21.2"
 
 # ============== Defaults ==============
 DRY_RUN=false

--- a/scripts/lab-standalone-single/bootstrap.sh
+++ b/scripts/lab-standalone-single/bootstrap.sh
@@ -459,9 +459,17 @@ step_init_unseal_vault() {
         fi
         local unseal_key
         unseal_key=$(sudo python3 -c "import json; print(json.load(open('$creds_file'))['unseal_keys_b64'][0])")
-        # `-` faz o Vault CLI ler a key do stdin — nunca em argv (visível via
-        # /proc/<pid>/cmdline ou `ps` local enquanto o comando roda).
-        printf '%s' "$unseal_key" | kubectl exec -i -n "$VAULT_NAMESPACE" "$VAULT_POD" -- vault operator unseal - >/dev/null
+        # BUG CORRIGIDO 2026-07-12 (achado no spike, ver docs/validacao/
+        # spike-pathprefix-hml-2026-07-12.md): o Vault CLI NÃO lê a unseal
+        # key via stdin com "-" como sentinel — "-" é tratado como valor
+        # literal da key e falha com "must be a valid hex or base64
+        # string" (confirmado empiricamente contra Vault 1.21.2). Passar
+        # como argumento posicional é a única forma de automatizar sem TTY
+        # interativo — expõe a key brevemente em `ps`/`/proc/<pid>/cmdline`
+        # dentro do pod durante a única chamada, aceitável neste contexto
+        # (bootstrap non-interativo, sem outro operador com acesso ao pod
+        # nesse instante).
+        kubectl exec -n "$VAULT_NAMESPACE" "$VAULT_POD" -- vault operator unseal "$unseal_key" >/dev/null
         unset unseal_key
         log_success "Vault desselado."
     else


### PR DESCRIPTION
## Resumo

Consolida a fundação documental do HML real da UNIFESSPA (`hml-standalone-single`, VM dedicada `192.168.21.134`), produzida por um spike técnico executado diretamente na VM real: valida `Host() && PathPrefix()` sem `StripPrefix` como padrão de roteamento (gate 8/8 PASS), planeja o pedido formal de DNS/TLS/rede à CTIC, e corrige dois bugs reais encontrados no caminho.

- `docs(runbooks)`: nova seção §21 — topologia, 9 hostnames DNS a solicitar, 3 alternativas de TLS confiável (DNS-01/ICPEdu-RNP/PKI interna — HTTP-01 não serve porque a VM é VPN-only sem IP público), matriz de fluxos de rede, desenho de roteamento Traefik, observabilidade/CORS, e o que fica deliberadamente fora de escopo (custódia do Vault, GitOps por-ambiente, K3s EOL)
- `docs(validacao)`: relatório do spike de PathPrefix (`spike-pathprefix-hml-2026-07-12.md`) — evidência completa do gate, achados e correções
- `fix(vault)`: `vault operator unseal -` não lê a key via stdin como o procedimento antigo presumia — corrigido no runbook (§8.4.2, produção real do `standalone-compact`) e no script do lab
- `fix(bootstrap)`: K3s `v1.31.4+k3s1` estava EOL desde nov/2025 — atualizado para `v1.36.2+k3s1` (e Helm para `v3.21.2`) nos dois scripts de bootstrap

## Contexto

Precede a cascata formal de issues do Epic #434 (HML real da UNIFESSPA). A Feature #435 e as Stories #439/#442/#445 referenciam diretamente `docs/RUNBOOKS.md §21.1` e `§21.5`, e o spike report — este PR é o pré-requisito para que essas referências existam no repositório antes de eu implementar a Story #439.

## O que NÃO está neste PR

- Environment `environments/hml-standalone-single/values.yaml` (Story #439)
- Decisão de custódia do Vault (Shamir vs Transit) para este ambiente — §21.5 deixa isso deliberadamente em aberto, é o objeto da Story #439
- Script de bootstrap adaptado para a VM real (Story #442)
- Qualquer execução contra a VM real — o spike foi executado e a VM devolvida ao estado limpo (seção 8 do relatório)

## Nota sobre IP interno

O documento referencia `192.168.21.134` (rede interna UNIFESSPA, VPN-only, sem rota da internet pública) em texto plano — mesmo padrão já usado nas issues #434/#435/#439/#442/#445, já públicas neste repositório.

## Test plan

- [x] `npx markdownlint-cli2` limpo em `docs/RUNBOOKS.md` e `docs/validacao/spike-pathprefix-hml-2026-07-12.md`
- [x] `shellcheck` (via Docker `koalaman/shellcheck:stable`) limpo nos dois scripts alterados — 2 achados SC2086 pré-existentes fora do diff, não introduzidos por este PR
- [x] Histórico linear preservado (4 commits atômicos, sem "round N")

Refs #434, #435, #439 (pré-requisito documental da Story #439 — não fecha a issue; falta ainda `environments/hml-standalone-single/values.yaml` e a decisão de custódia do Vault).
