### PR TITLE
feat(routing): adiciona ConnectionStrings__PublicacoesDb nativo ao chart uniplus-api-host

### DIFF
--- a/apps/uniplus-api-host/README.md
+++ b/apps/uniplus-api-host/README.md
@@ -83,7 +83,7 @@ environment e remover o build local.
 
 | Variável | Default | Notas |
 |---|---|---|
-| `uniplusApiHost.database.name`/`username` | `uniplus`/`uniplus` | Banco único — 5 connection strings (`UniPlusDb`, `ConfiguracaoDb`, `OrganizacaoDb`, `SelecaoDb`, `IngressoDb`) apontam todas para cá |
+| `uniplusApiHost.database.name`/`username` | `uniplus`/`uniplus` | Banco único — 6 connection strings (`UniPlusDb`, `ConfiguracaoDb`, `OrganizacaoDb`, `SelecaoDb`, `IngressoDb`, `PublicacoesDb`) apontam todas para cá |
 | `uniplusApiHost.kafka.enabled` | `false` | Desligado até o Apicurio Registry entrar no lab (issue #423) |
 | `uniplusApiHost.schemaRegistry.url` | `""` | Feature off; ver bloco Kafka acima |
 | `uniplusApiHost.oidc.enabled` | `true` | Bearer validation apenas — o Host não se autentica como client M2M contra nada |

--- a/apps/uniplus-api-host/templates/deployment.yaml
+++ b/apps/uniplus-api-host/templates/deployment.yaml
@@ -125,18 +125,19 @@ spec:
             - name: ASPNETCORE_URLS
               value: {{ .Values.uniplusApiHost.aspnet.urls | quote }}
             # === Postgres — banco único `uniplus`, schema-por-módulo (ADR-0097).
-            # As 5 connection strings (UniPlusDb/ConfiguracaoDb/OrganizacaoDb/
-            # SelecaoDb/IngressoDb) apontam para o MESMO host/database/role —
-            # cada DbContext usa seu próprio schema via HasDefaultSchema.
-            # UniPlusDb é consumida pelo outbox Wolverine (schema `wolverine`)
-            # e pelos health checks (AddUniPlusHealthChecks connectionStringName). ===
+            # As 6 connection strings (UniPlusDb/ConfiguracaoDb/OrganizacaoDb/
+            # SelecaoDb/IngressoDb/PublicacoesDb) apontam para o MESMO
+            # host/database/role — cada DbContext usa seu próprio schema via
+            # HasDefaultSchema. UniPlusDb é consumida pelo outbox Wolverine
+            # (schema `wolverine`) e pelos health checks
+            # (AddUniPlusHealthChecks connectionStringName). ===
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "uniplusApiHost.postgresSecretName" . }}
                   key: POSTGRES_PASSWORD
             {{- $db := .Values.uniplusApiHost.database }}
-            {{- range list "UniPlusDb" "ConfiguracaoDb" "OrganizacaoDb" "SelecaoDb" "IngressoDb" }}
+            {{- range list "UniPlusDb" "ConfiguracaoDb" "OrganizacaoDb" "SelecaoDb" "IngressoDb" "PublicacoesDb" }}
             - name: ConnectionStrings__{{ . }}
               value: "Host={{ $db.host }};Port={{ $db.port }};Database={{ $db.name }};Username={{ $db.username }};Password=$(POSTGRES_PASSWORD)"
             {{- end }}

--- a/apps/uniplus-api-host/values.yaml
+++ b/apps/uniplus-api-host/values.yaml
@@ -74,12 +74,13 @@ uniplusApiHost:
     urls: "http://+:8080"
 
   # === Backend Postgres — banco único `uniplus`, schema-por-módulo
