### PR TITLE
feat(hml): custódia do Vault e environment hml-standalone-single

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Validate values.schema.json across charts × environments
         run: |
           set -euo pipefail
-          ENVS="standalone-compact"
+          ENVS="standalone-compact hml-standalone-single"
           FAILS=0
           for chart_dir in apps/*/ platform/*/; do
             chart_name=$(basename "$chart_dir")
@@ -153,7 +153,7 @@ jobs:
         run: |
           set -euo pipefail
           K8S_VERSION="1.31.0"
-          ENVS="standalone-compact"
+          ENVS="standalone-compact hml-standalone-single"
           FAILS=0
           for chart in apps/*/ platform/*/ platform/observability/*/; do
             [ -f "$chart/Chart.yaml" ] || continue

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,14 @@ MAKEFLAGS += --no-print-directory
 # ============================================================================
 
 # Charts a serem processados. Atualizar se nova área surgir.
+#
+# platform/*/Chart.yaml sozinho não pega platform/observability/<x>/Chart.yaml
+# (1 nível a mais) — combinado explicitamente, senão helm-lint/schema-validate/
+# helm-template pulam os 5 charts de observability silenciosamente (achado real
+# em 2026-07-13: nenhum dos três cobria observability, embora o job "Manifest
+# Validate" do CI, que não usa este Makefile, já cobrisse via glob próprio).
 CHARTS_APPS     := $(wildcard apps/*/Chart.yaml)
-CHARTS_PLATFORM := $(wildcard platform/*/Chart.yaml)
+CHARTS_PLATFORM := $(wildcard platform/*/Chart.yaml) $(wildcard platform/observability/*/Chart.yaml)
 CHARTS_ALL      := $(CHARTS_APPS) $(CHARTS_PLATFORM)
 CHART_DIRS      := $(dir $(CHARTS_ALL))
 

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ CHART_DIRS      := $(dir $(CHARTS_ALL))
 # Diretórios validados pelo yamllint (mesma lista do CI).
 YAML_DIRS := apps/ platform/ data/ environments/ argocd/
 
-# Environments existentes (atualizar quando san-* / hml-* / 3-DC forem criados).
-ENVS := standalone-compact
+# Environments existentes (atualizar quando san-* / 3-DC forem criados).
+ENVS := standalone-compact hml-standalone-single
 
 # Comando markdownlint via npx (não exige instalação global).
 MARKDOWNLINT := npx --yes markdownlint-cli2

--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -156,7 +156,7 @@
       ]
     },
     {
-      "clientId": "apicurio-registry",
+      "clientId": {{ .Values.keycloak.realmImport.apicurioClient.clientId | quote }},
       "name": "Apicurio Registry — Schema Registry (Confluent SR API)",
       "description": "Cliente OIDC do Apicurio Registry (apps/apicurio-registry). Confidential — secret em secret/standalone/keycloak/clients/apicurio-registry via kcadm pós-import. directAccessGrantsEnabled=true para smoke (revisar em prod). RUNBOOKS §15.1.",
       "enabled": true,
@@ -167,11 +167,8 @@
       "directAccessGrantsEnabled": true,
       "serviceAccountsEnabled": true,
       "frontchannelLogout": true,
-      "redirectUris": [
-        "https://schema-registry.standalone.portaluni.com.br/*",
-        "https://schema-registry.standalone.portaluni.com.br/ui/*"
-      ],
-      "webOrigins": ["https://schema-registry.standalone.portaluni.com.br"],
+      "redirectUris": {{ .Values.keycloak.realmImport.apicurioClient.redirectUris | toJson }},
+      "webOrigins": {{ .Values.keycloak.realmImport.apicurioClient.webOrigins | toJson }},
       "attributes": {
         "post.logout.redirect.uris": "+"
       },

--- a/apps/keycloak-replica/values.schema.json
+++ b/apps/keycloak-replica/values.schema.json
@@ -110,6 +110,21 @@
                   "items": { "type": "string" }
                 }
               }
+            },
+            "apicurioClient": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "clientId": { "type": "string" },
+                "redirectUris": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "webOrigins": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              }
             }
           }
         },

--- a/apps/keycloak-replica/values.yaml
+++ b/apps/keycloak-replica/values.yaml
@@ -105,6 +105,20 @@ keycloak:
       webOrigins:
         - "+"
 
