### PR TITLE
feat(routing): suporte a Host+PathPrefix sem strip nos IngressRoute

### DIFF
--- a/apps/uniplus-api-host/templates/ingressroute.yaml
+++ b/apps/uniplus-api-host/templates/ingressroute.yaml
@@ -12,11 +12,25 @@ spec:
   entryPoints:
     - {{ .Values.uniplusApiHost.ingress.entryPoint }}
   routes:
+  {{- if .Values.uniplusApiHost.ingress.pathPrefixes }}
+    # Host + PathPrefix sem StripPrefix: o Host é composition root e serve vários
+    # módulos (e rotas transversais) sob o mesmo FQDN. Os controllers .NET já
+    # registram a rota com o prefixo completo (não aplicar UsePathBase) — o Traefik
+    # apenas encaminha o path intacto. Uma rota por prefixo. Ver docs/RUNBOOKS.md §21.3.
+  {{- range .Values.uniplusApiHost.ingress.pathPrefixes }}
+    - match: Host(`{{ $.Values.uniplusApiHost.ingress.host }}`) && PathPrefix(`{{ . }}`)
+      kind: Rule
+      services:
+        - name: {{ include "uniplusApiHost.fullname" $ }}
+          port: 8080
+  {{- end }}
+  {{- else }}
     - match: Host(`{{ .Values.uniplusApiHost.ingress.host }}`)
       kind: Rule
       services:
         - name: {{ include "uniplusApiHost.fullname" . }}
           port: 8080
+  {{- end }}
   {{- if .Values.uniplusApiHost.ingress.tls.enabled }}
   tls:
     secretName: {{ .Values.uniplusApiHost.ingress.tls.secretName | default (printf "%s-tls" (include "uniplusApiHost.fullname" .)) }}

--- a/apps/uniplus-api-host/values.yaml
+++ b/apps/uniplus-api-host/values.yaml
@@ -196,6 +196,21 @@ uniplusApiHost:
     enabled: false
     entryPoint: websecure
     host: ""                    # ex.: api.standalone.portaluni.com.br
+    # Roteamento path-based (Host + PathPrefix, sem StripPrefix) — RUNBOOKS §21.3.
+    # Lista opcional de prefixos servidos no MESMO host: cada entrada gera uma rota
+    # apontando pro mesmo Service (o Host multiplexa módulos + rotas transversais).
+    # Vazia/ausente → rota `Host()` pura (comportamento atual; preserva
+    # standalone-compact/lab). Semântica de prefixo literal do Traefik v3
+    # (`/api/selecao` casa com `/api/selecao/...`); entradas duplicadas/sobrepostas
+    # são permitidas (todas → mesmo Service). Ex. HML:
+    #   pathPrefixes:
+    #     - /api/selecao
+    #     - /api/ingresso
+    #     - /api/publicacoes
+    #     - /api/auth        # transversal — Host é o dono
+    #     - /api/profile     # transversal — Host é o dono
+    #     - /openapi         # transversal — Host é o dono
+    pathPrefixes: []
     tls:
       enabled: true
       secretName: ""

--- a/apps/uniplus-api-portal/templates/ingressroute.yaml
+++ b/apps/uniplus-api-portal/templates/ingressroute.yaml
@@ -12,7 +12,10 @@ spec:
   entryPoints:
     - {{ .Values.uniplusApiPortal.ingress.entryPoint }}
   routes:
-    - match: Host(`{{ .Values.uniplusApiPortal.ingress.host }}`)
+    # PathPrefix opcional, sem StripPrefix: o controller .NET registra a rota com o
+    # prefixo completo (`/api/portal`), então o Traefik encaminha o path intacto —
+    # não aplicar UsePathBase. Vazio → `Host()` puro. Ver docs/RUNBOOKS.md §21.3.
+    - match: Host(`{{ .Values.uniplusApiPortal.ingress.host }}`){{ if .Values.uniplusApiPortal.ingress.pathPrefix }} && PathPrefix(`{{ .Values.uniplusApiPortal.ingress.pathPrefix }}`){{ end }}
       kind: Rule
       services:
         - name: {{ include "uniplusApiPortal.fullname" . }}

