### PR TITLE
fix(vault): restringe a role do external-secrets a um audience específico

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1071,10 +1071,20 @@ path "secret/metadata/*" { capabilities = ["read"] }
 POLICY
 
 # 7) Role vinculando ServiceAccount external-secrets/external-secrets à policy
+#
+# audience: sem isso, o Vault aceita o JWT da ServiceAccount contra QUALQUER
+# audience presente no token — não restringe a validação ao TokenReview desta
+# role específica. Confirmado via `kubectl create token external-secrets -n
+# external-secrets` + decode do JWT que o K3s emite dois audiences por padrão
+# ([https://kubernetes.default.svc.cluster.local, k3s]) mesmo sem
+# `--api-audiences` explícito no kube-apiserver (K3s usa o
+# `--service-account-issuer` como default implícito) — usar o mesmo valor já
+# configurado em `kubernetes_host` acima garante que bate com um dos dois.
 vault write auth/kubernetes/role/external-secrets \
   bound_service_account_names=external-secrets \
   bound_service_account_namespaces=external-secrets \
   policies=external-secrets-read \
+  audience=https://kubernetes.default.svc.cluster.local \
   ttl=24h
 
 # 8) Habilitar KV v2 em `secret/` (não vem montado por default em HA Raft)


### PR DESCRIPTION
## Resumo

Configura `audience` na role `external-secrets` do auth method Kubernetes do Vault (`docs/RUNBOOKS.md §8.4.3`) — sem isso, a validação do TokenReview aceitava o JWT da ServiceAccount contra qualquer audience presente no token, não restringia à audience esperada por esta role.

Achado durante a configuração pós-unseal do `hml-standalone-single` (Story #445): o comando emite o warning `Role external-secrets does not have an audience configured`.

## Pesquisa (a issue pedia confirmar viabilidade antes de aplicar)

- **Bug conhecido do `vault-plugin-auth-kubernetes`** ([#175](https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/175)) torna o parâmetro `audience` inefetivo em Vault ≤1.12. Este ambiente roda **1.21.2** — bem além da faixa afetada.
- **Pré-condição real** (segundo os [caveats documentados pela HashiCorp](https://support.hashicorp.com/hc/en-us/articles/34458984727443-Audience-parameter-usage-with-kube-auth-in-vault-with-caveats)): como não há `token_reviewer_jwt` explícito configurado (Vault roda no cluster, usa a SA do próprio pod), a validação de audience exige que o API server tenha uma audience efetiva configurada.
- **Confirmado empiricamente**: gerei um token real da ServiceAccount `external-secrets` (`kubectl create token`) e decodifiquei o JWT — o claim `aud` já vem com `["https://kubernetes.default.svc.cluster.local", "k3s"]` por padrão, mesmo sem `--api-audiences` explícito no kube-apiserver (K3s usa o `--service-account-issuer` como default implícito). Usar o mesmo valor já configurado em `kubernetes_host` bate com um dos dois.

## Validado ao vivo

Apliquei a mudança na role já existente do Vault do `hml-standalone-single` (idempotente — `vault write` na mesma role) e forcei o reconcile de um `ExternalSecret` real para confirmar que o login do External Secrets Operator continua funcionando com a validação mais restrita:

```
keycloak-replica-in-cluster-db   ClusterSecretStore   vault-default   1h   SecretSynced   True   11s
```

`ClusterSecretStore` continua `Valid`/`Ready`, `keycloak-replica` e `apicurio-registry` continuam `1/1 Running`.

## Escopo

A issue mencionava atualizar "a cópia usada por `standalone-compact`" também — investigando, existe só **um** bloco canônico documentado (`docs/RUNBOOKS.md §8.4.3`), referenciado (não duplicado) pelos dois ambientes. Este PR cobre a fonte única; a mudança live no Vault do `standalone-compact` fica para quando alguém operar aquele ambiente e seguir o procedimento atualizado.

## Test plan

- [x] `make validate` local — exit 0
- [x] `make markdown-lint` — 0 erros
- [x] Aplicado e testado ao vivo contra o Vault real do `hml-standalone-single`, com reconcile forçado de um `ExternalSecret` confirmando que a autenticação do ESO continua funcionando

Closes #466
Refs #434, #435, #445