+    # Client OIDC do Apicurio Registry (UI + Confluent SR API). Default
+    # aqui reproduz o valor que estava hardcoded no uniplus-realm.json antes
+    # da parametrização — preserva o comportamento de standalone-compact.
+    # Qualquer outro environment que habilite apicurioRegistry.ingress DEVE
+    # sobrescrever com o próprio host, ou o login pela UI do Apicurio é
+    # rejeitado pelo Keycloak (redirect_uri/origin não batem com o client).
+    apicurioClient:
+      clientId: apicurio-registry
+      redirectUris:
+        - https://schema-registry.standalone.portaluni.com.br/*
+        - https://schema-registry.standalone.portaluni.com.br/ui/*
+      webOrigins:
+        - https://schema-registry.standalone.portaluni.com.br
+
   # Realm reconcile — Job Helm hook (post-install,post-upgrade) que
   # executa keycloak-config-cli (adorsys) para reconciliar o realm
   # declarativamente em runtime, depois do --import-realm já ter sido

--- a/docs/adrs/ADR-014-vault-shamir-hml-standalone-single.md
+++ b/docs/adrs/ADR-014-vault-shamir-hml-standalone-single.md
@@ -1,0 +1,132 @@
+# ADR-014: Custódia do Vault via Shamir manual no `hml-standalone-single`
+
+- **Status:** ✅ Aceito
+- **Data:** 2026-07-13
+- **Relacionado:** [Issue #439](https://github.com/unifesspa-edu-br/uniplus-infra/issues/439) · [Feature #435](https://github.com/unifesspa-edu-br/uniplus-infra/issues/435) · [Epic #434](https://github.com/unifesspa-edu-br/uniplus-infra/issues/434)
+
+## Contexto
+
+O `docs/RUNBOOKS.md §21.5` deixou deliberadamente em aberto a decisão de custódia do
+Vault para o ambiente `hml-standalone-single` (VM real dedicada `192.168.21.134`, rede
+interna UNIFESSPA, VPN-only): seguir o mesmo padrão Shamir manual do
+`standalone-compact`, ou avaliar auto-unseal via Vault Transit. A Story #439 pede que
+essa decisão seja tomada antes de criar o `environments/hml-standalone-single/values.yaml`.
+
+O [ADR-007](ADR-007-vault-ha-storage-unseal.md) (Superseded) descrevia um Vault Transit
+central em PA1 para auto-unseal de todos os clusters SP1/SP2 — mas esse desenho
+dependia inteiramente do modelo de 3 DCs lógicos ([ADR-001](ADR-001-tres-dcs-logicos-e-clusters-k8s-independentes.md),
+também Superseded). Não existe hoje nenhum Vault Transit provisionado e alcançável em
+rede a partir de nenhum ambiente Uni+ — nem do `standalone-compact` (que já resolveu
+essa mesma pergunta, ver abaixo), nem, com maior razão, da rede interna da UNIFESSPA
+(isolada por VPN, sem rota para a VCN OCI onde rodaria um eventual Transit).
+
+## Alternativas consideradas
+
+1. **Auto-unseal via Vault Transit dedicado.** Provisionar (ou reaproveitar) um Vault
+   Transit alcançável em rede a partir da VM HML, eliminando a necessidade de unseal
+   manual após cada restart do Pod.
+   - ❌ Rejeitada: não existe hoje nenhuma instância de Vault Transit provisionada em
+     lugar algum do ecossistema Uni+ — provisionar uma só para este HML introduziria
+     infraestrutura nova (outro Vault, outra rede a proteger, outro ponto de falha) e
+     dependência de rede cross-ambiente (UNIFESSPA VPN-only → algum outro host) sem
+     nenhum caminho de conectividade validado. Custo/risco desproporcional ao ganho
+     (evitar `vault operator unseal` manual pós-restart, procedimento já documentado
+     e operado em produção real).
+
+2. **Auto-unseal via KMS de nuvem (OCI KMS, seguindo o desenho original de
+   `standalone-compact`).** Delegar o unseal a uma chave gerenciada.
+   - ❌ Rejeitada: não se aplica — a VM HML está na rede interna da própria
+     UNIFESSPA, fora de qualquer provedor de nuvem. Mesmo se aplicável, o
+     `standalone-compact` real já hoje **não** usa isso: bug confirmado
+     (`go-kms-wrapping@v2.0.9`, nil pointer dereference em `ocikms.go:290`, ver
+     `environments/standalone-compact/values.yaml`) forçou fallback para Shamir
+     manual em produção real — reproduzir uma dependência já sabida como quebrada
+     não faz sentido para um ambiente novo.
+
+3. **Shamir manual, 1 réplica Raft — threshold igual ao `standalone-compact` (5
+   shares/3), não ao `lab-standalone-single`.** O lab usa Shamir **1 share/1
+   threshold** (`scripts/lab-standalone-single/bootstrap.sh`, `vault operator init
+   -key-shares=1 -key-threshold=1`) — simplificação deliberada de ambiente
+   descartável/single-operador (ver `docs/RUNBOOKS.md §20.5`), inadequada para um
+   ambiente de homologação real com múltiplos operadores. `standalone-compact`
+   (produção real) usa 5/3 (`docs/RUNBOOKS.md §8.4`) — esse é o padrão a seguir aqui.
+   - ✅ Escolhida.
+
+## Decisão
+
+Adotar **Shamir manual, 5 shares/3 threshold, 1 réplica Raft** para o Vault do
+`hml-standalone-single` — mesmo threshold de `environments/standalone-compact/values.yaml`
+(produção real), **não** o 1/1 simplificado do `lab-standalone-single`. Réplica única
+porque a topologia é host único (mesmo racional do lab). Após `vault operator init`,
+cada restart do Pod (upgrade de K3s, manutenção da VM, OOMKill) exige unseal manual
+com 3 das 5 shares — procedimento documentado em `docs/RUNBOOKS.md §8.4.2` (prompt
+interativo mascarado nativo do `vault operator unseal`, sem stdin/argv — corrigido no
+PR #461). A Story #442 (adaptação do script de bootstrap) precisa portar o
+`vault operator init -key-shares=5 -key-threshold=3` de `standalone-compact` —
+**não** copiar o `-key-shares=1 -key-threshold=1` do lab.
+
+### Custódia das 5 shares
+
+- **Distribuição:** cada uma das 5 shares vai para um custodiante institucional
+  distinto (mesmo modelo de `standalone-compact`, gestor a definir na Story #445 —
+  não necessariamente as mesmas 5 pessoas do `standalone-compact`, já que este é um
+  ambiente HML, não produção). Nenhuma pessoa detém 2+ shares.
+- **Root token:** gerado no `vault operator init`, usado só para a configuração
+  inicial (policies, auth methods, KV mounts, e a policy/role `external-secrets`
+  exigida pelo contrato do ClusterSecretStore em
+  `environments/hml-standalone-single/values.yaml`). Antes de revogar o root
+  token, criar uma identidade administrativa não-root (policy própria com
+  permissão para gerenciar policies/auth methods/snapshots — não `sudo`
+  irrestrito) para as operações contínuas (seed de secrets, rekey, snapshot
+  manual). Só depois revogar o root token (`vault token revoke -self`) — sem
+  essa identidade prévia, revogar o root token deixaria a VM sem nenhum
+  caminho administrativo até o próximo `vault operator init`/rekey. Mesma
+  prática recomendada para `standalone-compact`. Procedimento detalhado (nomes
+  de policy, role) fica para a Story #445 documentar em `docs/RUNBOOKS.md`
+  junto do primeiro `vault operator init` real.
+- **Rekey:** se uma share for comprometida ou um custodiante sair do time,
+  `vault operator rekey` gera um novo conjunto de 5 shares e invalida o anterior.
+  Procedimento a documentar em `docs/RUNBOOKS.md` quando a Story #445 rodar o
+  `vault operator init` de fato (não pode ser testado antes de existir um Vault
+  real nesta VM).
+- **Perda de share:** com threshold 3 de 5, perder até 2 shares não impede unseal.
+  Perder 3+ shares torna os dados do Vault permanentemente irrecuperáveis (Shamir
+  não tem "master key" de recuperação) — reforça a necessidade do backup abaixo.
+- **Backup fora da VM:** Shamir protege o **unseal**, não substitui backup dos
+  dados. Snapshot do Raft (`vault operator raft snapshot save`) precisa rodar
+  periodicamente e ser armazenado fora desta VM (mesmo racional de
+  `docs/RUNBOOKS.md §3.3` para `standalone-compact` — sem isso, perda de disco da
+  VM é perda total do Vault, independente de quantas shares sobrevivam). Cadência e
+  destino do snapshot ficam para a Story #445 definir junto do bootstrap real.
+- **Teste de recuperação:** validar ao menos uma vez, após o `vault operator init`
+  real (Story #445), que 3 das 5 shares de fato desselam o Vault — não presumir que
+  o procedimento documentado funciona sem execução real contra a VM.
+
+Revisitar a escolha de Shamir (não Transit) só se/quando existir um Vault Transit
+real, provisionado e com conectividade de rede validada a partir da VM HML — não
+antes.
+
+## Consequências
+
+- ✅ **Sem infraestrutura nova.** Nenhum Vault Transit adicional para provisionar,
+  proteger e operar.
+- ✅ **Procedimento já validado e documentado.** A equipe já opera esse fluxo em
+  `standalone-compact`; `docs/RUNBOOKS.md §8.4.2` cobre o passo-a-passo, sem
+  necessidade de escrever runbook novo.
+- ✅ **Threshold consistente com produção real (`standalone-compact`).** 5/3 desde o
+  primeiro `vault operator init` — evita ter que fazer `rekey` para sair do 1/1 do
+  lab se este ambiente algum dia ganhar exigências mais próximas de produção.
+- ⚠️ **Diverge deliberadamente do `lab-standalone-single`.** O lab usa 1/1
+  (single-operador, ambiente descartável) — a Story #442 precisa portar o
+  `-key-shares=5 -key-threshold=3` de `standalone-compact`, não copiar o comando do
+  lab por padrão. Risco real de regressão se `bootstrap.sh` for adaptado por
+  cópia superficial do lab sem revisar este ponto.
+- ⚠️ **Unseal manual pós-restart.** Cada reinício do Pod do Vault exige operador
+  humano com acesso a 3 das 5 shares (guardadas fora do repositório, distribuídas
+  entre custodiantes distintos — ver seção "Custódia das 5 shares" acima) para
+  rodar `vault operator unseal` 3 vezes. Aceitável para HML (sem SLA de
+  disponibilidade contínua); reavaliar se este ambiente evoluir para produção real
+  com exigência de restart automatizado sem intervenção.
+- ⚠️ **Shamir protege o unseal, não os dados.** Sem snapshot Raft off-VM (ver
+  acima), perda de disco da VM é perda total e irrecuperável do Vault — a
+  distribuição de shares por si só não é backup.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -25,3 +25,4 @@ Este diretório contém as decisões arquiteturais da infraestrutura da platafor
 | 011 | [Loki SingleBinary com storage S3-MinIO em standalone](ADR-011-loki-singlebinary-s3-standalone.md) | ✅ Aceito | 2026-05-08 | — |
 | 012 | [Tempo single-binary com storage S3-MinIO em standalone](ADR-012-tempo-singlebinary-s3-standalone.md) | ✅ Aceito | 2026-05-08 | — |
 | 013 | [OpenTelemetry Collector em DaemonSet único em standalone](ADR-013-otel-collector-daemonset-standalone.md) | ✅ Aceito | 2026-05-08 | — |
+| 014 | [Custódia do Vault via Shamir manual no `hml-standalone-single`](ADR-014-vault-shamir-hml-standalone-single.md) | ✅ Aceito | 2026-07-13 | [#439](https://github.com/unifesspa-edu-br/uniplus-infra/issues/439) |

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -1,0 +1,322 @@
+# Ambiente: hml-standalone-single
+#
+# Topologia de host único (mesmo modelo do `lab-standalone-single`, ADR-008),
+# mas na VM REAL dedicada da UNIFESSPA (`192.168.21.134`, Ubuntu 24.04.4,
+# 6 vCPU/31GB RAM, rede interna VPN-only, sem IP público). Diferente do lab
+# (VirtualBox, aplicado manualmente via `helm install/upgrade -f`), este
+# ambiente é **gerenciado continuamente pelo ArgoCD**
+# (`argocd/applicationset.yaml`, label `uniplus.io/managed=true`,
+# `environment: hml-standalone-single`) — o generator combina o cluster
+# registrado com TODOS os 9 apps + 14 componentes de platform, aplicando
+# este arquivo como overlay em TODOS eles, não só nos referenciados abaixo.
+#
+# Isso muda a regra do jogo em relação ao lab: qualquer chart cujo default
+# seja `enabled: true` e que não pertença ao escopo desta fase PRECISA de
+# override explícito para `false` aqui — omitir a chave não é seguro (ao
+# contrário do lab, que só instala manualmente o que é explicitamente
+# comandado). Ver "Escopo desta fase" abaixo.
+#
+# Contexto completo: Epic #434, Feature #435, Story #439. Planejamento em
+# `docs/RUNBOOKS.md §21`. Decisão de custódia do Vault em
+# [ADR-014](../../docs/adrs/ADR-014-vault-shamir-hml-standalone-single.md).
+#
+# ============================================================================
+# Escopo desta fase (Feature 1 do Epic #434 — "Bootstrap da fundação real")
+# ============================================================================
+#
+# Habilitados: Vault, External Secrets Operator, Traefik+TLS (autoassinado,
+# provisório — ADR/RUNBOOKS §21.2 item 2), Keycloak, Apicurio Registry,
+# StorageClass. Kafka roda fora do K8s (systemd no data-host, escopo do
+# script de bootstrap #442) — não aparece neste arquivo.
+#
+# Deliberadamente FORA de escopo (Features 2-4 do Epic #434 ainda não têm
+# base de código pronta — ver `docs/RUNBOOKS.md §21.3`, coluna "Mudança
+# necessária: Código"):
+#   - uniplusApiHost / uniplusApiPortal / unifesspaGeoApi — chart não tem
+#     `ConnectionStrings__PublicacoesDb` nativo (Feature 3), IngressRoute
+#     não suporta `PathPrefix` (Feature 2), sem imagem publicada em GHCR
+#     (Feature 3). Também evita o problema de que o certificado autoassinado
+#     real desta VM só existe DEPOIS do bootstrap (#442/#445) — os apps .NET
+#     precisariam de `customCA.certPEM`, que não pode ser fabricado agora.
+#   - uniplusWeb — default `enabled: true` no chart; desligado explicitamente
+#     abaixo. Mesma falta de suporte a `PathPrefix`/subpath (Feature 2) +
+#     trabalho cross-repo em `uniplus-web` (Feature 4).
+#   - cert-manager, Vault Transit (auto-unseal), Vault Transit Bootstrap
+#     (engine transit local p/ idempotência do uniplus-api — sem consumidor
+#     enquanto uniplusApiHost não roda aqui), observabilidade completa
+#     (Prometheus/Grafana/Loki/Tempo/OTel Collector) — nenhum mencionado no
+#     escopo da Feature 1; RUNBOOKS §21.4 documenta requisitos adicionais
+#     (hostPort do OTel Collector, NetworkPolicy do Prometheus) que exigem
+#     tratamento próprio antes de ligar, fora do escopo desta Story.
+#
+# Provisionamento de DB/roles (Postgres do Keycloak) e do client secret do
+# Apicurio é responsabilidade do script de bootstrap (#442/#445) — mesma
+# sequência já operada em `lab-standalone-single` (ver seu README.md).
+
+cluster:
+  name: hml-standalone-single
+  region: unifesspa-interna
+  dc: hml-standalone-single
+
+# ============================================================================
+# Vault (chart platform/vault/) — custódia Shamir manual, ver ADR-014.
+# Mesma configuração de `lab-standalone-single`/`standalone-compact`: HA
+# Raft com 1 réplica (host único), sem PDB (nada a preservar durante drain),
+# `service_registration "kubernetes"` removido (K3s/flannel + auth por
+# service-account gera nil response no GET do Pod, bloqueando requests
+# síncronos do Vault — mesmo bug documentado em standalone-compact/lab).
+# ============================================================================
+vault:
+  enabled: true
+
+  global:
+    tlsDisable: true # TLS terminado no Traefik, mesmo padrão do lab/standalone-compact
+
+  server:
+    ha:
+      enabled: true
+      replicas: 1
+
+      disruptionBudget:
+        enabled: false
+
+      raft:
+        enabled: true
+        setNodeId: true
+        config: |
+          ui = true
+
+          listener "tcp" {
+            tls_disable     = 1
+            address         = "0.0.0.0:8200"
+            cluster_address = "0.0.0.0:8201"
+          }
+
+          storage "raft" {
+            path = "/vault/data"
+          }
+
+    dataStorage:
+      size: 2Gi
+      storageClass: hml-local-nvme
+    auditStorage:
+      size: 2Gi
+      storageClass: hml-local-nvme
+
+# Vault Transit (auto-unseal centralizado) e o bootstrap da engine Transit
+# LOCAL (usada pela feature de idempotência do uniplus-api) — ambos
+# desligados. O primeiro por decisão da ADR-014 (Shamir manual, sem Transit
+# alcançável em rede). O segundo por falta de consumidor: uniplusApiHost
+# não roda nesta fase (ver "Escopo desta fase" acima).
+vaultTransit:
+  enabled: false
+
+vaultTransitBootstrap:
+  enabled: false
+
+# NetworkPolicy compartilhada pelos wrappers platform/vault/ e
+# platform/external-secrets/ — kubeApiCidrs precisa do CIDR do host, não só
+# do service CIDR (K3s: apiserver roda como processo no host, não Pod; o
+# kube-router avalia egress DEPOIS do DNAT do kube-proxy — mesmo bug
+# documentado em lab-standalone-single/standalone-compact).
+networkPolicy:
+  enabled: true
+  kubeApiCidrs:
+    - 10.43.0.0/16
+    - 192.168.21.134/32
+
+ingress:
+  enabled: false # acesso administrativo via kubectl port-forward / túnel VPN
+
+serviceMonitor:
+  enabled: false # sem Prometheus Operator habilitado nesta fase
+
+# ============================================================================
+# External Secrets Operator — o chart tem `enabled: true` como default
+# (mantido). ClusterSecretStore fica `enabled: true` aqui — é o estado FINAL
+# desejado, mesmo padrão de `environments/standalone-compact/values.yaml`
+# (que também commita `true` direto). NÃO é um toggle de duas fases: ao
+# contrário do lab (manual, `--set clusterSecretStore.enabled=false` só no
+# primeiro `helm install`, depois `helm upgrade` sem o override), este
+# ambiente é reconciliado continuamente — declarar `false` aqui faria o
+# ArgoCD manter isso para sempre (self-heal), e os 4 `ExternalSecret` do
+# Keycloak/Apicurio (que dependem do Secret que só o ClusterSecretStore
+# entrega) ficariam permanentemente em `CreateContainerConfigError`, não
+# "em retry até convergir".
+#
+# CONTRATO para a Story #445 (ordem obrigatória, mesma de `standalone-compact`
+# — ver comentário lá): completar `vault operator init` + unseal + policy
+# `external-secrets-read` + role `external-secrets` (auth k8s) ANTES de
+# registrar o cluster no ArgoCD (`argocd cluster add`). Registrar primeiro e
+# inicializar o Vault depois inverte a ordem esperada — o primeiro sync do
+# ArgoCD falharia (Vault ainda sem a role) e ficaria em retry (5x, backoff até
+# 3min) até esgotar, exigindo re-sync manual depois de corrigido.
+#
+# vaultServer: release do Vault, gerado pelo ApplicationSet como
+# `platform-vault-<cluster>` (o chart não usa fullnameOverride). CONTRATO
+# adicional para a Story #445: o cluster PRECISA ser registrado no ArgoCD com
+# `--name hml-standalone-single` (idêntico ao label `environment` usado
+# abaixo) — qualquer nome diferente quebra este endereço.
+# ============================================================================
+clusterSecretStore:
+  enabled: true
+  vaultServer: "http://platform-vault-hml-standalone-single.vault.svc.cluster.local:8200"
+
+# ============================================================================
+# StorageClass (chart platform/storage/) — nome obrigatório por tier
+# (convenção do chart: lab-local-nvme, hml-local-nvme, prod-local-nvme...).
+# provisioner (rancher.io/local-path) e reclaimPolicy (Retain) mantêm os
+# defaults do chart — VM real não é descartável como o standalone-compact
+# PAYG, então preservar dados em delete de PVC é o comportamento certo.
+# ============================================================================
+storage:
+  enabled: true
+  storageClass:
+    name: hml-local-nvme
+
+# cert-manager fica desligado até a Feature 6 (pedido CTIC) resolver a
+# estratégia de TLS real (docs/RUNBOOKS.md §21.2, item 2) — os únicos
+# ClusterIssuer hoje implementados usam desafio HTTP-01, que não serve para
+# esta VM (VPN-only, sem IP público alcançável pela Let's Encrypt). Manter
+# ligado sem nenhum Certificate que ele consiga emitir só gera Applications
+# Degraded sem propósito.
+cert-manager:
+  enabled: false
+
+# ============================================================================
+# Traefik (chart platform/traefik/) — hostPort 80+443 bindam direto na VM
+# real (mesmo padrão do lab/standalone-compact). TLS autoassinado
+# provisório (secret `uniplus-wildcard-nip-io-tls`, criado manualmente via
+# `kubectl create secret tls` durante o bootstrap #442/#445 — não é
+# gerenciado pelo cert-manager nem versionado no Git, mesmo padrão do lab).
+# redirections: null mantém :80 servindo em paralelo, útil para smoke tests
+# via curl sem exigir secure context.
+# ============================================================================
+traefik:
+  service:
+    type: NodePort
+  ports:
+    web:
+      hostPort: 80
+      http:
+        redirections: null
+    websecure:
+      hostPort: 443
+
+# ============================================================================
+# Keycloak (chart apps/keycloak-replica/, default enabled=false).
+#
+# database.host e hostname.strict eram aplicados via `--set` ad-hoc no lab
+# (nunca persistidos no values.yaml dele, ver environments/lab-standalone-single/README.md)
+# — como este ambiente é GitOps (sem `--set` manual possível), precisam
+# estar aqui explicitamente.
+#
+# hostname.url precisa bater com o host do IngressRoute abaixo — o `iss`
+# claim dos tokens e os endpoints do discovery document derivam de
+# KC_HOSTNAME; divergência quebra o fluxo de login OIDC (redirect_uri
+# mismatch / iss inesperado).
+#
+# realmImport.portalClient fica com os defaults do chart (redirectUris
+# vazio) — sem consumidor real enquanto uniplusWeb não roda nesta fase;
+# Feature 2/4 preenche quando ligar o frontend.
+# ============================================================================
+keycloak:
+  enabled: true
+
+  database:
+    host: 192.168.21.134
+
+  hostname:
+    url: https://keycloak.192.168.21.134.nip.io/auth
+    strict: false
+
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    host: keycloak.192.168.21.134.nip.io
+    tls:
+      enabled: true
+      secretName: uniplus-wildcard-nip-io-tls
+
+  networkPolicy:
+    enabled: true
+    dataHostCIDR: 192.168.21.134/32
+
+  # Precisa estar ligado: o realm-reconcile-job aplica mudanças de config
+  # (ex. portalClient, quando Feature 2/4 ligar) num Keycloak cujo realm já
+  # foi importado antes — `--import-realm` só roda no primeiro boot (gotcha
+  # documentado em feedback_keycloak_realm_reconcile_gated).
+  realmReconcile:
+    enabled: true
+
+# ============================================================================
+# Apicurio Registry (chart apps/apicurio-registry/) — Schema Registry.
+# Referência direta: lab-standalone-single (já validado, inclusive pelo
+# spike de PathPrefix na própria VM real — ver
+# docs/validacao/spike-pathprefix-hml-2026-07-12.md).
+# ============================================================================
+apicurioRegistry:
+  enabled: true
+
+  storage:
+    host: 192.168.21.134
+
+  oidc:
+    issuerUri: https://keycloak.192.168.21.134.nip.io/auth/realms/uniplus
+
+  # Quarkus rejeita o certificado autoassinado do Keycloak ao buscar o JWKS
+  # sem isso ("OIDC Server is not available"). trust-all é aceitável só
+  # porque o TLS é autoassinado nesta fase (nunca em produção real com
+  # Let's Encrypt via cert-manager).
+  extraEnv:
+    - name: QUARKUS_TLS_TRUST_ALL
+      value: "true"
+
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    host: apicurio.192.168.21.134.nip.io
+    tls:
+      enabled: true
+      secretName: uniplus-wildcard-nip-io-tls
+
+  networkPolicy:
+    enabled: true
+    dataHostCIDR: 192.168.21.134/32
+    keycloakService: keycloak-replica
+    keycloakNamespace: uniplus
+    keycloakPort: 8080
+    # NÃO aponta pro IP da VM — o hostPort do Traefik é implementado via
+    # DNAT (CNI portmap), e o kube-router avalia egress DEPOIS do DNAT: o
+    # destino real pós-DNAT é o IP do Pod do Traefik (10.42.0.x), não o IP
+    # da VM (mesmo gotcha documentado em kubeApiCidrs acima, aqui via
+    # hostPort em vez de kube-proxy). Usa o pod CIDR do cluster + a porta
+    # real do container (8443, entryPoint websecure).
+    oidcIssuerCIDR: 10.42.0.0/16
+    oidcIssuerPort: 8443
+
+  serviceMonitor:
+    enabled: false # sem Prometheus Operator habilitado nesta fase
+
+# ============================================================================
+# Fora de escopo desta fase — desligados explicitamente porque o
+# ApplicationSet os habilitaria por default (enabled=true no chart) assim
+# que o cluster for registrado. Ver "Escopo desta fase" no topo do arquivo.
+# ============================================================================
+uniplusWeb:
+  enabled: false
+
+kubePrometheusStack:
+  enabled: false
+
+grafana:
+  enabled: false
+
+loki:
+  enabled: false
+
+tempo:
+  enabled: false
+
+otelCollector:
+  enabled: false

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -218,7 +218,10 @@ traefik:
 #
 # realmImport.portalClient fica com os defaults do chart (redirectUris
 # vazio) — sem consumidor real enquanto uniplusWeb não roda nesta fase;
-# Feature 2/4 preenche quando ligar o frontend.
+# Feature 2/4 preenche quando ligar o frontend. realmImport.apicurioClient
+# É sobrescrito abaixo — diferente do portal, o Apicurio roda nesta fase, e
+# sem o override o client OIDC herdaria o hostname do standalone-compact
+# (default do chart), rejeitando o login pela UI deste ambiente.
 # ============================================================================
 keycloak:
   enabled: true
@@ -248,6 +251,18 @@ keycloak:
   # documentado em feedback_keycloak_realm_reconcile_gated).
   realmReconcile:
     enabled: true
+
+  realmImport:
+    # Sem isso, o client apicurio-registry herdaria o default do chart
+    # (hostname do standalone-compact) — login pela UI do Apicurio neste
+    # HML seria rejeitado pelo Keycloak (redirect_uri/origin não batem).
+    apicurioClient:
+      clientId: apicurio-registry
+      redirectUris:
+        - https://apicurio.192.168.21.134.nip.io/*
+        - https://apicurio.192.168.21.134.nip.io/ui/*
+      webOrigins:
+        - https://apicurio.192.168.21.134.nip.io
 
 # ============================================================================
 # Apicurio Registry (chart apps/apicurio-registry/) — Schema Registry.


### PR DESCRIPTION
## Resumo

Implementa a Story #439 da Feature #435 (Epic #434 — HML real da UNIFESSPA): decide a custódia do Vault e cria o environment GitOps `hml-standalone-single` para a VM real dedicada (`192.168.21.134`, VPN-only).

- `docs(adr)`: **ADR-014** — custódia do Vault via **Shamir manual, 5 shares/3 threshold** (mesmo threshold de `standalone-compact`, **não** o 1/1 simplificado do lab). Sem Vault Transit alcançável em rede a partir desta VM, introduzir auto-unseal seria infraestrutura nova sem necessidade real. Documenta distribuição de shares, manejo do root token, rekey e a necessidade de snapshot Raft fora da VM.
- `feat(hml)`: `environments/hml-standalone-single/values.yaml` — Vault, External Secrets Operator, Traefik+TLS autoassinado provisório, Keycloak e Apicurio Registry (escopo exato da Feature 1 do Epic #434). Todo o resto (uniplusWeb, cert-manager, vaultTransit, observabilidade) desligado explicitamente — ver "Decisão de escopo" abaixo.
- `fix(makefile)`: `CHARTS_PLATFORM` não pegava os 5 charts de `platform/observability/*` (gap pré-existente, achado ao validar este PR).
- `ci(validate)`: registra `hml-standalone-single` nos jobs `schema-validate`/`manifest-validate` do CI.

## Decisão de escopo — por que só 5 componentes

Diferente do `lab-standalone-single` (aplicado manualmente via `helm install -f`), este ambiente é **gerenciado continuamente pelo ArgoCD**: o `ApplicationSet` combina o cluster registrado com **todos** os 9 apps + 14 componentes de platform, aplicando este `values.yaml` como overlay em todos eles — não só nos referenciados no arquivo. Por isso:

- Componentes com default `enabled: true` no chart mas fora do escopo desta fase (`uniplusWeb`, `cert-manager`, `vaultTransit`, `kubePrometheusStack`, `grafana`, `loki`, `tempo`, `otelCollector`) precisam de override explícito para `false` — omitir a chave os deixaria ligados no primeiro sync.
- `uniplusApiHost`/`uniplusApiPortal`/`unifesspaGeoApi` ficam de fora: sem `ConnectionStrings__PublicacoesDb` nativo, sem suporte a `PathPrefix` (Features 2/3 do Epic #434), sem imagem publicada em GHCR, e o certificado autoassinado real desta VM só existe depois do bootstrap (#442/#445) — os apps .NET exigiriam um `customCA.certPEM` que não pode ser fabricado agora.

## Contratos para a Story #445 (bootstrap real + registro no ArgoCD)

Documentados como comentários no `values.yaml`, resumindo aqui:

1. **Ordem obrigatória**: completar `vault operator init` (5/3) + unseal + policy/role `external-secrets` **antes** de `argocd cluster add`. `clusterSecretStore.enabled: true` já é o estado final commitado (mesmo padrão de `standalone-compact`) — registrar o cluster antes do Vault pronto gera falha de sync temporária (retry 5x/backoff até 3min).
2. **Nome do cluster**: registrar com `--name hml-standalone-single` (idêntico ao label `environment`) — `clusterSecretStore.vaultServer` já assume esse nome no endereço do Service.
3. **Vault init**: usar `-key-shares=5 -key-threshold=3` (de `standalone-compact`), **não** `-key-shares=1 -key-threshold=1` (do lab) — risco real de regressão se o script for adaptado por cópia superficial.

## Test plan

- [x] `make validate` local (yaml-lint, helm-lint, markdown-lint, schema-validate) — 0 falhas, `standalone-compact` continua verde
- [x] `helm template` dos 24 charts do repositório × `hml-standalone-single/values.yaml`, com a mesma versão de Helm do CI (3.14.0, via Docker) — 0 falhas
- [x] `kubeconform -strict` + `scripts/validate-rfc1123.py` nos 24 renders — 0 falhas
- [x] Revisão de plano + revisão de diff via Codex CLI (2 rodadas) — 3 P1 + 4 P2/P3 corrigidos: escopo parcial incompatível com ApplicationSet, endereço do Vault para o ESO, threshold de Shamir incorreto na primeira versão do ADR, `storageClass` ausente no Vault, `clusterSecretStore` permanentemente `false` travando o GitOps, custódia do root token incompleta, `CHARTS_PLATFORM` sem observability

Closes #439
Refs #434, #435
