### PR TITLE
feat(hml): adapta script de bootstrap para a VM real

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -4191,6 +4191,46 @@ Para não conferir a este documento uma precisão que ele não tem:
   esperado, já que ainda não foram solicitados; não deve ser lido como indício de que já existem
   ou não numa view DNS interna específica.
 
+### 21.7 Bootstrap da fundação (Story #442)
+
+`scripts/hml-standalone-single/bootstrap.sh` — adaptado de
+`scripts/lab-standalone-single/bootstrap.sh` (já validado no lab e no spike de PathPrefix
+executado nesta mesma VM real), mas cobrindo só o que precisa existir **antes** do cluster ser
+registrado no ArgoCD: Docker, K3s, Helm, ArgoCD self-hosted (mesmo padrão de
+`scripts/bootstrap-standalone.sh --role=standalone-k8s`), Postgres (banco do Keycloak), Kafka
+(Feature 1 do Epic #434) e o certificado TLS autoassinado provisório (`uniplus-wildcard-nip-io-tls`,
+namespace `uniplus`) que Traefik/Keycloak/Apicurio Registry esperam já existir na primeira
+sincronização.
+
+**Diferença estrutural em relação ao lab:** este ambiente é GitOps (`environments/
+hml-standalone-single/values.yaml`, Story #439) — Vault, ESO, Traefik, Keycloak e Apicurio
+Registry **não** são instalados por este script. O `ApplicationSet` os cria automaticamente assim
+que o cluster for registrado (mesma sequência já operada em `standalone-compact`, §8.3): registro
+primeiro, depois `kubectl apply` de `argocd/project.yaml` + `argocd/applicationset.yaml` — os
+manifests aplicam normalmente (`Synced`), mas os Pods de Vault/Keycloak/Apicurio Registry ficam
+`Degraded`/`Progressing` até o `vault operator init` manual (mesmo procedimento de §8.4, ainda não
+scriptado nem em produção real — Story #445 documenta a variante específica deste ambiente,
+incluindo Shamir **5/3**, não o 1/1 simplificado do lab, e o seed dos secrets que Keycloak/Apicurio
+esperam via `ExternalSecret`). O self-heal do ArgoCD reconcilia drift entre Git e estado live — não
+resolve por si só a indisponibilidade do Vault, que depende exclusivamente do passo manual.
+
+Este script também reaplica os dois fixes de DNS achados no spike (Docker daemon.json + patch do
+CoreDNS — ambos com o nameserver IPv4 do host inalcançável) e provisiona role+database do Keycloak
+e do Apicurio Registry no Postgres via `docker exec ... psql` pós-cluster-ready — **não** via bind
+mount em `/docker-entrypoint-initdb.d` (a imagem `postgis/postgis` já usa esse path para o próprio
+script de extensões; um bind mount nosso o esconderia e o cluster subiria sem PostGIS).
+
+**CONTRATO de nomenclatura (Story #445):** o cluster precisa ser registrado com
+`argocd cluster add ... --in-cluster --name in-cluster --label environment=hml-standalone-single`
+— `--name in-cluster` **explícito**, não implícito. O nome usado pelo `ApplicationSet` para nomear
+as Applications reflete o valor passado em `--name` (ou o contexto kubeconfig, se omitido) — em
+`standalone-compact` o resultado observado foi o literal `in-cluster` (ver comentário em
+`environments/standalone-compact/values.yaml`), presumivelmente porque `--name in-cluster` foi
+passado explicitamente no registro original, não por comportamento implícito de `--in-cluster`. Por
+isso `environments/hml-standalone-single/values.yaml` já aponta `clusterSecretStore.vaultServer`
+para `platform-vault-in-cluster...`, igual ao `standalone-compact` — mas isso só fica correto se a
+Story #445 passar `--name in-cluster` explicitamente no registro deste cluster.
+
 ---
 
 *Documento mantido pelo CTIC/UNIFESSPA. Atualizações via Pull Request.*

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -135,32 +135,31 @@ serviceMonitor:
 # External Secrets Operator — o chart tem `enabled: true` como default
 # (mantido). ClusterSecretStore fica `enabled: true` aqui — é o estado FINAL
 # desejado, mesmo padrão de `environments/standalone-compact/values.yaml`
-# (que também commita `true` direto). NÃO é um toggle de duas fases: ao
-# contrário do lab (manual, `--set clusterSecretStore.enabled=false` só no
-# primeiro `helm install`, depois `helm upgrade` sem o override), este
-# ambiente é reconciliado continuamente — declarar `false` aqui faria o
-# ArgoCD manter isso para sempre (self-heal), e os 4 `ExternalSecret` do
-# Keycloak/Apicurio (que dependem do Secret que só o ClusterSecretStore
-# entrega) ficariam permanentemente em `CreateContainerConfigError`, não
-# "em retry até convergir".
-#
-# CONTRATO para a Story #445 (ordem obrigatória, mesma de `standalone-compact`
-# — ver comentário lá): completar `vault operator init` + unseal + policy
-# `external-secrets-read` + role `external-secrets` (auth k8s) ANTES de
-# registrar o cluster no ArgoCD (`argocd cluster add`). Registrar primeiro e
-# inicializar o Vault depois inverte a ordem esperada — o primeiro sync do
-# ArgoCD falharia (Vault ainda sem a role) e ficaria em retry (5x, backoff até
-# 3min) até esgotar, exigindo re-sync manual depois de corrigido.
+# (que também commita `true` direto).
 #
 # vaultServer: release do Vault, gerado pelo ApplicationSet como
-# `platform-vault-<cluster>` (o chart não usa fullnameOverride). CONTRATO
-# adicional para a Story #445: o cluster PRECISA ser registrado no ArgoCD com
-# `--name hml-standalone-single` (idêntico ao label `environment` usado
-# abaixo) — qualquer nome diferente quebra este endereço.
+# `platform-vault-<cluster>` (o chart não usa fullnameOverride). O ArgoCD do
+# `standalone-compact` roda self-hosted no próprio cluster que gerencia,
+# registrado via `argocd cluster add ... --in-cluster` — e o nome resultante
+# usado pelo ApplicationSet é sempre o literal `in-cluster`, não o valor
+# passado em `--name` (empírico, ver comentário em
+# `environments/standalone-compact/values.yaml` linha ~674). A Story #442
+# instala ArgoCD na própria VM HML seguindo o mesmo padrão (self-hosted,
+# `--in-cluster`) — então o release aqui É `platform-vault-in-cluster`, igual
+# ao `standalone-compact`, não um nome específico do HML.
+#
+# CONTRATO para a Story #445 (ordem = mesma de `standalone-compact`, ver
+# `docs/RUNBOOKS.md §8.3`→`§8.4`): registrar o cluster no ArgoCD (que já
+# provisiona Vault/ESO sealed/sem role, via ApplicationSet) ANTES de
+# `vault operator init`. O primeiro sync do ClusterSecretStore fica
+# OutOfSync/Degraded até o Vault ser inicializado e a role
+# `external-secrets` configurada manualmente — esperado, não é erro; ArgoCD
+# reconcilia automaticamente (self-heal) assim que a role existir, sem
+# precisar recriar o cluster nem re-registrar nada.
 # ============================================================================
 clusterSecretStore:
   enabled: true
-  vaultServer: "http://platform-vault-hml-standalone-single.vault.svc.cluster.local:8200"
+  vaultServer: "http://platform-vault-in-cluster.vault.svc.cluster.local:8200"
 
 # ============================================================================
 # StorageClass (chart platform/storage/) — nome obrigatório por tier

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -138,15 +138,25 @@ serviceMonitor:
 # (que também commita `true` direto).
 #
 # vaultServer: release do Vault, gerado pelo ApplicationSet como
-# `platform-vault-<cluster>` (o chart não usa fullnameOverride). O ArgoCD do
-# `standalone-compact` roda self-hosted no próprio cluster que gerencia,
-# registrado via `argocd cluster add ... --in-cluster` — e o nome resultante
-# usado pelo ApplicationSet é sempre o literal `in-cluster`, não o valor
-# passado em `--name` (empírico, ver comentário em
-# `environments/standalone-compact/values.yaml` linha ~674). A Story #442
-# instala ArgoCD na própria VM HML seguindo o mesmo padrão (self-hosted,
-# `--in-cluster`) — então o release aqui É `platform-vault-in-cluster`, igual
-# ao `standalone-compact`, não um nome específico do HML.
+# `platform-vault-<cluster>` (o chart não usa fullnameOverride), onde
+# `<cluster>` é o `.name` do cluster ArgoCD — reflete o valor passado em
+# `--name` no `argocd cluster add` (ou o contexto kubeconfig, se `--name`
+# for omitido); `--in-cluster` sozinho NÃO força esse nome para `in-cluster`
+# (a doc do `argocd cluster add` documenta `--name` como parâmetro que
+# sobrescreve o nome do cluster, independente de `--in-cluster`).
+#
+# Em `standalone-compact` o resultado observado é o literal `in-cluster`
+# (`platform-vault-in-cluster`, ver comentário em
+# `environments/standalone-compact/values.yaml` linha ~674) — presumivelmente
+# porque `--name in-cluster` foi passado explicitamente no registro original.
+# A Story #442 instala ArgoCD na própria VM HML seguindo o mesmo padrão
+# self-hosted, então este arquivo já assume `platform-vault-in-cluster` —
+# mas isso só fica correto se a Story #445 passar `--name in-cluster`
+# EXPLICITAMENTE ao registrar o cluster (contrato documentado em
+# `docs/RUNBOOKS.md §21.7` e no resumo de
+# `scripts/hml-standalone-single/bootstrap.sh`). Registrar com qualquer
+# outro nome (ou sem `--name`, herdando o contexto kubeconfig) quebra este
+# endereço — o Vault seria liberado como `platform-vault-<outro-nome>`.
 #
 # CONTRATO para a Story #445 (ordem = mesma de `standalone-compact`, ver
 # `docs/RUNBOOKS.md §8.3`→`§8.4`): registrar o cluster no ArgoCD (que já

--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -1,0 +1,682 @@
+#!/usr/bin/env bash
+# ============================================================================
+# bootstrap.sh — hml-standalone-single
+#
+# Bootstrap da fundação real no ambiente HML da UNIFESSPA (VM dedicada
+# `192.168.21.134`, rede interna, VPN-only — Epic #434, Feature #435, Story
+# #442). Adaptado de scripts/lab-standalone-single/bootstrap.sh (já validado
+# no lab e no spike de PathPrefix executado na própria VM real — ver
+# docs/validacao/spike-pathprefix-hml-2026-07-12.md), mas com uma diferença
+# estrutural importante: este ambiente é GitOps/ArgoCD (environments/
+# hml-standalone-single/values.yaml, Story #439), não aplicação manual via
+# `helm install/upgrade -f` como o lab.
+#
+# Por isso este script cobre só o que precisa acontecer ANTES do cluster
+# existir no ArgoCD — os fixes de DNS achados no spike (Docker + CoreDNS,
+# ambos com nameserver do host inalcançável), Docker, K3s, Helm, ArgoCD
+# (self-hosted, mesmo padrão de scripts/bootstrap-standalone.sh
+# --role=standalone-k8s), Postgres (roles+databases do Keycloak e do
+# Apicurio Registry), Kafka (Feature 1 do Epic #434) e o certificado TLS
+# autoassinado provisório que Traefik/Keycloak/Apicurio Registry precisam.
+# Vault, ESO, Traefik, Keycloak e Apicurio Registry em si NÃO são
+# instalados por este script — o ApplicationSet os cria assim que o cluster
+# for registrado no ArgoCD (ver summary() no final e docs/RUNBOOKS.md §8.3
+# para o procedimento, idêntico ao já usado em standalone-compact). O init/
+# unseal do Vault, a configuração de auth/policy/role e o seed dos secrets
+# que Keycloak/Apicurio esperam também ficam fora deste script — são
+# procedimento manual pós-registro, mesmo padrão de docs/RUNBOOKS.md §8.4
+# (não scriptado nem em standalone-compact real).
+#
+# Uso:
+#   ./bootstrap.sh [--dry-run]
+#
+# Pré-requisitos: Ubuntu 24.04 LTS, usuário com sudo sem senha, não rodar
+# como root, executado de dentro da rede/VPN da UNIFESSPA (a VM não tem IP
+# público).
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Mesmo gotcha documentado em scripts/lab-standalone-single/bootstrap.sh: o
+# instalador oficial do K3s cria /usr/local/bin/kubectl como symlink pro
+# binário unificado, que usa /etc/rancher/k3s/k3s.yaml como kubeconfig
+# default nativo — ignora ~/.kube/config a menos que KUBECONFIG seja
+# exportado explicitamente.
+export KUBECONFIG="$HOME/.kube/config"
+
+# ============== Versões pinadas ==============
+# Mesmas versões de scripts/lab-standalone-single/bootstrap.sh (corrigidas
+# em 2026-07-12 — K3s 1.31.4 estava EOL desde nov/2025, ver
+# docs/validacao/spike-pathprefix-hml-2026-07-12.md) e de
+# scripts/bootstrap-standalone.sh (ARGOCD_VERSION — v2.14→v3.x é salto de
+# major version com guia de migração dedicado, fora do escopo de uma
+# atualização de rotina).
+#
+# ATENÇÃO: a matriz oficial de compatibilidade do ArgoCD 2.14.x lista
+# Kubernetes testado até 1.31 (K3s 1.36 embute 1.36) — 5 minors de gap não
+# validado pelo upstream. Não é bloqueante por si só (ArgoCD historicamente
+# tolera K8s mais novo na prática), mas reconfirmar contra
+# https://argo-cd.readthedocs.io/en/release-2.14/operator-manual/installation/#tested-versions
+# antes do bootstrap real (#445); se houver falha do controller/CRDs
+# relacionada à versão do K8s, o fallback é fixar um K3s dentro da matriz
+# testada só para esta VM, sem alterar o pin de lab/standalone-compact.
+K3S_VERSION="v1.36.2+k3s1"
+HELM_VERSION="v3.21.2"
+ARGOCD_VERSION="v2.14.3"
+
+# ============== Defaults ==============
+DRY_RUN=false
+
+DATA_BASE="/var/lib/uniplus"
+TLS_NAMESPACE="uniplus"
+TLS_SECRET_NAME="uniplus-wildcard-nip-io-tls"
+
+# ============== Logging ==============
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()    { echo -e "${BLUE}[INFO]${NC} $*"; }
+log_success() { echo -e "${GREEN}[ OK ]${NC} $*"; }
+log_warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+run() {
+    if $DRY_RUN; then
+        echo "[DRY-RUN] $*"
+    else
+        bash -c "$*"
+    fi
+}
+
+# ============== Arquitetura ==============
+case "$(uname -m)" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+    *)       log_error "Arquitetura não suportada: $(uname -m). Esperado x86_64 ou aarch64."; exit 1 ;;
+esac
+
+usage() {
+    cat <<EOF
+Uso: $0 [--dry-run]
+
+Bootstrap da fundação (Docker, K3s, Helm, ArgoCD, Postgres, Kafka, cert TLS
+provisório) da VM real do hml-standalone-single. Vault/ESO/Traefik/Keycloak/
+Apicurio Registry NÃO são instalados por este script — ver "Próximos
+passos" no resumo final.
+
+Opções:
+  --dry-run    Mostra o que seria feito, sem aplicar.
+  -h, --help   Esta mensagem.
+
+Exemplos:
+  $0 --dry-run
+  $0
+EOF
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run)  DRY_RUN=true ;;
+        -h|--help)  usage; exit 0 ;;
+        *) log_error "Opção inválida: $arg"; usage; exit 2 ;;
+    esac
+done
+
+if [[ "$EUID" -eq 0 ]]; then
+    log_error "Não rode como root — o script usa sudo internamente."
+    exit 1
+fi
+
+if ! sudo -n true 2>/dev/null; then
+    log_error "sudo sem senha é obrigatório para este usuário (ver docs/RUNBOOKS.md)."
+    exit 1
+fi
+
+# ============================================================================
+# Steps — Docker + K3s + Helm + ArgoCD
+# ============================================================================
+
+# DNS quebrado, específico desta VM — achado empírico do spike de PathPrefix
+# (docs/validacao/spike-pathprefix-hml-2026-07-12.md, seção 2, achados 1-2):
+# `/etc/resolv.conf` do host (systemd-resolved) lista um nameserver IPv4
+# inalcançável; o Docker extrai o nameserver "legacy" e usa esse, quebrando
+# `apt-get`/pull de imagem dentro de builds e containers. Fix: nameservers
+# explícitos no daemon.json do Docker. O spike preservou esse fix ao
+# derrubar a VM ("mantido de propósito"), mas o script reaplica
+# idempotentemente — cobre o caso de reimagem/nova VM onde o fix não existe.
+step_fix_docker_dns() {
+    local daemon_json="/etc/docker/daemon.json"
+
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Garantiria dns: [1.1.1.1, 8.8.8.8] em $daemon_json (+ restart docker se mudou)"
+        return
+    fi
+
+    if sudo test -f "$daemon_json" && sudo grep -q '"dns"' "$daemon_json" 2>/dev/null; then
+        log_success "$daemon_json já tem DNS explícito — preservando."
+        return
+    fi
+
+    log_info "Configurando DNS explícito no Docker (achado do spike — nameserver do host inalcançável)..."
+    sudo tee "$daemon_json" >/dev/null <<'JSON'
+{
+  "dns": ["1.1.1.1", "8.8.8.8"]
+}
+JSON
+    if systemctl is-active --quiet docker 2>/dev/null; then
+        sudo systemctl restart docker
+    fi
+    log_success "Docker DNS configurado."
+}
+
+step_install_docker() {
+    if command -v docker &>/dev/null && docker compose version &>/dev/null 2>&1; then
+        log_success "Docker já instalado: $(docker --version)"
+    else
+        log_info "Instalando Docker + Compose v2..."
+        run "sudo apt-get update -qq"
+        run "sudo apt-get install -y docker.io docker-compose-v2"
+        run "sudo systemctl enable --now docker"
+        run "sudo usermod -aG docker $USER"
+        log_warn "Logout/login necessário para aplicar o grupo 'docker' (se ainda não estiver nele)."
+        log_success "Docker instalado."
+    fi
+
+    step_fix_docker_dns
+}
+
+step_install_k3s() {
+    if command -v k3s &>/dev/null; then
+        log_success "K3s já instalado: $(k3s --version | head -1)"
+    else
+        local node_ip
+        node_ip=$(hostname -I | awk '{print $1}')
+
+        log_info "Instalando K3s $K3S_VERSION (host combinado, IP: $node_ip)..."
+
+        # --disable traefik/servicelb: platform/traefik/ (ArgoCD, pós-registro)
+        # é o IngressController real deste ambiente — o Traefik/ServiceLB
+        # bundled do K3s competiria pelo bind 80/443. --write-kubeconfig-mode
+        # 644: kubeconfig legível sem sudo, mesmo padrão de
+        # scripts/lab-standalone-single/bootstrap.sh e scripts/bootstrap-standalone.sh.
+        run "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=$K3S_VERSION sh -s - \
+            --node-name uniplus-hml \
+            --tls-san $node_ip \
+            --disable servicelb \
+            --disable traefik \
+            --write-kubeconfig-mode 644"
+    fi
+
+    run "mkdir -p $HOME/.kube"
+    run "sudo cp /etc/rancher/k3s/k3s.yaml $HOME/.kube/config"
+    run "sudo chown $(id -u):$(id -g) $HOME/.kube/config"
+    log_success "K3s pronto."
+}
+
+# Mesmo achado do spike (docs/validacao/spike-pathprefix-hml-2026-07-12.md,
+# seção 2, achado 2): o CoreDNS do cluster herda o `forward . /etc/resolv.conf`
+# default, que aponta pro mesmo nameserver IPv4 inalcançável do host —
+# `SERVFAIL` ao resolver hostnames de dentro de pods (nip.io, registries de
+# imagem, repos Helm). A VM do spike foi completamente derrubada ao final
+# (K3s desinstalado), então este fix NÃO sobrevive — precisa ser reaplicado
+# a cada bootstrap novo, diferente do fix do Docker acima.
+step_patch_coredns() {
+    if $DRY_RUN; then
+        echo "[DRY-RUN] kubectl patch configmap coredns -n kube-system (forward . 1.1.1.1 8.8.8.8)"
+        echo "[DRY-RUN] kubectl rollout restart deployment/coredns -n kube-system"
+        return
+    fi
+
+    log_info "Aguardando CoreDNS ficar disponível para patch..."
+    kubectl wait --for=condition=available --timeout=120s deployment/coredns -n kube-system
+
+    local corefile
+    corefile=$(kubectl get configmap coredns -n kube-system -o jsonpath='{.data.Corefile}')
+    if echo "$corefile" | grep -q 'forward \. 1\.1\.1\.1 8\.8\.8\.8'; then
+        log_success "CoreDNS já usa forwarders explícitos — preservando."
+        return
+    fi
+
+    log_info "Corrigindo CoreDNS (forward . /etc/resolv.conf -> 1.1.1.1 8.8.8.8, achado do spike)..."
+    local patched_corefile
+    patched_corefile=$(echo "$corefile" | sed 's/forward \. \/etc\/resolv\.conf/forward . 1.1.1.1 8.8.8.8/')
+    kubectl create configmap coredns -n kube-system \
+        --from-literal=Corefile="$patched_corefile" \
+        --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+    kubectl rollout restart deployment/coredns -n kube-system
+    kubectl rollout status deployment/coredns -n kube-system --timeout=120s
+    log_success "CoreDNS corrigido (forwarders explícitos)."
+}
+
+step_install_helm() {
+    if command -v helm &>/dev/null; then
+        log_success "Helm já instalado: $(helm version --short)"
+        return
+    fi
+
+    log_info "Instalando Helm $HELM_VERSION (linux-$ARCH)..."
+    local helm_tar="/tmp/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz"
+    local helm_sha="/tmp/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz.sha256sum"
+    run "curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz -o $helm_tar"
+    run "curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz.sha256sum -o $helm_sha"
+    run "echo \"\$(awk '{print \$1}' $helm_sha)  $helm_tar\" | sha256sum -c"
+    run "tar -xzf $helm_tar -C /tmp linux-${ARCH}/helm"
+    run "sudo install /tmp/linux-${ARCH}/helm /usr/local/bin/helm"
+    run "rm -rf $helm_tar $helm_sha /tmp/linux-${ARCH}"
+    log_success "Helm $HELM_VERSION instalado."
+}
+
+step_install_argocd() {
+    # Mesmo padrão de scripts/bootstrap-standalone.sh (step_install_argocd) —
+    # ArgoCD self-hosted no próprio cluster que gerencia (registrado via
+    # `argocd cluster add ... --in-cluster` no procedimento pós-script, ver
+    # summary()). Idempotente: reaplicar o manifest upstream em cima de uma
+    # instalação existente é um no-op ou upgrade in-place, conforme a versão
+    # já instalada.
+    log_info "Instalando ArgoCD $ARGOCD_VERSION..."
+
+    run "kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -"
+    # --server-side evita o limite de 262144 bytes nas anotações dos CRDs do
+    # ArgoCD no K3s; --force-conflicts resolve conflitos de field manager em
+    # re-runs após falha client-side.
+    run "kubectl apply --server-side --force-conflicts -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/$ARGOCD_VERSION/manifests/install.yaml"
+
+    log_info "Aguardando ArgoCD ficar disponível (até 5 min)..."
+    run "kubectl wait --for=condition=available --timeout=300s \
+        deployment/argocd-server \
+        deployment/argocd-repo-server \
+        deployment/argocd-applicationset-controller \
+        -n argocd"
+
+    log_success "ArgoCD instalado."
+}
+
+# ============================================================================
+# Step — Postgres (mesmo padrão systemd/LoadCredential de
+# scripts/lab-standalone-single/bootstrap.sh — imagem postgis/postgis em vez
+# de postgres:18-alpine porque módulos futuros do Epic #434 (unifesspa-geo-api,
+# Feature 2+) vão exigir PostGIS; adotar já evita migração disruptiva depois.
+#
+# Diferente de scripts/bootstrap-standalone.sh (step_data_setup_postgres),
+# que cria o role/database do Keycloak via bind mount em
+# /docker-entrypoint-initdb.d: essa imagem (postgis/postgis) já embute NESSE
+# MESMO path o script que cria template_postgis + carrega as extensions —
+# um bind mount nosso ali esconderia esse script da imagem e o cluster
+# subiria sem PostGIS (mesmo gotcha documentado no header de
+# environments/lab-standalone-single/README.md). Por isso role/database do
+# Keycloak e do Apicurio são criados via `docker exec ... psql` DEPOIS do
+# cluster já estar pronto (mesmo padrão de step_data_setup_apicurio_db em
+# scripts/bootstrap-standalone.sh), não via init script.
+# ============================================================================
+
+step_setup_postgres() {
+    log_info "Configurando Postgres 18 + PostGIS 3.6 systemd..."
+
+    local creds_file="$DATA_BASE/postgres/.bootstrap-creds"
+    local cred_dir="/etc/credstore"
+    local cred_file="$cred_dir/uniplus-postgres-password"
+    local unit_file="/etc/systemd/system/uniplus-postgres.service"
+
+    run "sudo mkdir -p $DATA_BASE/postgres/data"
+    run "sudo chown 70:70 $DATA_BASE/postgres/data"
+
+    local cluster_initialized=false
+    if ! $DRY_RUN && \
+       sudo find "$DATA_BASE/postgres/data" -name PG_VERSION -print -quit 2>/dev/null | grep -q .; then
+        cluster_initialized=true
+    fi
+
+    if sudo test -f "$creds_file" 2>/dev/null; then
+        log_success "Bootstrap creds do Postgres já existentes — preservando senha."
+    elif $DRY_RUN; then
+        log_warn "Dry-run: senha inicial seria gerada em $creds_file"
+    elif $cluster_initialized; then
+        log_error "$creds_file ausente, mas cluster Postgres já existe em $DATA_BASE/postgres/data"
+        log_error "Regenerar a senha agora produziria mismatch com o cluster já formatado."
+        log_error "Restaure $creds_file a partir do Vault — ver docs/RUNBOOKS.md §9.4."
+        exit 1
+    else
+        log_info "Gerando senha do superusuário (256 bits)..."
+        local super_pw
+        super_pw=$(openssl rand -hex 32)
+        sudo tee "$creds_file" >/dev/null <<EOF
+super_pw=$super_pw
+EOF
+        sudo chown root:root "$creds_file"
+        sudo chmod 600 "$creds_file"
+        log_warn "Senha gerada em $creds_file. Custódia obrigatória — ver docs/RUNBOOKS.md §9.2."
+        unset super_pw
+    fi
+
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Criaria $cred_dir + escreveria $cred_file (super_pw lido de $creds_file)"
+    else
+        local super_pw_current
+        super_pw_current=$(sudo grep '^super_pw=' "$creds_file" | cut -d= -f2)
+        if [[ -z "$super_pw_current" ]]; then
+            log_error "Não consegui ler super_pw de $creds_file. Abortando."
+            exit 1
+        fi
+        sudo mkdir -p "$cred_dir"
+        sudo chown root:root "$cred_dir"
+        sudo chmod 700 "$cred_dir"
+        printf '%s' "$super_pw_current" | sudo tee "$cred_file" >/dev/null
+        sudo chown root:root "$cred_file"
+        sudo chmod 400 "$cred_file"
+        unset super_pw_current
+    fi
+
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Escreveria $unit_file"
+    else
+        sudo tee "$unit_file" >/dev/null <<'UNIT'
+[Unit]
+Description=Uni+ Postgres 18 + PostGIS 3.6 (hml standalone-single)
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10
+TimeoutStartSec=120
+
+LoadCredential=postgres-password:/etc/credstore/uniplus-postgres-password
+
+ExecStartPre=-/usr/bin/docker rm -f uniplus-postgres
+ExecStart=/usr/bin/docker run --rm --name uniplus-postgres \
+  --network host \
+  -e POSTGRES_PASSWORD_FILE=/run/secrets/postgres-password \
+  -e POSTGRES_INITDB_ARGS=--encoding=UTF8 \
+  -v ${CREDENTIALS_DIRECTORY}/postgres-password:/run/secrets/postgres-password:ro \
+  -v /var/lib/uniplus/postgres/data:/var/lib/postgresql \
+  postgis/postgis:18-3.6 \
+  -c listen_addresses=0.0.0.0 \
+  -c max_connections=200 \
+  -c shared_buffers=512MB
+
+ExecStop=/usr/bin/docker stop -t 30 uniplus-postgres
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+    fi
+
+    run "sudo systemctl daemon-reload"
+    run "sudo systemctl enable uniplus-postgres"
+
+    if $DRY_RUN; then
+        echo "[DRY-RUN] systemctl start uniplus-postgres + aguardaria pg_isready (até 5min)"
+    elif sudo systemctl is-active --quiet uniplus-postgres; then
+        log_success "uniplus-postgres já ativo — preservando state (sem restart)."
+    else
+        sudo systemctl start uniplus-postgres
+        log_info "Aguardando Postgres aceitar conexões (cold start com pull de imagem pode levar minutos)..."
+        # 60 tentativas × 5s = 5min — 60s não bastava no spike (pull da imagem
+        # postgis/postgis, ~1-2GB na 1ª vez, mais o ciclo initdb+restart dos
+        # entrypoints oficiais excedeu o timeout fixo anterior; achado #4 do
+        # spike, não corrigido lá por não ser bloqueante — corrigido aqui.
+        local attempts=0
+        until sudo docker exec uniplus-postgres pg_isready -U postgres &>/dev/null; do
+            attempts=$(( attempts + 1 ))
+            if (( attempts >= 60 )); then
+                log_error "Postgres não ficou ready em 5min. Ver: sudo journalctl -u uniplus-postgres -n 50"
+                exit 1
+            fi
+            sleep 5
+        done
+        log_success "uniplus-postgres ativo + pg_isready OK."
+    fi
+
+    step_setup_postgres_databases
+}
+
+# Cria role+database do Keycloak e do Apicurio Registry — os dois apps
+# habilitados nesta fase (environments/hml-standalone-single/values.yaml,
+# Story #439) que esperam um Postgres já provisionado. Via `docker exec ...
+# psql` (não init script — ver comentário no topo da seção). Padrão idêntico
+# ao de step_data_setup_apicurio_db em scripts/bootstrap-standalone.sh:
+# detecta role pré-existente (evita ALTER ROLE silencioso desincronizando
+# senha do Vault), \if block do psql em vez de DO $$ (não interpola
+# :'var' dentro de dollar-quoted strings — reproduzido lá, Codex P1 round 2),
+# senhas via env var do `docker exec` (não argv — vazaria via
+# /proc/<pid>/cmdline).
+step_setup_postgres_databases() {
+    if $DRY_RUN; then
+        echo "[DRY-RUN] Criaria roles+databases 'keycloak' e 'apicurio' via psql (idempotente)"
+        return
+    fi
+
+    local pg_creds="$DATA_BASE/postgres/.bootstrap-creds"
+    local super_pw
+    super_pw=$(sudo grep '^super_pw=' "$pg_creds" | cut -d= -f2)
+    if [[ -z "$super_pw" ]]; then
+        log_error "super_pw vazio em $pg_creds. Abortando setup de databases."
+        exit 1
+    fi
+
+    _setup_app_database "keycloak" "$super_pw"
+    _setup_app_database "apicurio" "$super_pw"
+    unset super_pw
+    log_success "Databases de aplicação (keycloak, apicurio) prontas."
+}
+
+# $1 = nome do role/database/creds file (ex.: "keycloak", "apicurio")
+# $2 = super_pw do Postgres
+_setup_app_database() {
+    local app_name="$1"
+    local super_pw="$2"
+    local app_creds="$DATA_BASE/postgres/.bootstrap-creds-$app_name"
+
+    local role_exists=false
+    if sudo docker exec -e PGPASSWORD="$super_pw" uniplus-postgres \
+         psql -U postgres -tAc "SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='$app_name'" 2>/dev/null \
+         | grep -q '^1$'; then
+        role_exists=true
+    fi
+
+    if sudo test -f "$app_creds" 2>/dev/null; then
+        log_success "Bootstrap creds de '$app_name' já existentes — preservando senha."
+    elif $role_exists; then
+        # Guard: role já existe no Postgres mas o creds file foi shredded
+        # (custódia no Vault já feita). Regenerar agora rodaria ALTER ROLE
+        # silencioso, desincronizando Postgres da senha custodiada.
+        log_error "$app_creds ausente, mas role Postgres '$app_name' já existe."
+        log_error "Regenerar a senha agora desincronizaria Postgres do Vault."
+        log_error "Restaure $app_creds a partir do Vault antes de re-rodar."
+        exit 1
+    else
+        log_info "Gerando senha de '$app_name' (256 bits)..."
+        local app_pw
+        app_pw=$(openssl rand -hex 32)
+        sudo tee "$app_creds" >/dev/null <<EOF
+${app_name}_pw=$app_pw
+EOF
+        sudo chown root:root "$app_creds"
+        sudo chmod 600 "$app_creds"
+        unset app_pw
+        log_warn "Senha de '$app_name' gerada em $app_creds. Custódia obrigatória — nunca commitar."
+    fi
+
+    local app_pw
+    app_pw=$(sudo grep "^${app_name}_pw=" "$app_creds" | cut -d= -f2)
+    if [[ -z "$app_pw" ]]; then
+        log_error "${app_name}_pw vazio em $app_creds. Abortando."
+        exit 1
+    fi
+
+    sudo docker exec \
+        -e PGPASSWORD="$super_pw" \
+        -e APP_PW="$app_pw" \
+        -i uniplus-postgres \
+        psql -U postgres -v ON_ERROR_STOP=1 <<SQL 2>&1 | tail -10
+\getenv app_pw APP_PW
+SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = '$app_name') AS role_exists \gset
+\if :role_exists
+   ALTER ROLE $app_name WITH LOGIN PASSWORD :'app_pw';
+\else
+   CREATE ROLE $app_name WITH LOGIN PASSWORD :'app_pw' NOSUPERUSER NOCREATEDB NOCREATEROLE;
+\endif
+SQL
+
+    sudo docker exec -e PGPASSWORD="$super_pw" uniplus-postgres \
+        psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = '$app_name'" 2>/dev/null \
+        | grep -q 1 \
+      || sudo docker exec -e PGPASSWORD="$super_pw" uniplus-postgres \
+        psql -U postgres -c "CREATE DATABASE $app_name OWNER $app_name ENCODING 'UTF8' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0" 2>&1 | tail -3
+
+    sudo docker exec -e PGPASSWORD="$super_pw" uniplus-postgres \
+        psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE $app_name TO $app_name" >/dev/null 2>&1
+
+    unset app_pw
+}
+
+step_setup_kafka() {
+    log_info "Configurando Kafka (delegando para setup-kafka.sh)..."
+    if $DRY_RUN; then
+        "$SCRIPT_DIR/setup-kafka.sh" --dry-run
+    else
+        "$SCRIPT_DIR/setup-kafka.sh"
+    fi
+}
+
+# ============================================================================
+# Step — Certificado TLS autoassinado provisório (docs/RUNBOOKS.md §21.1:
+# obrigatório antes de qualquer usuário real, aceitável como paliativo de
+# bring-up administrativo). Mesmo procedimento manual documentado em
+# environments/lab-standalone-single/README.md, scriptado e tornado
+# idempotente — Traefik/Keycloak/Apicurio Registry (ApplicationSet, pós-
+# registro no ArgoCD) esperam o Secret `uniplus-wildcard-nip-io-tls` já
+# existente no namespace `uniplus` na primeira sincronização.
+#
+# Diferente do lab: aqui NÃO copiamos o PEM para nenhum values.yaml (a
+# fundação desta Story não inclui os apps .NET que precisariam de
+# customCA.certPEM — ver comentário em
+# environments/hml-standalone-single/values.yaml) — só o Secret Kubernetes,
+# consumido diretamente pelos IngressRoute via `tls.secretName`.
+# ============================================================================
+
+step_generate_tls_secret() {
+    log_info "Gerando certificado TLS autoassinado provisório..."
+
+    local node_ip
+    node_ip=$(hostname -I | awk '{print $1}')
+
+    if $DRY_RUN; then
+        echo "[DRY-RUN] kubectl create namespace $TLS_NAMESPACE (idempotente)"
+        echo "[DRY-RUN] openssl req -x509 -newkey rsa:2048 ... SAN=*.${node_ip}.nip.io"
+        echo "[DRY-RUN] kubectl create secret tls $TLS_SECRET_NAME -n $TLS_NAMESPACE (se ainda não existir)"
+        return
+    fi
+
+    kubectl create namespace "$TLS_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+    if kubectl get secret "$TLS_SECRET_NAME" -n "$TLS_NAMESPACE" &>/dev/null; then
+        log_success "Secret $TLS_SECRET_NAME já existe em $TLS_NAMESPACE — preservando."
+        return
+    fi
+
+    # Subshell + trap EXIT (não RETURN): sob `set -e`, uma falha no meio do
+    # bloco (openssl, kubectl create) sai do subshell sem passar por um
+    # `return` normal — trap RETURN não dispara nesse caminho, deixando a
+    # chave privada órfã em /tmp. trap EXIT roda em qualquer saída do
+    # subshell (sucesso, erro, sinal), mesmo padrão já usado em
+    # scripts/lab-standalone-single/bootstrap.sh (step_configure_vault_auth)
+    # para material sensível. `kubectl create secret` (não idempotente) trocado
+    # por gerar+aplicar via `apply`, seguro para re-run se a checagem acima
+    # falhar por race entre dois bootstraps concorrentes.
+    (
+        tmpdir=$(mktemp -d)
+        trap 'shred -u "$tmpdir"/*.key 2>/dev/null; rm -rf "$tmpdir"' EXIT
+        chmod 700 "$tmpdir"
+
+        openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout "$tmpdir/tls.key" -out "$tmpdir/tls.crt" -days 825 \
+            -subj "/CN=uniplus-hml" \
+            -addext "subjectAltName=DNS:*.${node_ip}.nip.io,DNS:${node_ip}.nip.io" \
+            >/dev/null 2>&1
+
+        kubectl create secret tls "$TLS_SECRET_NAME" \
+            --cert="$tmpdir/tls.crt" --key="$tmpdir/tls.key" -n "$TLS_NAMESPACE" \
+            --dry-run=client -o yaml | kubectl apply -f -
+    )
+
+    log_warn "Certificado autoassinado gerado (SAN: *.${node_ip}.nip.io) — chave privada descartada após criar o Secret."
+    log_success "Secret $TLS_SECRET_NAME criado em $TLS_NAMESPACE."
+}
+
+summary() {
+    echo ""
+    echo "============================================"
+    log_success "Bootstrap hml-standalone-single (fundação) concluído"
+    echo "============================================"
+    echo ""
+    echo "Data services systemd:"
+    echo "  systemctl status uniplus-{postgres,kafka}"
+    echo ""
+    echo "K3s + ArgoCD:"
+    echo "  kubectl get nodes"
+    echo "  kubectl get pods -n argocd"
+    echo "  kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d"
+    echo ""
+    echo "Próximos passos (fora deste script — Story #445):"
+    echo "  1. Registrar o cluster no ArgoCD — CONTRATO: '--name in-cluster' explícito"
+    echo "     (o Application/Service name do Vault gerado pelo ApplicationSet é o"
+    echo "     nome do cluster, não o contexto kubeconfig — ver"
+    echo "     environments/hml-standalone-single/values.yaml e o mesmo padrão já"
+    echo "     usado em standalone-compact):"
+    echo "       argocd cluster add <context> --in-cluster --name in-cluster \\"
+    echo "         --label uniplus.io/managed=true --label environment=hml-standalone-single"
+    echo ""
+    echo "  2. Aplicar os manifests GitOps (ApplicationSet cria Vault/ESO/Traefik/"
+    echo "     Keycloak/Apicurio Registry — os recursos aplicam normalmente, mas os"
+    echo "     Pods de Vault/Keycloak/Apicurio ficam Degraded/Progressing até o"
+    echo "     passo 3, já que o Vault sobe sealed/sem role e os apps dependem de"
+    echo "     Secrets que só o ClusterSecretStore entrega):"
+    echo "       kubectl apply -f $REPO_ROOT/argocd/project.yaml"
+    echo "       kubectl apply -f $REPO_ROOT/argocd/applicationset.yaml"
+    echo ""
+    echo "  3. Init + unseal do Vault (Shamir 5/3 — ADR-014, NÃO o 1/1 do lab) +"
+    echo "     configurar auth Kubernetes/policy/role external-secrets — mesmo"
+    echo "     procedimento de docs/RUNBOOKS.md §8.4, aplicado a este Vault. Depois,"
+    echo "     popular os secrets que Keycloak/Apicurio esperam via ExternalSecret"
+    echo "     (mesmo padrão de scripts/lab-standalone-single/seed-vault-secrets.sh,"
+    echo "     subconjunto desta fase — secret/standalone/postgres/{keycloak,apicurio}"
+    echo "     com as senhas geradas em"
+    echo "     $DATA_BASE/postgres/.bootstrap-creds-{keycloak,apicurio}, e"
+    echo "     secret/standalone/keycloak/admin + secret/standalone/keycloak/clients/"
+    echo "     apicurio-registry — este último só existe DEPOIS do primeiro"
+    echo "     --import-realm do Keycloak, recuperado via kcadm)."
+    echo ""
+    echo "  4. Validar convergência do ArgoCD (self-heal automático após o passo 3 —"
+    echo "     reconcilia drift Git-vs-live; a disponibilidade de Vault/Keycloak/"
+    echo "     Apicurio em si depende só do passo 3 estar completo):"
+    echo "       argocd app list --selector environment=hml-standalone-single"
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+echo "============================================"
+echo "  Uni+ HML Standalone Single Bootstrap"
+echo "  Dry-run: $DRY_RUN"
+echo "============================================"
+echo ""
+
+step_install_docker
+step_install_k3s
+step_patch_coredns
+step_install_helm
+step_install_argocd
+step_setup_postgres
+step_setup_kafka
+step_generate_tls_secret
+
+summary

--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -97,8 +97,12 @@ run() {
 # ============== Arquitetura ==============
 case "$(uname -m)" in
     x86_64)  ARCH="amd64" ;;
-    aarch64) ARCH="arm64" ;;
-    *)       log_error "Arquitetura não suportada: $(uname -m). Esperado x86_64 ou aarch64."; exit 1 ;;
+    # `postgis/postgis:18-3.6` (step_setup_postgres) só publica manifest
+    # amd64 (confirmado via `docker manifest inspect`) — arm64 seguiria até
+    # Docker/K3s/ArgoCD instalarem para só então falhar tarde, no primeiro
+    # `docker run` do Postgres. Falhar cedo aqui evita esse desperdício.
+    aarch64) log_error "Arquitetura arm64 não suportada — postgis/postgis:18-3.6 (step_setup_postgres) só publica imagem amd64."; exit 1 ;;
+    *)       log_error "Arquitetura não suportada: $(uname -m). Esperado x86_64."; exit 1 ;;
 esac
 
 usage() {
@@ -137,6 +141,20 @@ if ! sudo -n true 2>/dev/null; then
     log_error "sudo sem senha é obrigatório para este usuário (ver docs/RUNBOOKS.md)."
     exit 1
 fi
+
+# Capturado UMA VEZ, antes de qualquer step que crie interfaces de rede
+# adicionais (docker0 do Docker, cni0/flannel do K3s) — `hostname -I` listaria
+# essas IPs privadas também, e tanto `awk '{print $1}'` (ordem de listagem
+# não garantida) quanto o grep por range privado de
+# scripts/lab-standalone-single/setup-kafka.sh poderiam pegar a interface
+# errada se computados depois. `ip route get` resolve pela rota default —
+# sempre a interface real de saída, nunca uma bridge/CNI local.
+NODE_IP=$(ip route get 8.8.8.8 2>/dev/null | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1); exit}')
+if [[ -z "$NODE_IP" ]]; then
+    log_error "Não consegui determinar o IP real do host via 'ip route get 8.8.8.8'."
+    exit 1
+fi
+log_info "IP real do host (via rota default): $NODE_IP"
 
 # ============================================================================
 # Steps — Docker + K3s + Helm + ArgoCD
