### PR TITLE
fix(argocd): permite repos Helm da plataforma

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -23,7 +23,8 @@ argocd/
 
 `project.yaml` define um AppProject chamado `uniplus` que:
 
-- Permite repos da org `unifesspa-edu-br`
+- Permite os repositórios Git da org `unifesspa-edu-br` e os repositórios Helm
+  upstream explicitamente usados pelos charts da plataforma
 - Restringe destinos a este cluster
 - Define roles RBAC (ctic-admin, developer)
 - Bloqueia ResourceQuota/NetworkPolicy de virem do Git (gerenciados localmente)

--- a/argocd/project.yaml
+++ b/argocd/project.yaml
@@ -11,6 +11,16 @@ spec:
     - https://github.com/unifesspa-edu-br/uniplus-infra
     - https://github.com/unifesspa-edu-br/uniplus-web
     - https://github.com/unifesspa-edu-br/uniplus-api
+    # Repositórios upstream das dependências Helm declaradas pelos charts da
+    # plataforma. Manter a lista explícita evita ampliar a permissão com
+    # curingas e permite ao ArgoCD reconstruir as dependências quando preciso.
+    - https://charts.external-secrets.io
+    - https://charts.jetstack.io
+    - https://grafana.github.io/helm-charts
+    - https://helm.releases.hashicorp.com
+    - https://open-telemetry.github.io/opentelemetry-helm-charts
+    - https://prometheus-community.github.io/helm-charts
+    - https://traefik.github.io/charts
 
   destinations:
     - namespace: '*'


### PR DESCRIPTION
## O que muda

Inclui explicitamente no `AppProject` `uniplus` todos os repositórios Helm
upstream declarados pelos charts da plataforma.

## Por quê

As Applications de Vault e Prometheus não conseguiam gerar manifests no HML porque os repositórios de dependência dos charts wrapper não estavam autorizados em `spec.sourceRepos`. A revisão identificou que as demais dependências da plataforma exigem a mesma permissão explícita para uma reconstrução futura.

## Impacto e risco

Restaura a reconciliação GitOps para as origens upstream já usadas pelos charts versionados. Não altera destinos, namespaces, RBAC ou usa curingas.

## Validação

- `make validate`
- conferência de que cada `repository:` em `platform/**/Chart.yaml` está presente em `spec.sourceRepos`
- revisão do diff: somente `argocd/project.yaml`

Após o merge, o `AppProject` deve ser aplicado no HML com `kubectl apply -f argocd/project.yaml`; então Vault e Prometheus devem passar para `Synced/Healthy`.

Closes #481