--- a/apps/uniplus-api-portal/values.yaml
+++ b/apps/uniplus-api-portal/values.yaml
@@ -152,6 +152,10 @@ uniplusApiPortal:
     enabled: false
     entryPoint: websecure
     host: ""                    # ex.: api-portal.standalone.portaluni.com.br
+    # Prefixo de path opcional (Host + PathPrefix, sem StripPrefix) — RUNBOOKS §21.3.
+    # Vazio/ausente → rota `Host()` pura (preserva standalone-compact/lab).
+    # Ex. HML: pathPrefix: /api/portal
+    pathPrefix: ""
     tls:
       enabled: true
       secretName: ""

--- a/apps/uniplus-web/README.md
+++ b/apps/uniplus-web/README.md
@@ -51,7 +51,8 @@ templates/
 |-----------|---------|-----------|
 | `apps.portal.enabled` | `true` | Habilita Portal |
 | `apps.portal.replicas` | `2` | Réplicas do Portal |
-| `apps.portal.path` | `/portal` | Path prefix no Ingress |
+| `apps.portal.host` | `""` | Hostname público do app (obrigatório quando ingress habilitado) |
+| `apps.portal.pathPrefix` | `""` | Subpath opcional (Host + PathPrefix, sem StripPrefix). Vazio → `Host()` puro |
 | `apps.selecao.*` | similar | Mesma estrutura para Seleção |
 | `apps.ingresso.*` | similar | Mesma estrutura para Ingresso |
 | `ingress.host` | `uniplus.unifesspa.edu.br` | Hostname público |

--- a/apps/uniplus-web/templates/ingressroute.yaml
+++ b/apps/uniplus-web/templates/ingressroute.yaml
@@ -15,7 +15,10 @@ spec:
   entryPoints:
     - {{ $.Values.uniplusWeb.ingress.entryPoint }}
   routes:
-    - match: Host(`{{ $cfg.host }}`)
+    # PathPrefix opcional, sem StripPrefix — permite servir múltiplas SPAs sob o
+    # mesmo FQDN por subpath (`/portal`, `/selecao`, `/ingresso`). Vazio → `Host()`
+    # puro (comportamento atual). Ver docs/RUNBOOKS.md §21.3.
+    - match: Host(`{{ $cfg.host }}`){{ if $cfg.pathPrefix }} && PathPrefix(`{{ $cfg.pathPrefix }}`){{ end }}
       kind: Rule
       services:
         - name: {{ include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app) }}

--- a/apps/uniplus-web/values.yaml
+++ b/apps/uniplus-web/values.yaml
@@ -70,6 +70,11 @@ uniplusWeb:
       image: uniplus-portal
       tag: v0.2.1  # tag publicada em GHCR (override per-app possível)
       host: ""  # ex.: portal.standalone.portaluni.com.br
+      # Subpath opcional (Host + PathPrefix, sem StripPrefix) — RUNBOOKS §21.3.
+      # Vazio/ausente → rota `Host()` pura (preserva standalone-compact/lab).
+      # Servir SPA sob subpath exige ajustes cross-repo no uniplus-web
+      # (base-href, nginx, redirects OIDC) — Feature #436. Ex. HML: /portal
+      pathPrefix: ""
       # Conteúdo escrito em /assets/runtime-config.json via ConfigMap.
       # Schema é a interface AppConfig em libs/shared-data/lib/config/
       # app-config.model.ts do uniplus-web (ADR-0021).
@@ -93,6 +98,7 @@ uniplusWeb:
       image: uniplus-web-selecao
       tag: v0.2.1
       host: ""
