### PR TITLE
docs(routing): documenta prefixo do api portal

### DIFF
--- a/apps/uniplus-api-portal/README.md
+++ b/apps/uniplus-api-portal/README.md
@@ -2,7 +2,7 @@
 
 API .NET 10 do módulo Portal — conteúdo institucional e perfis
 
-> ⚠️ **Status:** placeholder inicial. Implementação dos templates pendente.
+> **Status:** chart funcional para implantação GitOps do Portal.
 
 ## Visão geral
 
@@ -14,17 +14,32 @@ Componente da plataforma Uni+. Veja [docs/ARCHITECTURE.md](../../docs/ARCHITECTU
 - Helm 3.x
 - Vault + External Secrets Operator (para secrets)
 
-## Implementação pendente
+## Roteamento path-based
 
-- [ ] templates/deployment.yaml
-- [ ] templates/service.yaml
-- [ ] templates/ingressroute.yaml (se exposto externamente)
-- [ ] templates/configmap.yaml
-- [ ] templates/externalsecret.yaml
-- [ ] templates/networkpolicy.yaml
-- [ ] templates/servicemonitor.yaml
+Para expor a API do Portal junto de outros serviços sob o mesmo FQDN, configure
+`uniplusApiPortal.ingress.pathPrefix`. O chart cria uma regra Traefik
+`Host() && PathPrefix()` sem middleware de `StripPrefix`: o controller do
+Portal recebe o caminho completo, incluindo `/api/portal`.
 
-Veja [apps/uniplus-web](../uniplus-web/) como referência para estrutura.
+```yaml
+uniplusApiPortal:
+  ingress:
+    enabled: true
+    host: uniplus-api-hml.192.168.21.134.nip.io
+    pathPrefix: /api/portal
+```
+
+`pathPrefix` é opcional. Vazio ou ausente mantém a rota `Host()` pura dos
+ambientes existentes, sem alteração no caminho encaminhado ao serviço.
+
+## Variáveis principais
+
+| Variável | Default | Notas |
+|---|---|---|
+| `uniplusApiPortal.ingress.enabled` | `false` | Habilita a criação do IngressRoute Traefik |
+| `uniplusApiPortal.ingress.host` | `""` | Hostname obrigatório quando o ingresso está habilitado |
+| `uniplusApiPortal.ingress.pathPrefix` | `""` | Subpath opcional. Preenchido gera `Host() && PathPrefix()` sem `StripPrefix`; vazio mantém `Host()` puro |
+| `uniplusApiPortal.ingress.tls.enabled` | `true` | Referencia o Secret TLS configurado para o ambiente |
 
 ## Contribuindo
 


### PR DESCRIPTION
Atualiza o README do chart uniplus-api-portal: remove o status incorreto de placeholder e documenta ingress.pathPrefix com exemplo HML, compatibilidade sem prefixo e TLS. O suporte funcional Host + PathPrefix sem StripPrefix já está em main; esta entrega fecha o critério de documentação da issue. Validado com renderizações Helm, make helm-deps, make lint, make schema-validate e revisão do diff. Risco baixo: somente documentação. Closes #451