-  # (ADR-0097). As 5 connection strings do host (UniPlusDb, ConfiguracaoDb,
-  # OrganizacaoDb, SelecaoDb, IngressoDb — renderizadas incondicionalmente
-  # pelo template) apontam todas para host/database/username abaixo; cada
-  # DbContext usa seu próprio schema via HasDefaultSchema. UniPlusDb é
-  # consumida pelo outbox Wolverine (schema `wolverine`) e pelos health
-  # checks (AddUniPlusHealthChecks connectionStringName: "UniPlusDb"). ===
+  # (ADR-0097). As 6 connection strings do host (UniPlusDb, ConfiguracaoDb,
+  # OrganizacaoDb, SelecaoDb, IngressoDb, PublicacoesDb — renderizadas
+  # incondicionalmente pelo template) apontam todas para host/database/
+  # username abaixo; cada DbContext usa seu próprio schema via
+  # HasDefaultSchema. UniPlusDb é consumida pelo outbox Wolverine (schema
+  # `wolverine`) e pelos health checks (AddUniPlusHealthChecks
+  # connectionStringName: "UniPlusDb"). ===
   database:
     host: ""                    # ex.: 10.0.2.87
     port: 5432

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -3869,7 +3869,7 @@ escopo de uma Task de lab. Quando a primeira release real existir
 (`ghcr.io/unifesspa-edu-br/uniplus-api-host`), atualizar `image.registry`/`image.repository`/
 `image.tag`/`pullPolicy` no environment e remover o passo 4.
 