+      pathPrefix: ""  # subpath opcional — ver nota em apps.portal.pathPrefix. Ex. HML: /selecao
       runtimeConfig:
         apiUrl: ""
         keycloak:
@@ -113,6 +119,7 @@ uniplusWeb:
       image: uniplus-web-ingresso
       tag: v0.2.1
       host: ""
+      pathPrefix: ""  # subpath opcional — ver nota em apps.portal.pathPrefix. Ex. HML: /ingresso
       runtimeConfig:
         apiUrl: ""
         keycloak:


### PR DESCRIPTION
## Contexto

Story #449 (Feature #436 — roteamento path-based; Epic #434 — HML real da UNIFESSPA). Estende os `IngressRoute` de `apps/uniplus-api-host`, `apps/uniplus-api-portal` e `apps/uniplus-web` para suportar `Host() && PathPrefix()` **sem StripPrefix**, permitindo expor múltiplos módulos/SPAs sob um único FQDN por família no HML de host único.

Replica na infraestrutura o padrão validado no spike de 2026-07-12 (`docs/validacao/spike-pathprefix-hml-2026-07-12.md`, gate 8/8 PASS) e o desenho de `docs/RUNBOOKS.md §21.3`. Segue o precedente já in-repo (`apps/keycloak-replica`, `platform/observability/grafana`).

## O que muda

Campos novos, **todos opcionais** — ausente/vazio preserva o comportamento atual (`Host()` puro):

| Chart | Campo | Tipo | Motivo |
|---|---|---|---|
| `uniplus-api-portal` | `ingress.pathPrefix` | string | Um prefixo (`/api/portal`); convenção singular de keycloak/grafana |
| `uniplus-web` | `apps.<app>.pathPrefix` | string | Um subpath por SPA (`/portal`, `/selecao`, `/ingresso`) |
| `uniplus-api-host` | `ingress.pathPrefixes` | **lista** | Host é composition root: multiplexa módulos + rotas transversais no mesmo FQDN |

O `pathPrefixes` do Host cobre tanto as rotas de módulo (`/api/selecao`, `/api/publicacoes`, ...) quanto as **transversais das quais o Host é dono** (`/api/auth`, `/api/profile`, `/openapi`) — cada entrada vira uma rota apontando pro mesmo Service, **sem host nem path hardcoded** no template (CA3).

**Sem StripPrefix** em nenhum caso: os controllers .NET já registram a rota com o prefixo completo; o Traefik encaminha o path intacto (não aplicar `UsePathBase`, conforme §21.3).

## Validação

- `make helm-lint` — OK (todos os charts).
- `make schema-validate` — OK.
- `make helm-template` — OK em `standalone-compact` **e** `hml-standalone-single`.
- **Zero diff funcional nos environments existentes**: `standalone-compact` (onde portal e web estão ativos) mantém todas as rotas `Host()` puras — a única adição no render é um comentário YAML inerte, que não integra o objeto aplicado pelo ArgoCD.
- Render isolado confirmando: default → `Host()`; com prefixo(s) → `Host(...) && PathPrefix(...)` **sem `middlewares`**.

## Notas

- **CA5 (values.schema.json)**: os três charts-alvo **não** têm schema (outros charts do repo têm) — logo não há schema a atualizar nesta mudança.
- Semântica de prefixo literal do Traefik v3 (`/api/selecao` casa com `/api/selecao/...`); entradas duplicadas/sobrepostas são permitidas e vão ao mesmo Service. Os prefixos reais em uso não se sobrepõem.
- Servir SPA sob subpath ainda exige trabalho cross-repo no `uniplus-web` (base-href, nginx, redirects OIDC) — fora do escopo desta story, faz parte da Feature #436.
- Corrige de passagem a linha stale do README do `uniplus-web` (`apps.portal.path` nunca existiu; o campo real é `pathPrefix`).

Refs #436
Closes #449