### PR TITLE
fix(uniplus-web): injeta base href do pathPrefix

### DIFF
--- a/apps/uniplus-web/README.md
+++ b/apps/uniplus-web/README.md
@@ -52,7 +52,7 @@ templates/
 | `apps.portal.enabled` | `true` | Habilita Portal |
 | `apps.portal.replicas` | `2` | Réplicas do Portal |
 | `apps.portal.host` | `""` | Hostname público do app (obrigatório quando ingress habilitado) |
-| `apps.portal.pathPrefix` | `""` | Subpath opcional (Host + PathPrefix, sem StripPrefix). Vazio → `Host()` puro; o chart injeta o valor normalizado em `APP_BASE_HREF` |
+| `apps.portal.pathPrefix` | `""` | Subpath opcional (Host + PathPrefix, sem StripPrefix). Vazio → `Host()` puro; `/portal` e `/portal/` são normalizados para o mesmo mount point e `APP_BASE_HREF` |
 | `apps.selecao.*` | similar | Mesma estrutura para Seleção |
 | `apps.ingresso.*` | similar | Mesma estrutura para Ingresso |
 | `ingress.host` | `uniplus.unifesspa.edu.br` | Hostname público |

--- a/apps/uniplus-web/README.md
+++ b/apps/uniplus-web/README.md
@@ -52,7 +52,7 @@ templates/
 | `apps.portal.enabled` | `true` | Habilita Portal |
 | `apps.portal.replicas` | `2` | Réplicas do Portal |
 | `apps.portal.host` | `""` | Hostname público do app (obrigatório quando ingress habilitado) |
-| `apps.portal.pathPrefix` | `""` | Subpath opcional (Host + PathPrefix, sem StripPrefix). Vazio → `Host()` puro |
+| `apps.portal.pathPrefix` | `""` | Subpath opcional (Host + PathPrefix, sem StripPrefix). Vazio → `Host()` puro; o chart injeta o valor normalizado em `APP_BASE_HREF` |
 | `apps.selecao.*` | similar | Mesma estrutura para Seleção |
 | `apps.ingresso.*` | similar | Mesma estrutura para Ingresso |
 | `ingress.host` | `uniplus.unifesspa.edu.br` | Hostname público |

--- a/apps/uniplus-web/templates/deployment.yaml
+++ b/apps/uniplus-web/templates/deployment.yaml
@@ -4,12 +4,14 @@
 {{- if not $cfg.image -}}
 {{- fail (printf "uniplusWeb.apps.%s.image é obrigatório (nome da imagem em ghcr.io/unifesspa-edu-br/, ex.: uniplus-portal)." $app) -}}
 {{- end }}
-{{- if and $cfg.pathPrefix (not (regexMatch "^/([A-Za-z0-9_-]+/)*[A-Za-z0-9_-]*$" $cfg.pathPrefix)) -}}
+{{- $pathPrefix := default "" $cfg.pathPrefix -}}
+{{- if and $pathPrefix (not (regexMatch "^/([A-Za-z0-9_-]+/)*[A-Za-z0-9_-]*$" $pathPrefix)) -}}
 {{- fail (printf "uniplusWeb.apps.%s.pathPrefix deve ser vazio, / ou um caminho absoluto com segmentos alfanuméricos, hífen ou underscore (ex.: /portal ou /selecao/hml)." $app) -}}
 {{- end }}
+{{- $normalizedPathPrefix := trimSuffix "/" $pathPrefix -}}
 {{- $baseHref := "/" -}}
