### PR TITLE
fix(hml): restringe permissões dos kubeconfigs

### DIFF
--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -231,20 +231,19 @@ step_install_k3s() {
 
         # --disable traefik/servicelb: platform/traefik/ (ArgoCD, pós-registro)
         # é o IngressController real deste ambiente — o Traefik/ServiceLB
-        # bundled do K3s competiria pelo bind 80/443. --write-kubeconfig-mode
-        # 644: kubeconfig legível sem sudo, mesmo padrão de
-        # scripts/lab-standalone-single/bootstrap.sh e scripts/bootstrap-standalone.sh.
+        # bundled do K3s competiria pelo bind 80/443. O kubeconfig contém
+        # credenciais administrativas: restringi-lo a root e copiar uma
+        # versão privada para o operador autorizado abaixo.
         run "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=$K3S_VERSION sh -s - \
             --node-name uniplus-hml \
             --tls-san $NODE_IP \
             --disable servicelb \
             --disable traefik \
-            --write-kubeconfig-mode 644"
+            --write-kubeconfig-mode 600"
     fi
 
-    run "mkdir -p $HOME/.kube"
-    run "sudo cp /etc/rancher/k3s/k3s.yaml $HOME/.kube/config"
-    run "sudo chown $(id -u):$(id -g) $HOME/.kube/config"
+    run "install -d -m 700 $HOME/.kube"
+    run "sudo install -m 600 -o $(id -u) -g $(id -g) /etc/rancher/k3s/k3s.yaml $HOME/.kube/config"
     log_success "K3s pronto."
 }
 

--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -723,6 +723,8 @@ summary() {
     echo "  systemctl status uniplus-{postgres,kafka}"
     echo ""
     echo "K3s + ArgoCD:"
+    echo "  # Em uma nova sessão de operador, usar o kubeconfig privado:"
+    echo "  export KUBECONFIG=$HOME/.kube/config"
     echo "  kubectl get nodes"
     echo "  kubectl get pods -n argocd"
     echo "  kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d"

--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -242,6 +242,11 @@ step_install_k3s() {
             --write-kubeconfig-mode 600"
     fi
 
+    # Em reexecuções, o K3s pode ter sido instalado por uma versão anterior
+    # do bootstrap que usava modo 0644. Não depender apenas da flag do
+    # instalador mantém o kubeconfig administrativo restrito também nesses
+    # hosts já existentes.
+    run "sudo chmod 600 /etc/rancher/k3s/k3s.yaml"
     run "install -d -m 700 $HOME/.kube"
     run "sudo install -m 600 -o $(id -u) -g $(id -g) /etc/rancher/k3s/k3s.yaml $HOME/.kube/config"
     log_success "K3s pronto."


### PR DESCRIPTION
## Contexto

O dry-run real do HML identificou kubeconfigs administrativos em modo `0644`, expondo credenciais do cluster a outros usuários locais.

## Alterações

- configura o K3s com `--write-kubeconfig-mode 600`;
- cria `~/.kube` com modo `0700`;
- instala a cópia do kubeconfig do operador com proprietário explícito e modo `0600`.

## Validação

- `make validate`;
- `bash -n scripts/hml-standalone-single/bootstrap.sh`;
- dry-run na VM `192.168.21.134`, usando o usuário `jeferson`;
- correção aplicada na VM sem reiniciar K3s: ambos os kubeconfigs em `0600`, diretório do operador em `0700`, `kubectl` via `KUBECONFIG=~/.kube/config` e pods do ArgoCD saudáveis.

Closes #474