@@ -195,10 +213,7 @@ step_install_k3s() {
     if command -v k3s &>/dev/null; then
         log_success "K3s já instalado: $(k3s --version | head -1)"
     else
-        local node_ip
-        node_ip=$(hostname -I | awk '{print $1}')
-
-        log_info "Instalando K3s $K3S_VERSION (host combinado, IP: $node_ip)..."
+        log_info "Instalando K3s $K3S_VERSION (host combinado, IP: $NODE_IP)..."
 
         # --disable traefik/servicelb: platform/traefik/ (ArgoCD, pós-registro)
         # é o IngressController real deste ambiente — o Traefik/ServiceLB
@@ -207,7 +222,7 @@ step_install_k3s() {
         # scripts/lab-standalone-single/bootstrap.sh e scripts/bootstrap-standalone.sh.
         run "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=$K3S_VERSION sh -s - \
             --node-name uniplus-hml \
-            --tls-san $node_ip \
+            --tls-san $NODE_IP \
             --disable servicelb \
             --disable traefik \
             --write-kubeconfig-mode 644"
@@ -540,10 +555,15 @@ SQL
 
 step_setup_kafka() {
     log_info "Configurando Kafka (delegando para setup-kafka.sh)..."
+    # DATA_HOST_IP explícito (NODE_IP, capturado ANTES de Docker/K3s criarem
+    # interfaces adicionais) — sem isso, setup-kafka.sh auto-detectaria via
+    # seu próprio `hostname -I | grep <range privado> | head -1`, que neste
+    # ponto do fluxo (Docker + K3s já instalados) já lista docker0/cni0 além
+    # da interface real, com risco real de pegar a IP errada.
     if $DRY_RUN; then
-        "$SCRIPT_DIR/setup-kafka.sh" --dry-run
+        DATA_HOST_IP="$NODE_IP" "$SCRIPT_DIR/setup-kafka.sh" --dry-run
     else
-        "$SCRIPT_DIR/setup-kafka.sh"
+        DATA_HOST_IP="$NODE_IP" "$SCRIPT_DIR/setup-kafka.sh"
     fi
 }
 
@@ -566,12 +586,9 @@ step_setup_kafka() {
 step_generate_tls_secret() {
     log_info "Gerando certificado TLS autoassinado provisório..."
 
-    local node_ip
-    node_ip=$(hostname -I | awk '{print $1}')
-
     if $DRY_RUN; then
         echo "[DRY-RUN] kubectl create namespace $TLS_NAMESPACE (idempotente)"
-        echo "[DRY-RUN] openssl req -x509 -newkey rsa:2048 ... SAN=*.${node_ip}.nip.io"
+        echo "[DRY-RUN] openssl req -x509 -newkey rsa:2048 ... SAN=*.${NODE_IP}.nip.io"
         echo "[DRY-RUN] kubectl create secret tls $TLS_SECRET_NAME -n $TLS_NAMESPACE (se ainda não existir)"
         return
     fi
@@ -600,7 +617,7 @@ step_generate_tls_secret() {
         openssl req -x509 -newkey rsa:2048 -nodes \
             -keyout "$tmpdir/tls.key" -out "$tmpdir/tls.crt" -days 825 \
             -subj "/CN=uniplus-hml" \
-            -addext "subjectAltName=DNS:*.${node_ip}.nip.io,DNS:${node_ip}.nip.io" \
+            -addext "subjectAltName=DNS:*.${NODE_IP}.nip.io,DNS:${NODE_IP}.nip.io" \
             >/dev/null 2>&1
 
         kubectl create secret tls "$TLS_SECRET_NAME" \
@@ -608,7 +625,7 @@ step_generate_tls_secret() {
             --dry-run=client -o yaml | kubectl apply -f -
     )
 
-    log_warn "Certificado autoassinado gerado (SAN: *.${node_ip}.nip.io) — chave privada descartada após criar o Secret."
+    log_warn "Certificado autoassinado gerado (SAN: *.${NODE_IP}.nip.io) — chave privada descartada após criar o Secret."
     log_success "Secret $TLS_SECRET_NAME criado em $TLS_NAMESPACE."
 }
 

--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -499,13 +499,37 @@ step_setup_postgres_databases() {
 
 # $1 = nome do role/database/creds file (ex.: "keycloak", "apicurio")
 # $2 = super_pw do Postgres
-_setup_app_database() {
+#
+# Senhas passadas via `docker exec --env-file <tmp>` (não `-e NAME=value`):
+# `-e` expõe o valor no argv do processo `docker` no HOST (visível via
+# `ps`/`/proc/<pid>/cmdline` a qualquer usuário local enquanto o comando
+# roda) — diferente de `/proc/<pid>/environ` (root-only, mode 400) do
+# processo DENTRO do container, que é o que o comentário original de
+# scripts/bootstrap-standalone.sh (step_data_setup_apicurio_db) endereça.
+# --env-file lê de um arquivo (mode 600, shredded ao final) e não aparece em
+# nenhum argv, nem do container nem do host.
+#
+# Corpo inteiro roda num subshell com trap EXIT próprio — chamado 2x (keycloak,
+# apicurio) por step_setup_postgres_databases; um `trap ... EXIT` direto na
+# função (sem subshell) seria substituído pela segunda chamada antes de
+# disparar para a primeira (trap EXIT não é function-scoped em bash), e
+# `trap ... RETURN` não dispara em abort por `set -e` no meio do corpo
+# (mesmo gotcha corrigido em step_generate_tls_secret). Falha dentro do
+# subshell propaga como retorno não-zero da função, `set -e` do chamador
+# aborta o script normalmente.
+_setup_app_database() (
     local app_name="$1"
     local super_pw="$2"
     local app_creds="$DATA_BASE/postgres/.bootstrap-creds-$app_name"
 
+    local envfile
+    envfile=$(sudo mktemp /etc/credstore/pg-envfile-XXXXXX)
+    trap 'sudo shred -u "$envfile" 2>/dev/null || true' EXIT
+    sudo chmod 600 "$envfile"
+    printf 'PGPASSWORD=%s\n' "$super_pw" | sudo tee "$envfile" >/dev/null
+
     local role_exists=false
-    if sudo docker exec -e PGPASSWORD="$super_pw" uniplus-postgres \
+    if sudo docker exec --env-file "$envfile" uniplus-postgres \
          psql -U postgres -tAc "SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='$app_name'" 2>/dev/null \
          | grep -q '^1$'; then
         role_exists=true
@@ -540,10 +564,10 @@ EOF
         log_error "${app_name}_pw vazio em $app_creds. Abortando."
         exit 1
     fi
+    printf 'PGPASSWORD=%s\nAPP_PW=%s\n' "$super_pw" "$app_pw" | sudo tee "$envfile" >/dev/null
 
     sudo docker exec \
-        -e PGPASSWORD="$super_pw" \
-        -e APP_PW="$app_pw" \
+        --env-file "$envfile" \
         -i uniplus-postgres \
         psql -U postgres -v ON_ERROR_STOP=1 <<SQL 2>&1 | tail -10
 \getenv app_pw APP_PW
@@ -555,17 +579,15 @@ SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = '$app_name') AS
 \endif
 SQL
 
-    sudo docker exec -e PGPASSWORD="$super_pw" uniplus-postgres \
+    sudo docker exec --env-file "$envfile" uniplus-postgres \
         psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = '$app_name'" 2>/dev/null \
         | grep -q 1 \
-      || sudo docker exec -e PGPASSWORD="$super_pw" uniplus-postgres \
+      || sudo docker exec --env-file "$envfile" uniplus-postgres \
         psql -U postgres -c "CREATE DATABASE $app_name OWNER $app_name ENCODING 'UTF8' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0" 2>&1 | tail -3
 
-    sudo docker exec -e PGPASSWORD="$super_pw" uniplus-postgres \
+    sudo docker exec --env-file "$envfile" uniplus-postgres \
         psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE $app_name TO $app_name" >/dev/null 2>&1
-
-    unset app_pw
-}
+)
 
 step_setup_kafka() {
     log_info "Configurando Kafka (delegando para setup-kafka.sh)..."

--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -172,7 +172,7 @@ step_fix_docker_dns() {
     local daemon_json="/etc/docker/daemon.json"
 
     if $DRY_RUN; then
-        echo "[DRY-RUN] Garantiria dns: [1.1.1.1, 8.8.8.8] em $daemon_json (+ restart docker se mudou)"
+        echo "[DRY-RUN] Faria merge de dns: [1.1.1.1, 8.8.8.8] em $daemon_json, preservando outras chaves (+ restart docker se mudou)"
         return
     fi
 
@@ -182,15 +182,29 @@ step_fix_docker_dns() {
     fi
 
     log_info "Configurando DNS explícito no Docker (achado do spike — nameserver do host inalcançável)..."
-    sudo tee "$daemon_json" >/dev/null <<'JSON'
-{
-  "dns": ["1.1.1.1", "8.8.8.8"]
-}
-JSON
+    # Merge via python3 (sempre presente em Ubuntu Server 24.04, mesma
+    # dependência já usada em scripts/lab-standalone-single/bootstrap.sh para
+    # parsear `vault status -format=json`) — NUNCA sobrescrever o arquivo
+    # inteiro: se já existir com outras chaves (registry mirrors, insecure-
+    # registries, logging, storage-driver), um `tee` sem merge apagaria essas
+    # configurações.
+    local merged
+    merged=$(sudo python3 -c "
+import json, sys
+path = '$daemon_json'
+try:
+    with open(path) as f:
+        data = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    data = {}
+data['dns'] = ['1.1.1.1', '8.8.8.8']
+print(json.dumps(data, indent=2))
+")
+    printf '%s\n' "$merged" | sudo tee "$daemon_json" >/dev/null
     if systemctl is-active --quiet docker 2>/dev/null; then
         sudo systemctl restart docker
     fi
-    log_success "Docker DNS configurado."
+    log_success "Docker DNS configurado (demais chaves de $daemon_json preservadas)."
 }
 
 step_install_docker() {

--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -452,8 +452,19 @@ UNIT
         # postgis/postgis, ~1-2GB na 1ª vez, mais o ciclo initdb+restart dos
         # entrypoints oficiais excedeu o timeout fixo anterior; achado #4 do
         # spike, não corrigido lá por não ser bloqueante — corrigido aqui.
+        #
+        # `-h 127.0.0.1` força o probe via TCP, não Unix socket: num data dir
+        # novo, o entrypoint oficial do Postgres (herdado pelo postgis/postgis)
+        # sobe um servidor TEMPORÁRIO socket-only (listen_addresses='') pra
+        # rodar os scripts de init, para esse servidor, e só DEPOIS sobe o
+        # servidor final com listen_addresses=0.0.0.0 (o que o unit systemd
+        # configura). `pg_isready` sem -h usa o socket local por padrão — sem
+        # forçar TCP, o probe passaria contra o servidor temporário, e
+        # step_setup_postgres_databases correria o risco de bater exatamente
+        # na janela entre o temporário cair e o final subir (connection
+        # refused).
         local attempts=0
-        until sudo docker exec uniplus-postgres pg_isready -U postgres &>/dev/null; do
+        until sudo docker exec uniplus-postgres pg_isready -h 127.0.0.1 -U postgres &>/dev/null; do
             attempts=$(( attempts + 1 ))
             if (( attempts >= 60 )); then
                 log_error "Postgres não ficou ready em 5min. Ver: sudo journalctl -u uniplus-postgres -n 50"

--- a/scripts/hml-standalone-single/setup-kafka.sh
+++ b/scripts/hml-standalone-single/setup-kafka.sh
@@ -46,6 +46,18 @@ for arg in "$@"; do
     esac
 done
 
+# `ip route get` resolve pela rota default — sempre a interface real de
+# saída, imune a bridges locais (docker0, cni0/flannel) que também têm IP
+# em range privado. Quando chamado via bootstrap.sh, DATA_HOST_IP já chega
+# explícito (capturado antes de Docker/K3s existirem) e este bloco nem roda;
+# a auto-detecção só importa em execução direta (`./setup-kafka.sh`), onde
+# Docker/K3s já podem estar instalados — daí a preferência por `ip route
+# get` sobre `hostname -I` (que listaria as bridges também, com risco real
+# de pegar a IP errada). Fallback pro método antigo só se `ip` não estiver
+# disponível.
+if [[ -z "${DATA_HOST_IP:-}" ]] && command -v ip &>/dev/null; then
+    DATA_HOST_IP=$(ip route get 8.8.8.8 2>/dev/null | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1); exit}')
+fi
 if [[ -z "${DATA_HOST_IP:-}" ]] && command -v hostname &>/dev/null; then
     DATA_HOST_IP=$(hostname -I 2>/dev/null | tr ' ' '\n' \
         | grep -E '^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)' \

--- a/scripts/hml-standalone-single/setup-kafka.sh
+++ b/scripts/hml-standalone-single/setup-kafka.sh
@@ -222,8 +222,18 @@ log.dirs=/var/lib/kafka/data
 EOF
     sudo chmod 644 "$fmt_props"
 
+    # chown 1000:1000 (não root:root): a imagem apache/kafka:4.2.0 roda como
+    # appuser (UID 1000) por default, sem --user root neste `docker run` —
+    # um arquivo root:root mode 400 seria ilegível de dentro do container
+    # (permission denied no `cat`), quebrando o format inteiro. UID 1000
+    # aqui é literal, não uma suposição sobre o usuário do host — Docker sem
+    # user namespace remapping (default) mapeia o UID do container 1:1 pro
+    # host, então "1000" sempre resolve ao mesmo UID numérico dentro do
+    # container, independente de qual usuário local esse número representa
+    # (ou não representa) no host.
     admin_pw_file=$(sudo mktemp)
     sudo grep '^admin_pw=' "$CREDS_FILE" | cut -d= -f2 | sudo tee "$admin_pw_file" >/dev/null
+    sudo chown 1000:1000 "$admin_pw_file"
     sudo chmod 400 "$admin_pw_file"
 
     if ! sudo docker run --rm \

--- a/scripts/hml-standalone-single/setup-kafka.sh
+++ b/scripts/hml-standalone-single/setup-kafka.sh
@@ -192,10 +192,21 @@ fi
 # --add-scram só é honrado no format inicial. Roda ANTES do systemctl start
 # na 1ª execução, em container ad-hoc; runs subsequentes veem storage já
 # formatado (meta.properties presente) e pulam este passo.
+#
+# `kafka-storage.sh format --add-scram` só aceita a senha como argumento
+# posicional — não há alternativa via arquivo/env na própria ferramenta
+# (kafka-storage.sh do Kafka 4.2 não lê SCRAM de stdin nem de config file).
+# Passar `--add-scram "...password=$admin_pw_init"` direto no `docker run`
+# exporia a senha no argv do processo HOST (visível via ps/`/proc/<pid>/
+# cmdline` a qualquer usuário local enquanto o comando roda). Mitigado
+# montando a senha como arquivo (mode 400, só root) e construindo o
+# argumento --add-scram DENTRO do container via `sh -c` com script FIXO
+# (sem a senha interpolada na string do script — só o comando `cat` que a
+# lê em runtime): o argv do `docker run` visível no host mostra o texto
+# fixo do script, nunca o valor da senha.
 if ! $DRY_RUN && ! $already_initialized && sudo test -f "$CREDS_FILE"; then
     log_info "Format do storage com --add-scram (admin SCRAM-SHA-512 embarcada)..."
     cluster_id_init=$(sudo grep '^cluster_id=' "$CREDS_FILE" | cut -d= -f2)
-    admin_pw_init=$(sudo grep '^admin_pw=' "$CREDS_FILE" | cut -d= -f2)
 
     fmt_props=$(sudo mktemp)
     sudo tee "$fmt_props" >/dev/null <<EOF
@@ -211,21 +222,25 @@ log.dirs=/var/lib/kafka/data
 EOF
     sudo chmod 644 "$fmt_props"
 
+    admin_pw_file=$(sudo mktemp)
+    sudo grep '^admin_pw=' "$CREDS_FILE" | cut -d= -f2 | sudo tee "$admin_pw_file" >/dev/null
+    sudo chmod 400 "$admin_pw_file"
+
     if ! sudo docker run --rm \
         -v "$DATA_BASE/kafka/data:/var/lib/kafka/data" \
         -v "$fmt_props:/opt/kafka/config/format.properties:ro" \
-        --entrypoint /opt/kafka/bin/kafka-storage.sh \
+        -v "$admin_pw_file:/run/secrets/admin_pw:ro" \
+        --entrypoint /bin/sh \
         "$KAFKA_IMAGE" \
-        format --config /opt/kafka/config/format.properties \
-               --cluster-id "$cluster_id_init" \
-               --add-scram "SCRAM-SHA-512=[name=admin,password=$admin_pw_init]" \
-               --ignore-formatted >/dev/null 2>&1; then
+        -c 'exec /opt/kafka/bin/kafka-storage.sh format --config /opt/kafka/config/format.properties --cluster-id "$1" --add-scram "SCRAM-SHA-512=[name=admin,password=$(cat /run/secrets/admin_pw)]" --ignore-formatted' \
+        -- "$cluster_id_init" >/dev/null 2>&1; then
         log_error "Format do storage falhou. Re-rode manualmente em verbose para diagnosticar."
-        sudo rm -f "$fmt_props"
+        sudo rm -f "$fmt_props" "$admin_pw_file"
         exit 1
     fi
     sudo rm -f "$fmt_props"
-    unset cluster_id_init admin_pw_init
+    sudo shred -u "$admin_pw_file"
+    unset cluster_id_init
     log_success "Storage formatado com admin SCRAM-SHA-512 embarcada."
 fi
 

--- a/scripts/hml-standalone-single/setup-kafka.sh
+++ b/scripts/hml-standalone-single/setup-kafka.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# scripts/hml-standalone-single/setup-kafka.sh
+#
+# Fork de scripts/lab-standalone-single/setup-kafka.sh (já validado no lab e
+# no spike de PathPrefix na própria VM real — ver
+# docs/validacao/spike-pathprefix-hml-2026-07-12.md) para o host combinado
+# real do HML (K3s + data services na mesma VM dedicada UNIFESSPA), sem
+# mudança de lógica — só identificação (CN do cert, Description do systemd
+# unit). Replica fielmente o padrão do data-host real
+# (scripts/bootstrap-standalone.sh, step_data_setup_kafka) — já é single-node
+# combined (process.roles=broker,controller), SASL_SSL + SCRAM-SHA-512 +
+# StandardAuthorizer conforme ADR-009.
+#
+# UID/GID: 1000:1000 (appuser, default user da imagem apache/kafka:4.2.0).
+#
+# Encryption: TLS via cert PEM self-signed estático (10 anos), SAN cobrindo
+# DATA_HOST_IP + localhost. Authentication: SCRAM-SHA-512 exclusivo, admin
+# embarcada via `kafka-storage.sh format --add-scram` no bootstrap inicial
+# (--add-scram só é honrado no format inicial — daí o passo explícito antes
+# do primeiro systemctl start). Authorization: StandardAuthorizer,
+# fail-closed (allow.everyone.if.no.acl.found=false), super.users=User:admin.
+#
+# server.properties é gerado como arquivo (não via env KAFKA_*) porque o
+# KafkaDockerWrapper da imagem não preserva hyphens em nomes de listener
+# (ex.: SCRAM-SHA-512), inviabilizando via env.
+#
+# Uso:
+#   ./setup-kafka.sh [--dry-run]
+#
+# Variáveis de ambiente:
+#   DATA_HOST_IP   IPv4 privado a bindar (default: auto-detectado via `hostname -I`)
+#   DATA_BASE      Diretório base dos volumes de dados (default: /var/lib/uniplus)
+#
+# Pré-requisitos: Docker instalado, usuário com sudo sem senha (ou rodar via sudo).
+set -euo pipefail
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            echo "Uso: $0 [--dry-run]"
+            exit 0
+            ;;
+        *) echo "Opção inválida: $arg" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "${DATA_HOST_IP:-}" ]] && command -v hostname &>/dev/null; then
+    DATA_HOST_IP=$(hostname -I 2>/dev/null | tr ' ' '\n' \
+        | grep -E '^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)' \
+        | head -1)
+fi
+if [[ -z "${DATA_HOST_IP:-}" ]]; then
+    echo "ERRO: não consegui auto-detectar DATA_HOST_IP. Defina explicitamente: DATA_HOST_IP=x.x.x.x $0" >&2
+    exit 1
+fi
+
+DATA_BASE="${DATA_BASE:-/var/lib/uniplus}"
+CREDS_FILE="$DATA_BASE/kafka/.bootstrap-creds"
+CERTS_DIR="/etc/uniplus-kafka/certs"
+CONFIG_DIR="/etc/uniplus-kafka/config"
+SERVER_PROPS="$CONFIG_DIR/server.properties"
+ADMIN_PROPS="$DATA_BASE/kafka/admin.properties"
+ENV_FILE="/etc/uniplus-kafka.env"
+UNIT_FILE="/etc/systemd/system/uniplus-kafka.service"
+KAFKA_IMAGE="apache/kafka:4.2.0"
+
+log_info()    { echo "[INFO] $*"; }
+log_success() { echo "[ OK ] $*"; }
+log_warn()    { echo "[WARN] $*" >&2; }
+log_error()   { echo "[ERROR] $*" >&2; }
+
+run() {
+    if $DRY_RUN; then
+        echo "[DRY-RUN] $*"
+    else
+        bash -c "$*"
+    fi
+}
+
+log_info "DATA_HOST_IP=$DATA_HOST_IP DATA_BASE=$DATA_BASE DRY_RUN=$DRY_RUN"
+
+# data dir 1000:1000 (appuser do container); certs_dir/config_dir 755
+# root:root — uid 1000 precisa traverse para abrir os PEMs e o
+# server.properties (arquivos individuais têm mode próprio mais restrito).
+run "sudo mkdir -p $DATA_BASE/kafka/data $CERTS_DIR $CONFIG_DIR"
+run "sudo chown 1000:1000 $DATA_BASE/kafka/data"
+run "sudo chmod 750 $DATA_BASE/kafka/data"
+run "sudo chown root:root $CERTS_DIR $CONFIG_DIR"
+run "sudo chmod 755 $CERTS_DIR $CONFIG_DIR"
+
+already_initialized=false
+if ! $DRY_RUN && sudo test -f "$DATA_BASE/kafka/data/meta.properties" 2>/dev/null; then
+    already_initialized=true
+fi
+
+# ---- Decisão 1: .bootstrap-creds (cluster_id + admin_pw) ----
+if sudo test -f "$CREDS_FILE" 2>/dev/null; then
+    if ! sudo grep -q '^admin_pw=' "$CREDS_FILE" 2>/dev/null; then
+        log_error "$CREDS_FILE existe mas não contém admin_pw."
+        exit 1
+    fi
+    log_success "Bootstrap creds Kafka já existentes (cluster_id + admin_pw) — preservando."
+elif $DRY_RUN; then
+    log_warn "Dry-run: cluster_id + admin_pw seriam gerados em $CREDS_FILE"
+elif $already_initialized; then
+    log_error "$CREDS_FILE ausente, mas $DATA_BASE/kafka/data/meta.properties já existe."
+    log_error "Storage formatado mas creds ausentes — mismatch, não prossigo automaticamente."
+    exit 1
+else
+    log_info "Gerando cluster_id + admin SCRAM-SHA-512 password..."
+    cluster_id=$(sudo docker run --rm --entrypoint /opt/kafka/bin/kafka-storage.sh \
+        "$KAFKA_IMAGE" random-uuid 2>/dev/null | tr -d '\r\n')
+    if [[ -z "$cluster_id" ]]; then
+        log_error "Falha ao gerar cluster_id via kafka-storage.sh."
+        exit 1
+    fi
+    admin_pw=$(openssl rand -hex 32)
+    sudo tee "$CREDS_FILE" >/dev/null <<EOF
+cluster_id=$cluster_id
+admin_pw=$admin_pw
+EOF
+    sudo chown root:root "$CREDS_FILE"
+    sudo chmod 600 "$CREDS_FILE"
+    unset cluster_id admin_pw
+    log_warn "cluster_id + admin_pw gerados em $CREDS_FILE. Custódia obrigatória antes de descartar."
+fi
+
+# ---- Decisão 2: certs PEM self-signed (10 anos) ----
+# Só considera "completo" com os 4 arquivos presentes — um bootstrap
+# interrompido no meio poderia deixar server.pem ausente e o broker falharia
+# silenciosamente no próximo start.
+if sudo test -f "$CERTS_DIR/server.crt" 2>/dev/null && \
+   sudo test -f "$CERTS_DIR/server.key" 2>/dev/null && \
+   sudo test -f "$CERTS_DIR/ca.crt" 2>/dev/null && \
+   sudo test -f "$CERTS_DIR/server.pem" 2>/dev/null; then
+    log_success "Certs Kafka completos (crt/key/ca/pem) — preservando."
+elif $DRY_RUN; then
+    log_warn "Dry-run: cert self-signed seria gerado em $CERTS_DIR/"
+else
+    log_info "Gerando cert self-signed PEM (10 anos, SAN: $DATA_HOST_IP + localhost)..."
+    ssl_cnf="$CERTS_DIR/openssl.cnf"
+    sudo tee "$ssl_cnf" >/dev/null <<CNF
+[req]
+distinguished_name = req_distinguished_name
+prompt = no
+req_extensions = v3_req
+
+[req_distinguished_name]
+CN = uniplus-kafka.hml
+
+[v3_req]
+basicConstraints = CA:TRUE
+keyUsage = digitalSignature, keyEncipherment, keyCertSign
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = uniplus-kafka.hml
+DNS.2 = localhost
+IP.1 = $DATA_HOST_IP
+IP.2 = 127.0.0.1
+CNF
+    sudo openssl req -x509 -newkey rsa:2048 \
+        -keyout "$CERTS_DIR/server.key" \
+        -out "$CERTS_DIR/server.crt" \
+        -days 3650 -nodes \
+        -config "$ssl_cnf" \
+        -extensions v3_req >/dev/null 2>&1
+    sudo cp "$CERTS_DIR/server.crt" "$CERTS_DIR/ca.crt"
+    # PEM keystore = cert + key concatenados (KIP-651) — ssl.keystore.key.location
+    # não é propriedade válida do Kafka 4.x.
+    sudo bash -c "cat $CERTS_DIR/server.crt $CERTS_DIR/server.key > $CERTS_DIR/server.pem"
+    sudo chown 1000:1000 "$CERTS_DIR/server.crt" "$CERTS_DIR/server.key" \
+                          "$CERTS_DIR/ca.crt" "$CERTS_DIR/server.pem"
+    sudo chmod 644 "$CERTS_DIR/server.crt" "$CERTS_DIR/ca.crt"
+    sudo chmod 600 "$CERTS_DIR/server.key" "$CERTS_DIR/server.pem"
+    sudo rm -f "$ssl_cnf"
+    log_warn "Cert self-signed gerado em $CERTS_DIR/server.{crt,pem} (validade 10 anos)."
+fi
+
+# ---- Decisão 3: format inicial com --add-scram ----
+# --add-scram só é honrado no format inicial. Roda ANTES do systemctl start
+# na 1ª execução, em container ad-hoc; runs subsequentes veem storage já
+# formatado (meta.properties presente) e pulam este passo.
+if ! $DRY_RUN && ! $already_initialized && sudo test -f "$CREDS_FILE"; then
+    log_info "Format do storage com --add-scram (admin SCRAM-SHA-512 embarcada)..."
+    cluster_id_init=$(sudo grep '^cluster_id=' "$CREDS_FILE" | cut -d= -f2)
+    admin_pw_init=$(sudo grep '^admin_pw=' "$CREDS_FILE" | cut -d= -f2)
+
+    fmt_props=$(sudo mktemp)
+    sudo tee "$fmt_props" >/dev/null <<EOF
+process.roles=broker,controller
+node.id=1
+controller.quorum.voters=1@$DATA_HOST_IP:9093
+listeners=SASL_SSL://$DATA_HOST_IP:9092,CONTROLLER://$DATA_HOST_IP:9093
+advertised.listeners=SASL_SSL://$DATA_HOST_IP:9092
+controller.listener.names=CONTROLLER
+inter.broker.listener.name=SASL_SSL
+listener.security.protocol.map=CONTROLLER:SASL_SSL,SASL_SSL:SASL_SSL
+log.dirs=/var/lib/kafka/data
+EOF
+    sudo chmod 644 "$fmt_props"
+
+    if ! sudo docker run --rm \
+        -v "$DATA_BASE/kafka/data:/var/lib/kafka/data" \
+        -v "$fmt_props:/opt/kafka/config/format.properties:ro" \
+        --entrypoint /opt/kafka/bin/kafka-storage.sh \
+        "$KAFKA_IMAGE" \
+        format --config /opt/kafka/config/format.properties \
+               --cluster-id "$cluster_id_init" \
+               --add-scram "SCRAM-SHA-512=[name=admin,password=$admin_pw_init]" \
+               --ignore-formatted >/dev/null 2>&1; then
+        log_error "Format do storage falhou. Re-rode manualmente em verbose para diagnosticar."
+        sudo rm -f "$fmt_props"
+        exit 1
+    fi
+    sudo rm -f "$fmt_props"
+    unset cluster_id_init admin_pw_init
+    log_success "Storage formatado com admin SCRAM-SHA-512 embarcada."
+fi
+
+# ---- Decisão 4: server.properties (sempre re-aplicado) ----
+# Contém a senha SCRAM em cleartext (Kafka 4.x exige JAAS inline por
+# listener, sem mecanismo file-based). Mode 600 chown 1000:1000.
+if $DRY_RUN; then
+    log_warn "Dry-run: server.properties seria escrito em $SERVER_PROPS"
+else
+    admin_pw_curr=$(sudo grep '^admin_pw=' "$CREDS_FILE" | cut -d= -f2)
+    if [[ -z "$admin_pw_curr" ]]; then
+        log_error "admin_pw vazio em $CREDS_FILE. Abortando."
+        exit 1
+    fi
+    sudo tee "$SERVER_PROPS" >/dev/null <<EOF
+# === KRaft topology (single-node combined) ===
+process.roles=broker,controller
+node.id=1
+controller.quorum.voters=1@$DATA_HOST_IP:9093
+listeners=SASL_SSL://$DATA_HOST_IP:9092,CONTROLLER://$DATA_HOST_IP:9093
+advertised.listeners=SASL_SSL://$DATA_HOST_IP:9092
+controller.listener.names=CONTROLLER
+inter.broker.listener.name=SASL_SSL
+listener.security.protocol.map=CONTROLLER:SASL_SSL,SASL_SSL:SASL_SSL
+
+# === Storage ===
+log.dirs=/var/lib/kafka/data
+auto.create.topics.enable=false
+
+# === Replication factor 1 (single-node, sem replicação) ===
+offsets.topic.replication.factor=1
+transaction.state.log.replication.factor=1
+transaction.state.log.min.isr=1
+share.coordinator.state.topic.replication.factor=1
+share.coordinator.state.topic.min.isr=1
+
+# === SASL/SCRAM-SHA-512 (admin embarcada via --add-scram no format) ===
+sasl.enabled.mechanisms=SCRAM-SHA-512
+sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
+sasl.mechanism.controller.protocol=SCRAM-SHA-512
+listener.name.sasl_ssl.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="admin" password="$admin_pw_curr";
+listener.name.controller.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="admin" password="$admin_pw_curr";
+
+# === TLS (PEM keystore + truststore; self-signed = ca = cert) ===
+ssl.keystore.type=PEM
+ssl.keystore.location=/etc/kafka/secrets/server.pem
+ssl.truststore.type=PEM
+ssl.truststore.location=/etc/kafka/secrets/ca.crt
+ssl.client.auth=none
+
+# === StandardAuthorizer (KRaft-native; fail-closed) ===
+authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer
+super.users=User:admin
+allow.everyone.if.no.acl.found=false
+EOF
+    sudo chown 1000:1000 "$SERVER_PROPS"
+    sudo chmod 600 "$SERVER_PROPS"
+    unset admin_pw_curr
+fi
+
+# ---- Decisão 5: admin.properties (CLI tools como admin) ----
+if ! $DRY_RUN; then
+    admin_pw_props=$(sudo grep '^admin_pw=' "$CREDS_FILE" | cut -d= -f2)
+    sudo tee "$ADMIN_PROPS" >/dev/null <<EOF
+security.protocol=SASL_SSL
+sasl.mechanism=SCRAM-SHA-512
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="admin" password="$admin_pw_props";
+ssl.truststore.type=PEM
+ssl.truststore.location=$CERTS_DIR/ca.crt
+ssl.endpoint.identification.algorithm=
+EOF
+    sudo chown 1000:1000 "$ADMIN_PROPS"
+    sudo chmod 600 "$ADMIN_PROPS"
+    unset admin_pw_props
+fi
+
+# ---- Decisão 6: EnvironmentFile (mínimo — CLUSTER_ID + JVM heap) ----
+if $DRY_RUN; then
+    log_warn "Dry-run: $ENV_FILE seria escrito"
+else
+    cluster_id_env=$(sudo grep '^cluster_id=' "$CREDS_FILE" | cut -d= -f2)
+    sudo tee "$ENV_FILE" >/dev/null <<EOF
+CLUSTER_ID=$cluster_id_env
+KAFKA_HEAP_OPTS="-Xmx1g -Xms1g"
+EOF
+    sudo chown root:root "$ENV_FILE"
+    sudo chmod 600 "$ENV_FILE"
+    unset cluster_id_env
+fi
+
+# ---- Decisão 7: systemd unit ----
+if $DRY_RUN; then
+    log_warn "Dry-run: unit systemd seria escrito em $UNIT_FILE"
+else
+    sudo tee "$UNIT_FILE" >/dev/null <<UNIT
+[Unit]
+Description=Uni+ Apache Kafka 4.2.0 KRaft (SASL_SSL + SCRAM-SHA-512, hml standalone-single)
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10
+TimeoutStartSec=180
+EnvironmentFile=$ENV_FILE
+
+ExecStartPre=-/usr/bin/docker rm -f uniplus-kafka
+ExecStart=/usr/bin/docker run --rm --name uniplus-kafka \\
+  --network host \\
+  -e CLUSTER_ID \\
+  -e KAFKA_HEAP_OPTS \\
+  -v $DATA_BASE/kafka/data:/var/lib/kafka/data \\
+  -v $CONFIG_DIR:/mnt/shared/config:ro \\
+  -v $CERTS_DIR:/etc/kafka/secrets:ro \\
+  $KAFKA_IMAGE
+
+ExecStop=/usr/bin/docker stop -t 30 uniplus-kafka
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+fi
+
+run "sudo systemctl daemon-reload"
+run "sudo systemctl enable uniplus-kafka"
+
+if $DRY_RUN; then
+    log_warn "Dry-run: systemctl start uniplus-kafka + SASL_SSL broker-api-versions probe"
+elif sudo systemctl is-active --quiet uniplus-kafka; then
+    log_success "uniplus-kafka já ativo — preservando state (sem restart)."
+else
+    sudo systemctl start uniplus-kafka
+    log_info "Aguardando Kafka aceitar conexões SASL_SSL (cold start ~30-90s)..."
+    attempts=0
+    until sudo docker run --rm --network host \
+            -v "$ADMIN_PROPS:/tmp/admin.properties:ro" \
+            -v "$CERTS_DIR/ca.crt:$CERTS_DIR/ca.crt:ro" \
+            --entrypoint /opt/kafka/bin/kafka-broker-api-versions.sh \
+            "$KAFKA_IMAGE" \
+            --bootstrap-server "$DATA_HOST_IP:9092" \
+            --command-config /tmp/admin.properties &>/dev/null; do
+        attempts=$(( attempts + 1 ))
+        if (( attempts >= 36 )); then
+            log_error "Kafka SASL_SSL não respondeu broker-api-versions em 180s."
+            log_error "Ver: sudo journalctl -u uniplus-kafka -n 100"
+            exit 1
+        fi
+        sleep 5
+    done
+    log_success "uniplus-kafka ativo + SASL_SSL broker-api-versions OK."
+fi

--- a/scripts/hml-standalone-single/setup-kafka.sh
+++ b/scripts/hml-standalone-single/setup-kafka.sh
@@ -28,7 +28,7 @@
 #   ./setup-kafka.sh [--dry-run]
 #
 # Variáveis de ambiente:
-#   DATA_HOST_IP   IPv4 privado a bindar (default: auto-detectado via `hostname -I`)
+#   DATA_HOST_IP   IPv4 privado a bindar (default: auto-detectado via `ip route get`)
 #   DATA_BASE      Diretório base dos volumes de dados (default: /var/lib/uniplus)
 #
 # Pré-requisitos: Docker instalado, usuário com sudo sem senha (ou rodar via sudo).
@@ -48,23 +48,19 @@ done
 
 # `ip route get` resolve pela rota default — sempre a interface real de
 # saída, imune a bridges locais (docker0, cni0/flannel) que também têm IP
-# em range privado. Quando chamado via bootstrap.sh, DATA_HOST_IP já chega
-# explícito (capturado antes de Docker/K3s existirem) e este bloco nem roda;
-# a auto-detecção só importa em execução direta (`./setup-kafka.sh`), onde
-# Docker/K3s já podem estar instalados — daí a preferência por `ip route
-# get` sobre `hostname -I` (que listaria as bridges também, com risco real
-# de pegar a IP errada). Fallback pro método antigo só se `ip` não estiver
-# disponível.
+# em range privado (diferente do antigo `hostname -I | grep <range
+# privado> | head -1`, que listaria as bridges também, com risco real de
+# pegar a interface errada se Docker/K3s já estiverem instalados no
+# momento da chamada — ex.: execução direta deste script, fora de
+# bootstrap.sh, que já passa DATA_HOST_IP explícito). Sem fallback pro
+# método antigo: `ip` (pacote iproute2) é parte da instalação base de
+# qualquer Ubuntu Server, incluindo 24.04 — exigir DATA_HOST_IP explícito
+# na ausência de `ip` é mais seguro que arriscar detectar a bridge errada.
 if [[ -z "${DATA_HOST_IP:-}" ]] && command -v ip &>/dev/null; then
     DATA_HOST_IP=$(ip route get 8.8.8.8 2>/dev/null | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1); exit}')
 fi
-if [[ -z "${DATA_HOST_IP:-}" ]] && command -v hostname &>/dev/null; then
-    DATA_HOST_IP=$(hostname -I 2>/dev/null | tr ' ' '\n' \
-        | grep -E '^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)' \
-        | head -1)
-fi
 if [[ -z "${DATA_HOST_IP:-}" ]]; then
-    echo "ERRO: não consegui auto-detectar DATA_HOST_IP. Defina explicitamente: DATA_HOST_IP=x.x.x.x $0" >&2
+    echo "ERRO: não consegui auto-detectar DATA_HOST_IP (comando 'ip' ausente ou 'ip route get' sem resultado). Defina explicitamente: DATA_HOST_IP=x.x.x.x $0" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Resumo

Implementa a Story #442 da Feature #435 (Epic #434 — HML real da UNIFESSPA): adapta o script de bootstrap para a VM real dedicada (`192.168.21.134`).

- `feat(hml)`: `scripts/hml-standalone-single/bootstrap.sh` — Docker (+ fix de DNS do spike), K3s, CoreDNS (+ fix de DNS do spike), Helm, ArgoCD self-hosted, Postgres com role+database do Keycloak/Apicurio, Kafka (fork de `setup-kafka.sh` do lab), certificado TLS autoassinado provisório. **Não** instala Vault/ESO/Traefik/Keycloak/Apicurio Registry via `helm install` manual — isso é papel do ArgoCD, pós-registro do cluster.
- `docs`: `RUNBOOKS.md §21.7` documenta o script + o contrato de nomenclatura do registro no ArgoCD.
- Corrige o endereço do Vault para o `ClusterSecretStore` em `environments/hml-standalone-single/values.yaml` (Story #439) — achado durante a pesquisa desta Story.

## Decisão arquitetural — por que o script não instala Vault/ESO/Traefik/Keycloak/Apicurio

Diferente do `lab-standalone-single` (aplicação manual via `helm install/upgrade -f`), este ambiente é GitOps (Story #439). Investiguei o script real do `standalone-compact` (`scripts/bootstrap-standalone.sh --role=standalone-k8s`) e confirmei que ele **também** não instala esses componentes manualmente — só Docker/K3s/Helm/ArgoCD. O `ApplicationSet` os cria automaticamente assim que o cluster é registrado no ArgoCD (`docs/RUNBOOKS.md §8.3`), e o `vault operator init` é procedimento **manual documentado** (§8.4), não scriptado — mesmo em produção real. Segui exatamente esse precedente.

## Achados corrigidos antes do PR (2 rodadas de revisão via Codex CLI)

**Rodada 1 (plano/diff inicial):**
- P1 — endereço do Vault (`--in-cluster` → nome `in-cluster`, não o nome do environment)
- P1 — DB/role de Keycloak e Apicurio nunca eram provisionados
- P1 — CoreDNS quebrado (achado do spike) seria recriado por um K3s fresh install
- P2 — timeout de 60s do Postgres insuficiente (já reproduzido no spike)
- P2 — trap de limpeza da chave TLS não disparava em caminhos de erro sob `set -e`
- P2 — handoff pra #445 omitia o seed de secrets do Vault
- P2 — gap de versão K3s 1.36 × matriz testada do ArgoCD 2.14 (documentado, não bloqueante)
- P3 — imprecisão semântica ArgoCD (`Synced`+`Degraded` vs `OutOfSync`) no RUNBOOKS

Todos corrigidos — detalhes nos comentários do próprio script e em `RUNBOOKS.md §21.7`.

## Test plan

- [x] `bash -n` + `shellcheck` (Docker, `koalaman/shellcheck:stable`) limpos nos 2 scripts novos
- [x] `--dry-run` completo executado com sucesso (sudo-gate contornado só numa cópia de teste local, script real intocado) — fluxo ponta-a-ponta sem erros
- [x] `make validate` (24 charts × 2 environments) limpo, `standalone-compact` sem regressão
- [x] `markdownlint`/`yamllint` limpos

## O que fica para a Story #445

- Executar o bootstrap de fato na VM real (rede/VPN necessária, fora do alcance deste agente)
- Registrar o cluster no ArgoCD com `--name in-cluster` explícito
- `vault operator init -key-shares=5 -key-threshold=3` (Shamir 5/3, ADR-014 — não o 1/1 do lab) + configurar auth/policy/role
- Seed dos secrets que Keycloak/Apicurio esperam via `ExternalSecret`
- Validar convergência do ArgoCD + smoke de validação

Closes #442
Refs #434, #435