-{{- if $cfg.pathPrefix -}}
-{{- $baseHref = printf "%s/" (trimSuffix "/" $cfg.pathPrefix) -}}
+{{- if $normalizedPathPrefix -}}
+{{- $baseHref = printf "%s/" $normalizedPathPrefix -}}
 {{- end -}}
 {{/*
   `host` NÃO é validado aqui — só é consumido por ingressroute.yaml e

--- a/apps/uniplus-web/templates/deployment.yaml
+++ b/apps/uniplus-web/templates/deployment.yaml
@@ -4,6 +4,13 @@
 {{- if not $cfg.image -}}
 {{- fail (printf "uniplusWeb.apps.%s.image é obrigatório (nome da imagem em ghcr.io/unifesspa-edu-br/, ex.: uniplus-portal)." $app) -}}
 {{- end }}
+{{- if and $cfg.pathPrefix (not (regexMatch "^/([A-Za-z0-9_-]+/)*[A-Za-z0-9_-]*$" $cfg.pathPrefix)) -}}
+{{- fail (printf "uniplusWeb.apps.%s.pathPrefix deve ser vazio, / ou um caminho absoluto com segmentos alfanuméricos, hífen ou underscore (ex.: /portal ou /selecao/hml)." $app) -}}
+{{- end }}
+{{- $baseHref := "/" -}}
+{{- if $cfg.pathPrefix -}}
+{{- $baseHref = printf "%s/" (trimSuffix "/" $cfg.pathPrefix) -}}
+{{- end -}}
 {{/*
   `host` NÃO é validado aqui — só é consumido por ingressroute.yaml e
   certificate.yaml, que disparam o `fail` por conta própria quando
@@ -63,6 +70,12 @@ spec:
           imagePullPolicy: {{ $.Values.uniplusWeb.image.pullPolicy }}
           securityContext:
             {{- toYaml $.Values.uniplusWeb.containerSecurityContext | nindent 12 }}
+          # A imagem Nginx substitui a tag <base> a partir desta variável.
+          # `pathPrefix` vazio mantém standalone/lab na raiz; um prefixo é
+          # normalizado com barra final para resolver assets e deep links.
+          env:
+            - name: APP_BASE_HREF
+              value: {{ $baseHref | quote }}
           ports:
             - name: http
               containerPort: 8080

--- a/apps/uniplus-web/templates/ingressroute.yaml
+++ b/apps/uniplus-web/templates/ingressroute.yaml
@@ -4,6 +4,7 @@
 {{- if not $cfg.host -}}
 {{- fail (printf "uniplusWeb.apps.%s.host é obrigatório quando uniplusWeb.ingress.enabled=true (ex.: %s.standalone.portaluni.com.br). IngressRoute Traefik exige Host(...) válido." $app $app) -}}
 {{- end }}
+{{- $pathPrefix := trimSuffix "/" (default "" $cfg.pathPrefix) -}}
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
@@ -18,7 +19,7 @@ spec:
     # PathPrefix opcional, sem StripPrefix — permite servir múltiplas SPAs sob o
     # mesmo FQDN por subpath (`/portal`, `/selecao`, `/ingresso`). Vazio → `Host()`
     # puro (comportamento atual). Ver docs/RUNBOOKS.md §21.3.
-    - match: Host(`{{ $cfg.host }}`){{ if $cfg.pathPrefix }} && PathPrefix(`{{ $cfg.pathPrefix }}`){{ end }}
+    - match: Host(`{{ $cfg.host }}`){{ if $pathPrefix }} && PathPrefix(`{{ $pathPrefix }}`){{ end }}
       kind: Rule
       services:
         - name: {{ include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app) }}

--- a/apps/uniplus-web/templates/ingressroute.yaml
+++ b/apps/uniplus-web/templates/ingressroute.yaml
@@ -4,7 +4,6 @@
 {{- if not $cfg.host -}}
 {{- fail (printf "uniplusWeb.apps.%s.host é obrigatório quando uniplusWeb.ingress.enabled=true (ex.: %s.standalone.portaluni.com.br). IngressRoute Traefik exige Host(...) válido." $app $app) -}}
 {{- end }}
-{{- $pathPrefix := trimSuffix "/" (default "" $cfg.pathPrefix) -}}
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
@@ -19,7 +18,7 @@ spec:
     # PathPrefix opcional, sem StripPrefix — permite servir múltiplas SPAs sob o
     # mesmo FQDN por subpath (`/portal`, `/selecao`, `/ingresso`). Vazio → `Host()`
     # puro (comportamento atual). Ver docs/RUNBOOKS.md §21.3.
-    - match: Host(`{{ $cfg.host }}`){{ if $pathPrefix }} && PathPrefix(`{{ $pathPrefix }}`){{ end }}
+    - match: Host(`{{ $cfg.host }}`){{ if and $cfg.pathPrefix (ne $cfg.pathPrefix "/") }} && PathPrefix(`{{ trimSuffix "/" $cfg.pathPrefix }}`){{ end }}
       kind: Rule
       services:
         - name: {{ include "uniplusWeb.appFullname" (dict "ctx" $ "app" $app) }}

--- a/apps/uniplus-web/values.yaml
+++ b/apps/uniplus-web/values.yaml
@@ -72,8 +72,8 @@ uniplusWeb:
       host: ""  # ex.: portal.standalone.portaluni.com.br
       # Subpath opcional (Host + PathPrefix, sem StripPrefix) — RUNBOOKS §21.3.
       # Vazio/ausente → rota `Host()` pura (preserva standalone-compact/lab).
-      # Servir SPA sob subpath exige ajustes cross-repo no uniplus-web
-      # (base-href, nginx, redirects OIDC) — Feature #436. Ex. HML: /portal
+      # O chart propaga o valor normalizado como APP_BASE_HREF (<prefixo>/)
+      # para a imagem uniplus-web. Ex. HML: /portal
       pathPrefix: ""
       # Conteúdo escrito em /assets/runtime-config.json via ConfigMap.
       # Schema é a interface AppConfig em libs/shared-data/lib/config/


### PR DESCRIPTION
## Contexto

Complementa a correção de deep links em [uniplus-web#463](https://github.com/unifesspa-edu-br/uniplus-web/pull/463).

## Alterações

- injeta `APP_BASE_HREF` a partir de `uniplusWeb.apps.<app>.pathPrefix`;
- normaliza o valor com barra final e preserva `/` quando o prefixo está vazio;
- valida o formato do prefixo antes de renderizar o Deployment;
- documenta o contrato Helm-imagem.

## Validação

- `make validate`;
- renderização Helm para raiz, `/portal` e prefixo inválido.