-Detalhes completos (banco único com 5 connection strings, Kafka + Schema Registry ligados desde a
+Detalhes completos (banco único com 6 connection strings, Kafka + Schema Registry ligados desde a
 issue [#423](https://github.com/unifesspa-edu-br/uniplus-infra/issues/423) — deploy do Apicurio
 Registry documentado em `environments/lab-standalone-single/README.md`) em
 `apps/uniplus-api-host/README.md` e `environments/lab-standalone-single/README.md`.
@@ -4061,7 +4061,7 @@ fechada, e confirmar via observação real do tráfego durante o primeiro bootst
 | `uniplus-hml...` | `/portal`, `/ingresso`, `/selecao` | `apps/uniplus-web` (3 Deployments) | Sim | **Código** — `templates/ingressroute.yaml` hoje só suporta `Host(...)` |
 | `uniplus-hml...` | `/publicacoes` | — | — | **Não criar rota** — não existe SPA de Publicações em `uniplus-web` ainda; ativar só quando o 4º Deployment existir |
 | `uniplus-api-hml...` | `/api/portal` | `apps/uniplus-api-portal` | Sim | **Código** — idem. Hoje o Portal só tem endpoint-esqueleto (`/api/portal/ping`) — API de negócio ainda não implementada |
-| `uniplus-api-hml...` | `/api/ingresso`, `/api/selecao`, `/api/publicacoes` | `apps/uniplus-api-host` (composition root — Selecao+Ingresso+Configuracao+OrganizacaoInstitucional+Publicacoes, [ADR-0097](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md)/[ADR-0105](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0105-modulo-publicacoes-registro-central-dos-atos.md) do `uniplus-api`) | Sim | **Código** (IngressRoute) + **chart** (`templates/deployment.yaml` injeta só 5 connection strings — falta `ConnectionStrings__PublicacoesDb`) + registrar no ApplicationSet (ver nota abaixo) + **imagem publicada** — não há build do Host publicado em GHCR ainda. `/api/ingresso` é reserva de rota: módulo Ingresso ainda sem controller HTTP implementado |
+| `uniplus-api-hml...` | `/api/ingresso`, `/api/selecao`, `/api/publicacoes` | `apps/uniplus-api-host` (composition root — Selecao+Ingresso+Configuracao+OrganizacaoInstitucional+Publicacoes, [ADR-0097](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md)/[ADR-0105](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0105-modulo-publicacoes-registro-central-dos-atos.md) do `uniplus-api`) | Sim | **Código** (IngressRoute) + registrar no ApplicationSet (ver nota abaixo) + **imagem publicada** — não há build do Host publicado em GHCR ainda. `/api/ingresso` é reserva de rota: módulo Ingresso ainda sem controller HTTP implementado |
 | `uniplus-oidc-hml...` | `/auth` | `apps/keycloak-replica` | Sim (já suportado) | Só `values.yaml` |
 | `geo-api-hml...` | `/` | `apps/unifesspa-geo-api` | Não | Só `values.yaml` + registrar no ApplicationSet (ver nota abaixo) |
 | `grafana-hml...` | `/` | `platform/observability/grafana` | Não (`pathPrefix: ""`) | `values.yaml` — o template já suporta os dois modos (subpath e subdomínio); **falta provisionar o `Certificate`/`secretName`** que a IngressRoute referencia — o chart não cria o certificado sozinho |

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -32,12 +32,11 @@
 # Deliberadamente FORA de escopo (Features 2-4 do Epic #434 ainda não têm
 # base de código pronta — ver `docs/RUNBOOKS.md §21.3`, coluna "Mudança
 # necessária: Código"):
-#   - uniplusApiHost / uniplusApiPortal / unifesspaGeoApi — chart não tem
-#     `ConnectionStrings__PublicacoesDb` nativo (Feature 3), IngressRoute
-#     não suporta `PathPrefix` (Feature 2), sem imagem publicada em GHCR
-#     (Feature 3). Também evita o problema de que o certificado autoassinado
-#     real desta VM só existe DEPOIS do bootstrap (#442/#445) — os apps .NET
-#     precisariam de `customCA.certPEM`, que não pode ser fabricado agora.
+#   - uniplusApiHost / uniplusApiPortal / unifesspaGeoApi — sem imagem
+#     publicada em GHCR (Feature 3). Também evita o problema de que o
+#     certificado autoassinado real desta VM só existe DEPOIS do bootstrap
+#     (#442/#445) — os apps .NET precisariam de `customCA.certPEM`, que não
+#     pode ser fabricado agora.
 #   - uniplusWeb — default `enabled: true` no chart; desligado explicitamente
 #     abaixo. Mesma falta de suporte a `PathPrefix`/subpath (Feature 2) +
 #     trabalho cross-repo em `uniplus-web` (Feature 4).


### PR DESCRIPTION
## Contexto

O chart `apps/uniplus-api-host` já injeta nativamente 5 connection strings (`UniPlusDb`, `ConfiguracaoDb`, `OrganizacaoDb`, `SelecaoDb`, `IngressoDb`) — banco único `uniplus`, schema-por-módulo (ADR-0097 do `uniplus-api`). `ConnectionStrings__PublicacoesDb` (módulo Publicações, ADR-0105) ficou de fora; no spike de roteamento (`docs/validacao/spike-pathprefix-hml-2026-07-12.md`) foi contornada via `extraEnv` manual do usuário do chart.

## O que mudou

- `templates/deployment.yaml`: `PublicacoesDb` adicionado à lista de connection strings renderizadas — mesmo `Host`/`Port`/`Database`/`Username`/`Password=$(POSTGRES_PASSWORD)` das outras 5, sem campo novo em `values.yaml` (o módulo Publicações usa o mesmo host/database/username já configurados, confirmado contra `docker-compose.monolito.yml` e `appsettings.json` do `uniplus-api`).
- `values.yaml` e `README.md`: comentários/tabela atualizados de "5" para "6" connection strings.
- `docs/RUNBOOKS.md` e `environments/hml-standalone-single/values.yaml`: removida a premissa obsoleta de que o chart "não tem `ConnectionStrings__PublicacoesDb` nativo" como bloqueio para habilitar `uniplusApiHost` (achado do self-review via Codex).

## Validação

- `helm lint apps/uniplus-api-host` — OK
- `make validate` (helm-deps + yaml-lint + helm-lint + markdown-lint + schema-validate) — OK, sem novos warnings
- `make helm-template` — `uniplus-api-host` renderiza 0 recursos em ambos ambientes (chart segue `enabled: false` por padrão em todos os environments hoje — pré-existente, não é regressão desta mudança)
- Render manual com overrides mínimos (`enabled: true` + deps obrigatórias) mostrando as 6 connection strings, comparado byte-a-byte com o render antes da mudança: as 5 existentes permanecem idênticas, `ConnectionStrings__PublicacoesDb` presente com `Host=10.2.2.11;Port=5432;Database=uniplus;Username=uniplus;Password=$(POSTGRES_PASSWORD)`
- Self-review via Codex CLI: 0 P1, 0 P2, 1 P3 (documentação obsoleta) — aplicado nesta mesma PR

## Issues

Closes #454
Closes #455
Closes #456