### PR TITLE
fix(hml): aguarda Deployment do CoreDNS existir no bootstrap

### DIFF
--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -263,6 +263,22 @@ step_patch_coredns() {
     fi
 
     log_info "Aguardando CoreDNS ficar disponível para patch..."
+    # `kubectl wait --for=condition=available` exige que o objeto JÁ EXISTA —
+    # falha imediatamente com NotFound se o deployment ainda não foi criado,
+    # não espera pela criação. Logo após `systemctl start k3s`, o deploy
+    # controller do K3s ainda não aplicou os addons bundled (coredns,
+    # local-path-provisioner, metrics-server) — leva alguns segundos.
+    # Achado real na execução contra a VM (não reproduzível em dry-run, que
+    # nunca consulta a API do K3s).
+    local attempts=0
+    until kubectl get deployment coredns -n kube-system &>/dev/null; do
+        attempts=$(( attempts + 1 ))
+        if (( attempts >= 24 )); then
+            log_error "Deployment coredns não apareceu em 120s. Ver: kubectl get pods -n kube-system"
+            exit 1
+        fi
+        sleep 5
+    done
     kubectl wait --for=condition=available --timeout=120s deployment/coredns -n kube-system
 
     local corefile


### PR DESCRIPTION
## Resumo

Corrige um bug real encontrado durante a **execução de fato** do `scripts/hml-standalone-single/bootstrap.sh` contra a VM real (Story #445, Epic #434) — não reproduzível em `--dry-run`, que nunca consulta a API do K3s.

`step_patch_coredns` chamava `kubectl wait --for=condition=available deployment/coredns` logo após `systemctl start k3s`. `kubectl wait` exige que o objeto **já exista** — falha imediatamente com `NotFound` se o Deployment ainda não foi criado, não espera pela criação. O deploy controller do K3s leva alguns segundos para aplicar os addons bundled (coredns, local-path-provisioner, metrics-server) após o serviço subir — nesse intervalo, o bootstrap abortava logo após o K3s instalar com sucesso.

Corrigido com um loop de poll (até 120s) esperando o Deployment `coredns` existir antes de chamar `kubectl wait`.

## Evidência

Confirmado ao vivo na VM real: no primeiro `./bootstrap.sh` (sem o fix), o script abortou com `Error from server (NotFound): deployments.apps "coredns" not found` segundos após "K3s pronto." Aplicando o fix e re-rodando (idempotente — pulou Docker/K3s já instalados), o step passou.

## Test plan

- [x] `bash -n` + `shellcheck` limpos
- [x] Aplicado e validado ao vivo contra a VM real do `hml-standalone-single` (192.168.21.134) — bootstrap prosseguiu além do CoreDNS após o fix

Refs #434, #435, #445
