### PR TITLE
feat(argocd): mecanismo de habilitação por-ambiente no ApplicationSet

### DIFF
--- a/apps/unifesspa-geo-api/values.yaml
+++ b/apps/unifesspa-geo-api/values.yaml
@@ -4,13 +4,14 @@
 # estiver publicada e os pré-requisitos atendidos (DB, secrets, OIDC) ligam
 # via `unifesspaGeoApi.enabled: true`.
 #
-# NOTA: este chart ainda NÃO está registrado em argocd/applicationset.yaml.
-# Registrar antes de provisionar os secrets do Vault (postgres/geo, redis já
-# compartilhado, geo/encryption) e decidir o hostname de ingress geraria uma
-# Application vazia no standalone-compact — a syncPolicy do AppSet usa
-# `allowEmpty: false`, então o Application ficaria bloqueado/barulhento.
-# Registrar no AppSet + habilitar via environments/standalone-compact/values.yaml
-# é follow-up, junto do provisionamento dos secrets (issue #395).
+# NOTA: registrado em argocd/applicationset.yaml só para `hml-standalone-single`
+# (mecanismo de habilitação por-ambiente, story #457/task #458 — ver
+# argocd/README.md § Habilitação por-ambiente). Continua fora do
+# `standalone-compact` — não faz parte deste chart nem do valueFiles
+# desse ambiente. Ligar de fato (`unifesspaGeoApi.enabled: true`) em
+# qualquer ambiente é follow-up separado, condicionado ao provisionamento
+# dos secrets do Vault (postgres/geo, redis já compartilhado, geo/encryption)
+# e à decisão do hostname de ingress.
 
 commonLabels:
   app.kubernetes.io/part-of: uniplus

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -66,8 +66,10 @@ O mecanismo — um segundo `matrix` generator dentro do MESMO ApplicationSet `un
       - list:
           elements:
             - app: uniplus-api-host
+              namespace: uniplus
               targetEnvironment: hml-standalone-single
             - app: unifesspa-geo-api
+              namespace: geo
               targetEnvironment: hml-standalone-single
       # 2) `clusters.selector.matchLabels` referencia `{{.targetEnvironment}}`
       #    do elemento acima — só o cluster com esse `environment` label
@@ -79,7 +81,9 @@ O mecanismo — um segundo `matrix` generator dentro do MESMO ApplicationSet `un
               environment: '{{.targetEnvironment}}'
 ```
 
-**Para habilitar um chart num ambiente:** adicionar um elemento `{app: <chart>, targetEnvironment: <ambiente>}` na `list`. **Para habilitar o mesmo chart em mais de um ambiente:** repetir o elemento trocando só o `targetEnvironment`. Nenhuma edição em `clusters`/`selector` é necessária — o padrão já é genérico para qualquer combinação chart×ambiente.
+**Para habilitar um chart num ambiente:** adicionar um elemento `{app: <chart>, namespace: <namespace>, targetEnvironment: <ambiente>}` na `list`. **Para habilitar o mesmo chart em mais de um ambiente:** repetir o elemento trocando só o `targetEnvironment`. Nenhuma edição em `clusters`/`selector` é necessária — o padrão já é genérico para qualquer combinação chart×ambiente.
+
+**`namespace` é obrigatório em todo elemento, dos dois grupos (sempre-ligado e seletivo).** `destination.namespace` do template é `'{{.namespace}}'`, não um literal — com `goTemplateOptions: [missingkey=error]`, esquecer o campo num elemento novo quebra a geração de **toda** a Application daquele elemento. A maioria dos charts compartilha o namespace `uniplus` (mesmo bounded context — portal/selecao/ingresso/host, web, platform de apoio); `unifesspa-geo-api` é a exceção: aplicação independente com bounded context próprio (só compartilha o emissor OIDC com as demais APIs), roda no namespace `geo`.
 
 **Importante:** este mecanismo controla só se a `Application` é **gerada** pelo ArgoCD — não se o workload dentro dela está de fato ativo. Quando o chart tiver `<chart>.enabled: false` por padrão (caso de `uniplus-api-host`/`unifesspa-geo-api` hoje), uma `Application` gerada para um ambiente que não sobrescreve essa chave sincroniza com **zero recursos** (`Synced`/`Healthy`, sem `Deployment`/`Service`) até o ambiente ligar o chart explicitamente em `environments/<ambiente>/values.yaml`. O mesmo vale no sentido inverso — um chart cujo default seja `enabled: true` (caso de `uniplusWeb`) precisa de override explícito para `false` no ambiente que não deva rodá-lo ainda (é o que `hml-standalone-single` faz hoje com `uniplusWeb`, registrado no `matrix` sempre-ligado, mas desligado no overlay do ambiente). Em ambos os casos, habilitar a Application e habilitar o workload são duas decisões independentes.
 

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -32,27 +32,56 @@ argocd/
 
 `applicationset.yaml` contém **2 ApplicationSets**:
 
-1. **uniplus-apps** — gera Applications para cada chart em `apps/`:
-   - uniplus-web
-   - uniplus-api-portal
-   - uniplus-api-selecao
-   - uniplus-api-ingresso
-   - clamav-scanner
-   - keycloak-replica
+1. **uniplus-apps** — gera Applications para os charts em `apps/`. Dois grupos:
+   - **Sempre ligados** (todo cluster registrado): uniplus-web, uniplus-api-portal, uniplus-api-selecao, uniplus-api-ingresso, clamav-scanner, keycloak-replica, kafka-ui, apicurio-registry, redis-ui
+   - **Habilitados só em ambientes específicos** (mecanismo por-ambiente, ver seção abaixo): uniplus-api-host, unifesspa-geo-api — hoje só em `hml-standalone-single`
 
 2. **uniplus-platform** — gera Applications para componentes de plataforma:
    - storage, minio-console-proxy, traefik, cert-manager, external-secrets, vault, vault-transit, vault-transit-bootstrap
    - observability (prometheus, grafana, loki, tempo, otel-collector)
 
-Cada ApplicationSet usa **matrix generator** combinando:
+Cada ApplicationSet usa um ou mais **matrix generators** combinando:
 - Cada cluster registrado com label `uniplus.io/managed=true`
-- Cada componente (app ou platform)
+- Cada componente (app ou platform) — no grupo sempre-ligado, incondicionalmente; no grupo seletivo de `uniplus-apps` (ver "Habilitação por-ambiente" abaixo), só para o(s) ambiente(s) declarado(s) por chart
 
 E injeta **2 valueFiles**:
 - `values.yaml` (defaults do chart)
 - `environments/<environment>/values.yaml` (overrides do cluster)
 
 Os dois ApplicationSets declaram `spec.goTemplate: true` + `goTemplateOptions: [missingkey=error]`. Sem isso o controller cai em fasttemplate e renderiza literais como `{{.app}}`, `{{.metadata.labels.environment}}` e a função Sprig `replace` — todos os Applications gerados colidem no mesmo nome e o AppSet falha com `ApplicationValidationError`. Manter ao adicionar generators ou trocar a sintaxe dos templates.
+
+### Habilitação por-ambiente (quais charts existem em cada ambiente)
+
+A maioria dos apps em `apps/` deve virar `Application` em **todo** cluster registrado — é o `matrix` (clusters × list) padrão descrito acima. Alguns charts, porém, só fazem sentido num subconjunto dos ambientes (ex.: um chart cuja imagem ainda não foi publicada em produção, ou que só existe para um ambiente de homologação). Registrá-lo incondicionalmente poluiria os demais ambientes com uma `Application` sem propósito ali.
+
+O mecanismo — um segundo `matrix` generator dentro do MESMO ApplicationSet `uniplus-apps` — resolve isso sem hardcoded nenhum nome de chart na lógica de filtragem:
+
+```yaml
+- matrix:
+    generators:
+      # 1) o `list` PRECISA vir primeiro — ele produz `targetEnvironment`,
+      #    consumido pelo generator seguinte. Matrix passa parâmetros de um
+      #    generator filho para o próximo, mas só nesse sentido (produtor
+      #    antes do consumidor).
+      - list:
+          elements:
+            - app: uniplus-api-host
+              targetEnvironment: hml-standalone-single
+            - app: unifesspa-geo-api
+              targetEnvironment: hml-standalone-single
+      # 2) `clusters.selector.matchLabels` referencia `{{.targetEnvironment}}`
+      #    do elemento acima — só o cluster com esse `environment` label
+      #    sobrevive à combinação; nos demais, nenhuma Application nasce.
+      - clusters:
+          selector:
+            matchLabels:
+              uniplus.io/managed: "true"
+              environment: '{{.targetEnvironment}}'
+```
+
+**Para habilitar um chart num ambiente:** adicionar um elemento `{app: <chart>, targetEnvironment: <ambiente>}` na `list`. **Para habilitar o mesmo chart em mais de um ambiente:** repetir o elemento trocando só o `targetEnvironment`. Nenhuma edição em `clusters`/`selector` é necessária — o padrão já é genérico para qualquer combinação chart×ambiente.
+
+**Importante:** este mecanismo controla só se a `Application` é **gerada** pelo ArgoCD — não se o workload dentro dela está de fato ativo. Quando o chart tiver `<chart>.enabled: false` por padrão (caso de `uniplus-api-host`/`unifesspa-geo-api` hoje), uma `Application` gerada para um ambiente que não sobrescreve essa chave sincroniza com **zero recursos** (`Synced`/`Healthy`, sem `Deployment`/`Service`) até o ambiente ligar o chart explicitamente em `environments/<ambiente>/values.yaml`. O mesmo vale no sentido inverso — um chart cujo default seja `enabled: true` (caso de `uniplusWeb`) precisa de override explícito para `false` no ambiente que não deva rodá-lo ainda (é o que `hml-standalone-single` faz hoje com `uniplusWeb`, registrado no `matrix` sempre-ligado, mas desligado no overlay do ambiente). Em ambos os casos, habilitar a Application e habilitar o workload são duas decisões independentes.
 
 ## Aplicação
 

--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -22,6 +22,8 @@ spec:
   goTemplateOptions:
     - missingkey=error
   generators:
+    # Apps habilitados em todos os ambientes — combina cada cluster
+    # registrado com cada app desta lista, sem distinção por ambiente.
     - matrix:
         generators:
           # Cada cluster registrado
@@ -41,6 +43,30 @@ spec:
                 - app: kafka-ui
                 - app: apicurio-registry
                 - app: redis-ui
+    # Apps habilitados só em ambientes específicos — mecanismo genérico de
+    # habilitação por-ambiente (ver argocd/README.md § Habilitação por-ambiente).
+    # Cada elemento declara o chart + o(s) ambiente(s) (label `environment`
+    # do cluster) onde a Application deve ser gerada; o `list` generator
+    # produz `targetEnvironment`, consumido pelo `clusters` generator
+    # seguinte via `selector.matchLabels.environment` (matrix passa
+    # parâmetros de um generator filho para o próximo — o produtor precisa
+    # vir antes do consumidor). Para habilitar um chart em mais de um
+    # ambiente, repetir o elemento com `targetEnvironment` diferente; para
+    # habilitar um novo chart, adicionar um elemento novo — nenhum nome de
+    # chart é hardcoded na lógica de filtragem.
+    - matrix:
+        generators:
+          - list:
+              elements:
+                - app: uniplus-api-host
+                  targetEnvironment: hml-standalone-single
+                - app: unifesspa-geo-api
+                  targetEnvironment: hml-standalone-single
+          - clusters:
+              selector:
+                matchLabels:
+                  uniplus.io/managed: "true"
+                  environment: '{{.targetEnvironment}}'
 
   template:
     metadata:

--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -31,18 +31,30 @@ spec:
               selector:
                 matchLabels:
                   uniplus.io/managed: "true"
-          # Cada app em apps/
+          # Cada app em apps/. `namespace` é explícito por elemento (não um
+          # literal fixo no template) porque nem todo app deste ApplicationSet
+          # compartilha o mesmo namespace — ver bloco seletivo abaixo
+          # (unifesspa-geo-api usa `geo`, não `uniplus`).
           - list:
               elements:
                 - app: uniplus-web
+                  namespace: uniplus
                 - app: uniplus-api-portal
+                  namespace: uniplus
                 - app: uniplus-api-selecao
+                  namespace: uniplus
                 - app: uniplus-api-ingresso
+                  namespace: uniplus
                 - app: clamav-scanner
+                  namespace: uniplus
                 - app: keycloak-replica
+                  namespace: uniplus
                 - app: kafka-ui
+                  namespace: uniplus
                 - app: apicurio-registry
+                  namespace: uniplus
                 - app: redis-ui
+                  namespace: uniplus
     # Apps habilitados só em ambientes específicos — mecanismo genérico de
     # habilitação por-ambiente (ver argocd/README.md § Habilitação por-ambiente).
     # Cada elemento declara o chart + o(s) ambiente(s) (label `environment`
@@ -58,9 +70,16 @@ spec:
         generators:
           - list:
               elements:
+                # uniplus-api-host é composition root do mesmo bounded
+                # context de portal/selecao/ingresso — namespace `uniplus`.
                 - app: uniplus-api-host
+                  namespace: uniplus
                   targetEnvironment: hml-standalone-single
+                # unifesspa-geo-api é aplicação independente (bounded
+                # context próprio — só compartilha o emissor OIDC com as
+                # demais APIs) — namespace `geo`, não `uniplus`.
                 - app: unifesspa-geo-api
+                  namespace: geo
                   targetEnvironment: hml-standalone-single
           - clusters:
               selector:
@@ -95,7 +114,7 @@ spec:
           ref: values
       destination:
         server: '{{.server}}'
-        namespace: uniplus
+        namespace: '{{.namespace}}'
       syncPolicy:
         automated:
           prune: true

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -4061,25 +4061,27 @@ fechada, e confirmar via observação real do tráfego durante o primeiro bootst
 | `uniplus-hml...` | `/portal`, `/ingresso`, `/selecao` | `apps/uniplus-web` (3 Deployments) | Sim | **Código** — `templates/ingressroute.yaml` hoje só suporta `Host(...)` |
 | `uniplus-hml...` | `/publicacoes` | — | — | **Não criar rota** — não existe SPA de Publicações em `uniplus-web` ainda; ativar só quando o 4º Deployment existir |
 | `uniplus-api-hml...` | `/api/portal` | `apps/uniplus-api-portal` | Sim | **Código** — idem. Hoje o Portal só tem endpoint-esqueleto (`/api/portal/ping`) — API de negócio ainda não implementada |
-| `uniplus-api-hml...` | `/api/ingresso`, `/api/selecao`, `/api/publicacoes` | `apps/uniplus-api-host` (composition root — Selecao+Ingresso+Configuracao+OrganizacaoInstitucional+Publicacoes, [ADR-0097](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md)/[ADR-0105](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0105-modulo-publicacoes-registro-central-dos-atos.md) do `uniplus-api`) | Sim | **Código** (IngressRoute) + registrar no ApplicationSet (ver nota abaixo) + **imagem publicada** — não há build do Host publicado em GHCR ainda. `/api/ingresso` é reserva de rota: módulo Ingresso ainda sem controller HTTP implementado |
+| `uniplus-api-hml...` | `/api/ingresso`, `/api/selecao`, `/api/publicacoes` | `apps/uniplus-api-host` (composition root — Selecao+Ingresso+Configuracao+OrganizacaoInstitucional+Publicacoes, [ADR-0097](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md)/[ADR-0105](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0105-modulo-publicacoes-registro-central-dos-atos.md) do `uniplus-api`) | Sim (já suportado) | **Imagem publicada** — já registrado no ApplicationSet (story #457, ver nota abaixo) e o `templates/ingressroute.yaml` já suporta `ingress.pathPrefixes` (sem `StripPrefix`); falta só o build do Host em GHCR, então segue `enabled: false`. `/api/ingresso` é reserva de rota: módulo Ingresso ainda sem controller HTTP implementado |
 | `uniplus-oidc-hml...` | `/auth` | `apps/keycloak-replica` | Sim (já suportado) | Só `values.yaml` |
-| `geo-api-hml...` | `/` | `apps/unifesspa-geo-api` | Não | Só `values.yaml` + registrar no ApplicationSet (ver nota abaixo) |
+| `geo-api-hml...` | `/` | `apps/unifesspa-geo-api` | Não | Já registrado no ApplicationSet (story #457, ver nota abaixo); imagem publicada em GHCR — falta só `values.yaml` (`unifesspaGeoApi.enabled: true` + secrets do Vault, follow-up ainda sem issue própria) |
 | `grafana-hml...` | `/` | `platform/observability/grafana` | Não (`pathPrefix: ""`) | `values.yaml` — o template já suporta os dois modos (subpath e subdomínio); **falta provisionar o `Certificate`/`secretName`** que a IngressRoute referencia — o chart não cria o certificado sozinho |
 | `kafka-ui-hml...`, `apicurio-hml...`, `redis-ui-hml...`, `minio-hml...` | `/` | charts respectivos | Não | Só `values.yaml` |
 
-**Nota sobre o ApplicationSet:** registrar `apps/uniplus-api-host` e `apps/unifesspa-geo-api` em
-`argocd/applicationset.yaml` **não é uma mudança pontual**. O generator combina cada item da lista
-com **todo cluster gerenciado** — ou seja, adicionar os dois à lista compartilhada cria uma
-`Application` desses charts em **todo** cluster registrado, não só no futuro cluster HML. Como os
-dois charts vêm com `enabled: false` por default, o Helm renderiza zero manifests nos clusters que
-não sobrescreverem isso (ex. `standalone-compact`) — resultando em `Application`s vazias/no-op
-espalhadas por todo cluster que não precisa delas (ruído operacional no ArgoCD, não uma falha de
-sync — a proteção `allowEmpty: false` existe para impedir prune acidental de todos os recursos de
-uma Application que **já estava populada**, não para bloquear uma Application que nasce vazia por
-design). Ainda assim, esse ruído por si só já justifica não fazer a mudança pontual: este HML
-precisa de um mecanismo por ambiente (Applications específicas do cluster HML, ou overrides
-explícitos por cluster no generator) — desenho a definir antes da implementação, não resolvido por
-este documento.
+**Nota sobre o ApplicationSet:** `apps/uniplus-api-host` e `apps/unifesspa-geo-api` estão
+registrados em `argocd/applicationset.yaml` via o mecanismo de habilitação por-ambiente
+(story #457, documentado em [`argocd/README.md` § Habilitação por-ambiente](../argocd/README.md#habilitação-por-ambiente-quais-charts-existem-em-cada-ambiente)) —
+um segundo `matrix` generator (chart + `targetEnvironment`) só gera a `Application` desses 2
+charts para clusters cujo label `environment` seja `hml-standalone-single`; `standalone-compact` e
+`lab-standalone-single` não geram `Application` nenhuma para eles (regressão zero). Como os dois
+charts vêm com `enabled: false` por default e a `hml-standalone-single` não sobrescreve isso (ver
+`environments/hml-standalone-single/values.yaml`), a `Application` em HML sincroniza com zero
+manifests — `Synced`/`Healthy` sem `Deployment`/`Service`, mesmo padrão hoje usado por `uniplusWeb`
+nesse ambiente (a proteção `allowEmpty: false` existe para impedir prune acidental de todos os
+recursos de uma Application que **já estava populada**, não bloqueia uma Application que nasce
+vazia por design). Ligar o workload de fato é decisão independente, por chart: `uniplus-api-host`
+aguarda a primeira imagem publicada em GHCR; `unifesspa-geo-api` já tem imagem, mas aguarda o
+provisionamento dos secrets do Vault (follow-up ainda sem issue própria) antes de
+`unifesspaGeoApi.enabled: true`.
 
 **`uniplus-api-hml.../api/{ingresso,selecao,publicacoes}` é servido pelo `uniplus-api-host`, não
 pelos charts legados `apps/uniplus-api-{selecao,ingresso}`** — decisão deliberada, já que este HML
@@ -4179,9 +4181,6 @@ Registrado para rastreabilidade, não desenvolvido aqui — cada um é um docume
   manual de unseal/custódia de chaves), ou avaliar se há um Vault Transit alcançável em rede a
   partir desta VM que justifique auto-unseal — decisão técnica separada, fora do escopo deste
   documento.
-- **GitOps vs. bootstrap script** — registrar `apps/uniplus-api-host` e `apps/unifesspa-geo-api`
-  no `argocd/applicationset.yaml` não é pontual (ver nota em §21.3) — o desenho do mecanismo por
-  ambiente fica como decisão arquitetural separada, não resolvida aqui.
 - **K3s EOL** — `scripts/bootstrap-standalone.sh` pina `v1.31.4+k3s1` (Kubernetes 1.31 é EOL desde
   novembro/2025); atualização de versão é pré-requisito técnico do bootstrap, fora do escopo de
   DNS/roteamento deste documento.

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -4071,16 +4071,21 @@ fechada, e confirmar via observação real do tráfego durante o primeiro bootst
 registrados em `argocd/applicationset.yaml` via o mecanismo de habilitação por-ambiente
 (story #457, documentado em [`argocd/README.md` § Habilitação por-ambiente](../argocd/README.md#habilitação-por-ambiente-quais-charts-existem-em-cada-ambiente)) —
 um segundo `matrix` generator (chart + `targetEnvironment`) só gera a `Application` desses 2
-charts para clusters cujo label `environment` seja `hml-standalone-single`; `standalone-compact` e
-`lab-standalone-single` não geram `Application` nenhuma para eles (regressão zero). Como os dois
-charts vêm com `enabled: false` por default e a `hml-standalone-single` não sobrescreve isso (ver
-`environments/hml-standalone-single/values.yaml`), a `Application` em HML sincroniza com zero
-manifests — `Synced`/`Healthy` sem `Deployment`/`Service`, mesmo padrão hoje usado por `uniplusWeb`
-nesse ambiente (a proteção `allowEmpty: false` existe para impedir prune acidental de todos os
-recursos de uma Application que **já estava populada**, não bloqueia uma Application que nasce
-vazia por design). Ligar o workload de fato é decisão independente, por chart: `uniplus-api-host`
-aguarda a primeira imagem publicada em GHCR; `unifesspa-geo-api` já tem imagem, mas aguarda o
-provisionamento dos secrets do Vault (follow-up ainda sem issue própria) antes de
+charts para clusters cujo label `environment` seja `hml-standalone-single`; `standalone-compact`
+(único outro cluster ArgoCD-managed hoje) continua sem gerar `Application` para eles — regressão
+zero (`lab-standalone-single` nem entra na comparação: não tem cluster ArgoCD registrado, é
+aplicado manualmente via `helm install/upgrade -f`, fora do escopo deste ApplicationSet).
+`uniplus-api-host` roda no namespace `uniplus` (mesmo bounded context do Portal/Selecao/Ingresso);
+`unifesspa-geo-api` roda em namespace próprio, `geo` — aplicação independente, só compartilha o
+emissor OIDC com as demais APIs. Como os dois charts vêm com `enabled: false` por default e a
+`hml-standalone-single` não sobrescreve isso (ver `environments/hml-standalone-single/values.yaml`),
+a `Application` em HML sincroniza com zero manifests — `Synced`/`Healthy` sem `Deployment`/`Service`,
+mesmo padrão hoje usado por `uniplusWeb` nesse ambiente (a proteção `allowEmpty: false` existe para
+impedir prune acidental de todos os recursos de uma Application que **já estava populada**, não
+bloqueia uma Application que nasce vazia por design). Ligar o workload de fato é decisão
+independente, por chart: `uniplus-api-host` aguarda a primeira imagem publicada em GHCR;
+`unifesspa-geo-api` já tem imagem, mas aguarda o provisionamento dos secrets do Vault (follow-up
+ainda sem issue própria) antes de
 `unifesspaGeoApi.enabled: true`.
 
 **`uniplus-api-hml.../api/{ingresso,selecao,publicacoes}` é servido pelo `uniplus-api-host`, não

--- a/docs/validacao/incidente-dns-coredns-hml-2026-07-15.md
+++ b/docs/validacao/incidente-dns-coredns-hml-2026-07-15.md
@@ -1,0 +1,111 @@
+# Incidente: DNS interno inalcançável bloqueou GitOps no `hml-standalone-single`
+
+> **Contexto:** verificação ao vivo do PR #471 (uniplus-infra, story #457/#458/#459 — mecanismo de
+> habilitação por-ambiente no ApplicationSet). Ao conectar na VM para observar o efeito real do PR,
+> encontrado um incidente **não relacionado** ao PR que já estava em andamento: todas as 22
+> `Application`s do ArgoCD estavam com `sync.status: Unknown` havia mais de 1 dia.
+>
+> **Data:** 2026-07-15 · **VM:** `hml-standalone-single` (`192.168.21.134`)
+
+## Resultado: causa raiz identificada e mitigada — GitOps normalizado
+
+## 1. Sintoma
+
+```
+kubectl -n argocd get applications -o custom-columns='NAME:.metadata.name,SYNC:.status.sync.status,HEALTH:.status.health.status'
+```
+
+Todas as 22 `Application`s (9 `apps/` + 13 `platform/`) com `SYNC: Unknown`, `HEALTH: Healthy`
+(saúde cacheada do último estado bom conhecido). Condição reportada em cada `Application`:
+
+```
+Failed to load target state: failed to generate manifest for source 1 of 2: rpc error:
+code = Unknown desc = failed to list refs:
+Get "https://github.com/unifesspa-edu-br/uniplus-infra/info/refs?service=git-upload-pack":
+dial tcp: lookup github.com on 10.43.0.10:53: server misbehaving
+```
+
+O ArgoCD repo-server não conseguia resolver `github.com` — nenhuma `Application` conseguia
+comparar contra o Git, então nada progredia (nem as já existentes, nem as 2 novas do PR #471).
+
+## 2. Diagnóstico
+
+Descartadas por evidência direta (1-2), causa raiz confirmada por eliminação + teste direto (3-4):
+
+1. **NetworkPolicy bloqueando egress do CoreDNS** — `kubectl -n kube-system get networkpolicy`
+   retornou vazio. Não é isso.
+2. **Flannel não fazendo SNAT do tráfego pod→LAN** — `iptables -t nat -L FLANNEL-POSTRTG -n -v`
+   mostrou a regra `MASQUERADE 10.42.0.0/16 !224.0.0.0/4` ativa e com contadores altos; um pod de
+   teste alcançou o gateway (`192.168.21.254`) normalmente (0,7ms, 0% perda). Não é isso.
+3. **`192.168.21.13` (servidor DNS interno IPv4 da UNIFESSPA) estava inalcançável desta VM** —
+   confirmado via `ping` **direto do host** (não só de pod): `Destination Host Unreachable` (nível
+   de rede/roteamento, não timeout de firewall). O gateway (`192.168.21.254`) respondia normal.
+4. O host continuava resolvendo DNS porque `systemd-resolved` **preferia o nameserver IPv6**
+   (`2001:12f0:d88::894`, resolveu `github.com` em 52ms via `dig`). Os **pods não têm rota IPv6
+   nenhuma** (Flannel/K3s aqui é IPv4-only — só endereços link-local `fe80::` nas interfaces
+   `cni0`/`flannel.1`) — quando o único nameserver IPv4 configurado caiu, o CoreDNS ficou sem
+   nenhuma rota funcional, mesmo o host tendo internet normal.
+
+`resolvectl status` confirmou os 3 nameservers efetivamente usados pelo host (herdados também
+pelo CoreDNS via `/run/systemd/resolve/resolv.conf`, não o stub `127.0.0.53`):
+`192.168.21.13`, `2001:12f0:d88::894`, `2001:12f0:d8c:200::36`.
+
+Confirmado que pods alcançam a internet pública em geral (`ping`/`nslookup` contra `1.1.1.1`
+funcionaram, ~49ms) — não é um ambiente sem saída à internet, só o servidor DNS interno específico
+que estava fora do ar.
+
+## 3. Mitigação aplicada
+
+`ConfigMap coredns` (namespace `kube-system`) — `forward` alterado de `/etc/resolv.conf` (lista
+herdada do host, sem controle de política) para uma lista explícita com fallback público
+sequencial:
+
+```diff
+-    forward . /etc/resolv.conf
++    forward . 192.168.21.13 1.1.1.1 1.0.0.1 {
++        policy sequential
++    }
+```
+
+- `policy sequential` mantém `192.168.21.13` como primeira tentativa sempre — quando ele voltar,
+  volta a ser usado automaticamente (preserva resolução de nomes internos da UNIFESSPA quando
+  esse servidor também os atender).
+- Cai para os públicos (`1.1.1.1`/`1.0.0.1`, Cloudflare) só quando o interno falhar.
+- As 2 entradas IPv6 foram removidas da lista — inúteis para os pods hoje (sem rota), só
+  atrasavam cada tentativa de resolução com "network unreachable".
+- Backup do `ConfigMap` original salvo em `/tmp/coredns-cm-backup-20260715-200343.yaml` **na
+  própria VM** (não versionado — este documento é o registro).
+- Aplicado via `kubectl apply`; o plugin `reload` do CoreDNS (já presente no Corefile) detectou a
+  mudança e recarregou em ~30-45s, sem restart do pod (confirmado via `[INFO] Reloading complete`
+  nos logs).
+
+## 4. Resultado
+
+Após o reload, `nslookup github.com` de um pod de teste resolveu (`4.228.31.150`). Refresh forçado
+(`argocd.argoproj.io/refresh=normal`) em todas as `Application`s — as 22 voltaram a
+`SYNC: Synced`, `HEALTH: Healthy`.
+
+Achado colateral relevante para o PR #471: `uniplus-web-in-cluster` (registrado sempre-ligado, mas
+com `uniplusWeb.enabled: false` no overlay deste ambiente) sincronizou como `Synced`/`Healthy` com
+**0 recursos gerenciados** — confirma ao vivo, e não só por relatório anterior, que uma
+`Application` cujo chart renderiza vazio não é bloqueada por `syncPolicy.automated.allowEmpty:
+false` (essa proteção existe para impedir prune acidental de uma Application que **já tinha**
+recursos, não para recusar uma que nasce vazia por design). É a mesma premissa usada no desenho do
+mecanismo de habilitação por-ambiente do PR #471 para `uniplus-api-host`/`unifesspa-geo-api`.
+
+## 5. Pendências / follow-up
+
+- **Fora do escopo Kubernetes:** por que `192.168.21.13` ficou inalcançável — é infraestrutura de
+  rede da UNIFESSPA (possível problema de VPN/roteamento específico para esse host), não algo
+  corrigível a partir do cluster. Reportado à Divisão de Redes/CTIC (Idelvandro) por email.
+- **Mitigação é paliativa, não definitiva:** enquanto `192.168.21.13` seguir instável, nomes
+  *internos* exclusivos da UNIFESSPA (não resolvíveis publicamente) continuarão falhando quando o
+  fallback público for usado — isso não afetou o ArgoCD (só depende de `github.com`, público), mas
+  pode afetar outro componente que dependa de resolução interna.
+- **Sem rota IPv6 para pods** é uma característica estrutural do cluster (Flannel IPv4-only) e não
+  foi alterada — permanece como gap conhecido, não corrigido aqui (mudança de maior porte,
+  precisaria de planejamento próprio se algum dia for necessário dual-stack).
+- Verificar, após o merge do PR #471, que `uniplus-api-host-in-cluster` e
+  `unifesspa-geo-api-in-cluster` aparecem como novas `Application`s (`Synced`/`Healthy`, 0
+  recursos, namespaces `uniplus` e `geo` respectivamente) — não observado ainda porque o PR não
+  estava mergeado no momento desta sessão.

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -7,8 +7,11 @@
 # ambiente é **gerenciado continuamente pelo ArgoCD**
 # (`argocd/applicationset.yaml`, label `uniplus.io/managed=true`,
 # `environment: hml-standalone-single`) — o generator combina o cluster
-# registrado com TODOS os 9 apps + 14 componentes de platform, aplicando
-# este arquivo como overlay em TODOS eles, não só nos referenciados abaixo.
+# registrado com os 9 apps sempre-ligados + os apps habilitados só neste
+# ambiente via o mecanismo de habilitação por-ambiente (`uniplus-api-host` e
+# `unifesspa-geo-api`, ver `argocd/README.md` — story #457) + 14 componentes
+# de platform, aplicando este arquivo como overlay em TODOS eles, não só nos
+# referenciados abaixo.
 #
 # Isso muda a regra do jogo em relação ao lab: qualquer chart cujo default
 # seja `enabled: true` e que não pertença ao escopo desta fase PRECISA de
@@ -32,11 +35,19 @@
 # Deliberadamente FORA de escopo (Features 2-4 do Epic #434 ainda não têm
 # base de código pronta — ver `docs/RUNBOOKS.md §21.3`, coluna "Mudança
 # necessária: Código"):
-#   - uniplusApiHost / uniplusApiPortal / unifesspaGeoApi — sem imagem
-#     publicada em GHCR (Feature 3). Também evita o problema de que o
-#     certificado autoassinado real desta VM só existe DEPOIS do bootstrap
-#     (#442/#445) — os apps .NET precisariam de `customCA.certPEM`, que não
-#     pode ser fabricado agora.
+#   - uniplusApiHost — registrado no ApplicationSet (story #457), mas chart
+#     default é `enabled: false` e assim permanece aqui: sem imagem
+#     publicada em GHCR ainda (Feature 3). A Application sincroniza vazia
+#     (mesmo padrão de uniplusWeb abaixo) até a imagem existir e o chart ser
+#     ligado.
+#   - unifesspaGeoApi — registrado no ApplicationSet (story #457); imagem já
+#     publicada em GHCR, mas `enabled: false` aqui até o provisionamento dos
+#     secrets (Vault: postgres/geo, redis, geo/encryption) e a decisão do
+#     hostname de ingress — follow-up ainda sem issue própria.
+#   - uniplusApiPortal — já registrado, imagem publicada, mas TLS real desta
+#     VM depende do certificado autoassinado gerado no bootstrap
+#     (#442/#445) — os apps .NET precisariam de `customCA.certPEM`,
+#     acompanhar quando o app for de fato ligado neste ambiente.
 #   - uniplusWeb — default `enabled: true` no chart; desligado explicitamente
 #     abaixo. Mesma falta de suporte a `PathPrefix`/subpath (Feature 2) +
 #     trabalho cross-repo em `uniplus-web` (Feature 4).


### PR DESCRIPTION
## Contexto

`apps/uniplus-api-host` e `apps/unifesspa-geo-api` existem no repo mas não estavam registrados em `argocd/applicationset.yaml`. Adicioná-los à lista compartilhada do `matrix` sempre-ligado criaria `Application`s desses 2 charts em **todo** cluster gerenciado (incluindo `standalone-compact` e `lab-standalone-single`), sem propósito ali.

## O que muda

Um segundo `matrix` generator dentro do ApplicationSet `uniplus-apps` (`argocd/applicationset.yaml`) registra esses 2 charts só nos ambientes declarados por chart — hoje, `hml-standalone-single`:

- `list` generator produz `{app, targetEnvironment}` por elemento
- `clusters` generator (em seguida, consumindo o parâmetro) filtra por `selector.matchLabels.environment: '{{.targetEnvironment}}'`

Nenhum nome de chart fica hardcoded na lógica de filtragem — habilitar um novo chart, ou o mesmo chart em outro ambiente, é só um elemento novo na `list`. Padrão de passagem de parâmetro entre generators filhos do `matrix`, documentado oficialmente pelo ArgoCD.

`standalone-compact` e `lab-standalone-single` continuam sem gerar `Application` para esses 2 charts — **regressão zero**.

## Sobre os workloads (não é o escopo desta mudança)

Isso só controla se a `Application` é **gerada**, não se o workload está ativo. Os 2 charts mantêm `<chart>.enabled: false` (default) — a `Application` em `hml-standalone-single` vai sincronizar com **zero recursos** (`Synced`/`Healthy`, sem `Deployment`/`Service`), o mesmo padrão hoje usado por `uniplusWeb` nesse ambiente. Confirmado que `syncPolicy.automated.allowEmpty: false` não bloqueia esse caso — ele existe para impedir prune acidental de uma `Application` que já tinha recursos, não para bloquear uma que nasce vazia por design (empiricamente confirmado: `uniplusWeb` já está nesse estado hoje em HML, `Synced`/`Healthy`).

Ligar os workloads de fato é follow-up separado, por chart:
- `uniplus-api-host` — aguarda a primeira imagem publicada em GHCR (não existe ainda)
- `unifesspa-geo-api` — imagem já publicada, mas aguarda provisionamento dos secrets do Vault (postgres/geo, redis, geo/encryption) e decisão do hostname de ingress

## Documentação

- `argocd/README.md` — nova seção "Habilitação por-ambiente" explicando o mecanismo com exemplo, e correção da lista de apps (estava desatualizada, listava 6 de 9)
- `docs/RUNBOOKS.md` §21.3/21.5 — nota que antecipava este mecanismo ("desenho a definir... não resolvido por este documento") atualizada para referenciar a implementação; tabela de roteamento corrigida (Host já suporta `pathPrefixes`, contrário ao que constava)
- `environments/hml-standalone-single/values.yaml`, `apps/unifesspa-geo-api/values.yaml` — comentários que ficariam desatualizados/incorretos após esta mudança, corrigidos (inclusive uma referência à issue #395, que era sobre outro ambiente)

## Validação

- `make validate` (yaml-lint + helm-lint + markdown-lint + schema-validate) — verde
- `helm template` manual confirmando que os 2 charts renderizam 0 manifests com `enabled: false` (comportamento documentado, não é falha)
- Revisão de plano e de diff via `codex exec` (2 rodadas — achados aplicados: referência à issue errada removida, nota desatualizada do chart Geo corrigida, bullet órfão removido do RUNBOOKS, wording generalizado)
- **Não testado** contra o ArgoCD real de `hml-standalone-single`/`standalone-compact` (exigiria SSH numa VM institucional ao vivo) — o padrão usado é idêntico ao exemplo oficial documentado do ArgoCD para passagem de parâmetros entre generators do `matrix`

## Critérios de aceite

- [x] `standalone-compact` continua sem gerar Applications para os 2 charts
- [x] `hml-standalone-single` gera as Applications quando registrado
- [x] Mecanismo genérico o bastante para qualquer chart/ambiente, não hardcoded a estes 2
- [x] Documentado em `argocd/README.md`

Closes #458
Closes #459
Closes #457