### PR TITLE
feat(hml): aponta ambiente para hostnames reais e liga o portal

### DIFF
--- a/apps/keycloak-replica/templates/realm-reconcile-job.yaml
+++ b/apps/keycloak-replica/templates/realm-reconcile-job.yaml
@@ -102,8 +102,12 @@ spec:
               value: "{{ .Values.keycloak.realmReconcile.availabilityCheckTimeout | default "120s" }}"
             # Caminho do realm.json montado via ConfigMap (mesmo arquivo
             # consumido pelo --import-realm inicial em deployment.yaml).
+            # Nome do arquivo segue realmImport.realmName (ver
+            # configmap-realm.yaml) — hardcoded pra "uniplus-realm.json"
+            # quebrava o Job sempre que um ambiente sobrescrevia o nome do
+            # realm (ex. hml-standalone-single usa "unifesspa").
             - name: IMPORT_FILES_LOCATIONS
-              value: "/realm/uniplus-realm.json"
+              value: "/realm/{{ .Values.keycloak.realmImport.realmName }}-realm.json"
             # ${VAR} no realm.json (ex.: ${UNIPLUS_PORTAL_CLIENT_SECRET})
             # é substituído por env vars do Pod — mesmo pattern do KC.
             - name: IMPORT_VARSUBSTITUTION_ENABLED

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -201,9 +201,10 @@ cert-manager:
 # ============================================================================
 # Traefik (chart platform/traefik/) — hostPort 80+443 bindam direto na VM
 # real (mesmo padrão do lab/standalone-compact). TLS autoassinado
-# provisório (secret `uniplus-wildcard-nip-io-tls`, criado manualmente via
-# `kubectl create secret tls` durante o bootstrap #442/#445 — não é
-# gerenciado pelo cert-manager nem versionado no Git, mesmo padrão do lab).
+# provisório (secret `uniplus-hml-unifesspa-tls`, criado manualmente via
+# `kubectl create secret tls` durante o bootstrap #442/#445 e regenerado
+# com SANs reais na issue #486 — não é gerenciado pelo cert-manager nem
+# versionado no Git, mesmo padrão do lab).
 # redirections: null mantém :80 servindo em paralelo, útil para smoke tests
 # via curl sem exigir secure context.
 # ============================================================================
@@ -323,24 +324,25 @@ uniplusApiHost:
     endpoint: 192.168.21.134:9000
 
   oidc:
-    issuerUri: https://keycloak.192.168.21.134.nip.io/auth/realms/uniplus
+    issuerUri: https://uniplus-oidc-hml.unifesspa.edu.br/auth/realms/unifesspa
 
   customCA:
     enabled: true
     # Lê o mesmo certificado público usado pelo Traefik. Assim, recriar ou
     # rotacionar o Secret TLS não deixa uma cópia PEM obsoleta no Git.
-    existingSecretName: uniplus-wildcard-nip-io-tls
+    existingSecretName: uniplus-hml-unifesspa-tls
     existingSecretKey: tls.crt
 
   cors:
     allowedOrigins:
-      # O Web HML usa o mesmo host com PathPrefix (/portal, /selecao e
-      # /ingresso). CORS compara somente esquema, host e porta — nunca o
-      # path — portanto esta é a origem efetiva das três SPAs.
-      - https://uniplus-hml.192.168.21.134.nip.io
-      - https://portal.192.168.21.134.nip.io
-      - https://selecao.192.168.21.134.nip.io
-      - https://ingresso.192.168.21.134.nip.io
+      # As 3 SPAs (portal/selecao/ingresso) vivem sob o MESMO host com
+      # PathPrefix (/portal, /selecao, /ingresso — RUNBOOKS §21.2/§21.3),
+      # não em subdomínios próprios. CORS compara só esquema+host+porta,
+      # nunca o path, então esta é a única origem efetiva das três —
+      # `portal.*`/`selecao.*`/`ingresso.*` do valor anterior eram
+      # subdomínios que nunca existiram nesta topologia (nem em nip.io,
+      # nem nos 9 hostnames registrados pela CTIC — RUNBOOKS §21.2).
+      - https://uniplus-hml.unifesspa.edu.br
 
   encryption:
     provider: local
@@ -355,7 +357,7 @@ uniplusApiHost:
   ingress:
     enabled: true
     entryPoint: websecure
-    host: uniplus-api-hml.192.168.21.134.nip.io
+    host: uniplus-api-hml.unifesspa.edu.br
     pathPrefixes:
       - /api/ingresso
       - /api/selecao
@@ -365,7 +367,7 @@ uniplusApiHost:
       - /openapi
     tls:
       enabled: true
-      secretName: uniplus-wildcard-nip-io-tls
+      secretName: uniplus-hml-unifesspa-tls
 
   networkPolicy:
     enabled: true

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -231,12 +231,11 @@ traefik:
 # KC_HOSTNAME; divergência quebra o fluxo de login OIDC (redirect_uri
 # mismatch / iss inesperado).
 #
-# realmImport.portalClient fica com os defaults do chart (redirectUris
-# vazio) — sem consumidor real enquanto uniplusWeb não roda nesta fase;
-# Feature 2/4 preenche quando ligar o frontend. realmImport.apicurioClient
-# É sobrescrito abaixo — diferente do portal, o Apicurio roda nesta fase, e
-# sem o override o client OIDC herdaria o hostname do standalone-compact
-# (default do chart), rejeitando o login pela UI deste ambiente.
+# realmImport.portalClient e realmImport.apicurioClient são sobrescritos
+# abaixo (issue #486, uniplusWeb.apps.portal ligado) — sem o override,
+# ambos os clients OIDC herdariam os defaults do chart (redirectUris vazio
+# no portal; hostname do standalone-compact no Apicurio), rejeitando o
+# login pela UI/callback deste ambiente.
 # ============================================================================
 keycloak:
   enabled: true

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -42,9 +42,11 @@
 #     VM depende do certificado autoassinado gerado no bootstrap
 #     (#442/#445) — os apps .NET precisariam de `customCA.certPEM`,
 #     acompanhar quando o app for de fato ligado neste ambiente.
-#   - uniplusWeb — default `enabled: true` no chart; desligado explicitamente
-#     abaixo. Mesma falta de suporte a `PathPrefix`/subpath (Feature 2) +
-#     trabalho cross-repo em `uniplus-web` (Feature 4).
+#   - uniplusWeb — só o app `portal` ligado (issue #486), servido na raiz do
+#     host `uniplus-hml.unifesspa.edu.br` (sem `pathPrefix`) como smoke test
+#     do pipeline de deploy. `selecao`/`ingresso` continuam desligados, e
+#     nenhum dos três usa `PathPrefix`/subpath ainda — depende de
+#     `uniplus-web#447`/`#448`/`#449` (Feature 4, ainda abertas).
 #   - cert-manager, Vault Transit (auto-unseal), Vault Transit Bootstrap
 #     (engine transit local p/ idempotência do uniplus-api — sem consumidor
 #     enquanto uniplusApiHost não roda aqui), observabilidade completa
@@ -243,16 +245,16 @@ keycloak:
     host: 192.168.21.134
 
   hostname:
-    url: https://keycloak.192.168.21.134.nip.io/auth
+    url: https://uniplus-oidc-hml.unifesspa.edu.br/auth
     strict: false
 
   ingress:
     enabled: true
     entryPoint: websecure
-    host: keycloak.192.168.21.134.nip.io
+    host: uniplus-oidc-hml.unifesspa.edu.br
     tls:
       enabled: true
-      secretName: uniplus-wildcard-nip-io-tls
+      secretName: uniplus-hml-unifesspa-tls
 
   networkPolicy:
     enabled: true
@@ -266,16 +268,36 @@ keycloak:
     enabled: true
 
   realmImport:
+    # Alinha com o nome de realm já usado localmente (uniplus-web e
+    # uniplus-api têm realm-export.json com "realm": "unifesspa") e com o
+    # Keycloak institucional de produção que este ambiente vai eventualmente
+    # substituir. O realm anterior ("uniplus") fica órfão no Postgres do
+    # Keycloak após esta troca — `--import-realm` só roda no primeiro boot
+    # por realm (gotcha documentado em feedback_keycloak_realm_reconcile_gated),
+    # então o realm novo é importado no próximo restart do pod (o checksum
+    # do ConfigMap muda com esta edição), sem afetar o realm antigo, que
+    # segue existindo até uma limpeza manual futura.
+    realmName: unifesspa
+    # Portal está ligado nesta fase (issue #486) — sem isso o client
+    # uniplus-portal herda o default do chart (redirectUris vazio) e o
+    # Keycloak rejeita o callback OIDC com invalid redirect_uri.
+    portalClient:
+      clientId: uniplus-portal
+      rootUrl: https://uniplus-hml.unifesspa.edu.br
+      redirectUris:
+        - https://uniplus-hml.unifesspa.edu.br/*
+      webOrigins:
+        - https://uniplus-hml.unifesspa.edu.br
     # Sem isso, o client apicurio-registry herdaria o default do chart
     # (hostname do standalone-compact) — login pela UI do Apicurio neste
     # HML seria rejeitado pelo Keycloak (redirect_uri/origin não batem).
     apicurioClient:
       clientId: apicurio-registry
       redirectUris:
-        - https://apicurio.192.168.21.134.nip.io/*
-        - https://apicurio.192.168.21.134.nip.io/ui/*
+        - https://apicurio-hml.unifesspa.edu.br/*
+        - https://apicurio-hml.unifesspa.edu.br/ui/*
       webOrigins:
-        - https://apicurio.192.168.21.134.nip.io
+        - https://apicurio-hml.unifesspa.edu.br
 
 # ============================================================================
 # uniplus-api-host — Host dos módulos internos Seleção, Ingresso,
@@ -368,7 +390,7 @@ apicurioRegistry:
     host: 192.168.21.134
 
   oidc:
-    issuerUri: https://keycloak.192.168.21.134.nip.io/auth/realms/uniplus
+    issuerUri: https://uniplus-oidc-hml.unifesspa.edu.br/auth/realms/unifesspa
 
   # Quarkus rejeita o certificado autoassinado do Keycloak ao buscar o JWKS
   # sem isso ("OIDC Server is not available"). trust-all é aceitável só
@@ -381,10 +403,10 @@ apicurioRegistry:
   ingress:
     enabled: true
     entryPoint: websecure
-    host: apicurio.192.168.21.134.nip.io
+    host: apicurio-hml.unifesspa.edu.br
     tls:
       enabled: true
-      secretName: uniplus-wildcard-nip-io-tls
+      secretName: uniplus-hml-unifesspa-tls
 
   networkPolicy:
     enabled: true
@@ -405,12 +427,43 @@ apicurioRegistry:
     enabled: false # sem Prometheus Operator habilitado nesta fase
 
 # ============================================================================
-# Fora de escopo desta fase — desligados explicitamente porque o
-# ApplicationSet os habilitaria por default (enabled=true no chart) assim
-# que o cluster for registrado. Ver "Escopo desta fase" no topo do arquivo.
+# uniplus-web (chart apps/uniplus-web/) — só o app portal, servido na RAIZ
+# do host (sem pathPrefix). Smoke test do pipeline de deploy: valida que o
+# chart/IngressRoute/TLS funcionam ponta-a-ponta contra um hostname real.
+# `selecao`/`ingresso` continuam desligados (default do chart), e portal
+# continua sem pathPrefix — uniplus-web#448 (nginx.conf parametrizado por
+# subpath) ainda está aberta; servir sob `/portal` quebraria
+# runtime-config.json/silent-check-sso.html (âncoras sem prefixo no
+# nginx.conf hoje). Ativar pathPrefix quando #447/#448/#449 fecharem.
 # ============================================================================
 uniplusWeb:
-  enabled: false
+  enabled: true
+
+  apps:
+    portal:
+      enabled: true
+      host: uniplus-hml.unifesspa.edu.br
+      runtimeConfig:
+        # uniplus-api-portal ainda não está ligado nesta fase (TLS real
+        # depende do customCA do certificado autoassinado — ver "Escopo
+        # desta fase" no topo do arquivo) — chamadas à API vão falhar em
+        # runtime até lá. URL segue a convenção de roteamento já reservada
+        # em docs/RUNBOOKS.md §21.2 (host uniplus-api-hml, path /api/portal);
+        # apiUrl vazio não é aceito pelo chart (ADR-0021 assertNaoEhPlaceholder).
+        apiUrl: https://uniplus-api-hml.unifesspa.edu.br/api/portal
+        keycloak:
+          url: https://uniplus-oidc-hml.unifesspa.edu.br/auth
+          realm: unifesspa
+          clientId: uniplus-portal
+
+  ingress:
+    enabled: true
+    entryPoint: websecure
+    tls:
+      enabled: true
+      secretName: uniplus-hml-unifesspa-tls
+      certManager:
+        enabled: false
 
 kubePrometheusStack:
   enabled: false

--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -72,7 +72,11 @@ DRY_RUN=false
 
 DATA_BASE="/var/lib/uniplus"
 TLS_NAMESPACE="uniplus"
-TLS_SECRET_NAME="uniplus-wildcard-nip-io-tls"
+TLS_SECRET_NAME="uniplus-hml-unifesspa-tls"
+# 9 hostnames de docs/RUNBOOKS.md §21.2, já registrados pela CTIC
+# (issue #486) — substitui o SAN provisório *.${NODE_IP}.nip.io usado
+# antes do DNS real existir.
+TLS_SANS="DNS:uniplus-hml.unifesspa.edu.br,DNS:uniplus-api-hml.unifesspa.edu.br,DNS:uniplus-oidc-hml.unifesspa.edu.br,DNS:geo-api-hml.unifesspa.edu.br,DNS:grafana-hml.unifesspa.edu.br,DNS:kafka-ui-hml.unifesspa.edu.br,DNS:apicurio-hml.unifesspa.edu.br,DNS:redis-ui-hml.unifesspa.edu.br,DNS:minio-hml.unifesspa.edu.br"
 
 # ============== Logging ==============
 RED='\033[0;31m'
@@ -656,9 +660,10 @@ step_setup_kafka() {
 # obrigatório antes de qualquer usuário real, aceitável como paliativo de
 # bring-up administrativo). Mesmo procedimento manual documentado em
 # environments/lab-standalone-single/README.md, scriptado e tornado
-# idempotente — Traefik/Keycloak/Apicurio Registry (ApplicationSet, pós-
-# registro no ArgoCD) esperam o Secret `uniplus-wildcard-nip-io-tls` já
-# existente no namespace `uniplus` na primeira sincronização.
+# idempotente — Traefik/Keycloak/Apicurio Registry/uniplus-web
+# (ApplicationSet, pós-registro no ArgoCD) esperam o Secret
+# `$TLS_SECRET_NAME` já existente no namespace `uniplus` na primeira
+# sincronização.
 #
 # Diferente do lab: aqui NÃO copiamos o PEM para nenhum values.yaml (a
 # fundação desta Story não inclui os apps .NET que precisariam de
@@ -672,7 +677,7 @@ step_generate_tls_secret() {
 
     if $DRY_RUN; then
         echo "[DRY-RUN] kubectl create namespace $TLS_NAMESPACE (idempotente)"
-        echo "[DRY-RUN] openssl req -x509 -newkey rsa:2048 ... SAN=*.${NODE_IP}.nip.io"
+        echo "[DRY-RUN] openssl req -x509 -newkey rsa:2048 ... SAN=$TLS_SANS"
         echo "[DRY-RUN] kubectl create secret tls $TLS_SECRET_NAME -n $TLS_NAMESPACE (se ainda não existir)"
         return
     fi
@@ -700,8 +705,8 @@ step_generate_tls_secret() {
 
         openssl req -x509 -newkey rsa:2048 -nodes \
             -keyout "$tmpdir/tls.key" -out "$tmpdir/tls.crt" -days 825 \
-            -subj "/CN=uniplus-hml" \
-            -addext "subjectAltName=DNS:*.${NODE_IP}.nip.io,DNS:${NODE_IP}.nip.io" \
+            -subj "/CN=uniplus-hml.unifesspa.edu.br" \
+            -addext "subjectAltName=$TLS_SANS" \
             >/dev/null 2>&1
 
         kubectl create secret tls "$TLS_SECRET_NAME" \
@@ -709,7 +714,7 @@ step_generate_tls_secret() {
             --dry-run=client -o yaml | kubectl apply -f -
     )
 
-    log_warn "Certificado autoassinado gerado (SAN: *.${NODE_IP}.nip.io) — chave privada descartada após criar o Secret."
+    log_warn "Certificado autoassinado gerado (SAN: $TLS_SANS) — chave privada descartada após criar o Secret."
     log_success "Secret $TLS_SECRET_NAME criado em $TLS_NAMESPACE."
 
     # O Host mescla a CA no trust store durante o initContainer. Quando uma


### PR DESCRIPTION
## Contexto

A CTIC já registrou os 9 hostnames de `docs/RUNBOOKS.md §21.2` — confirmado ao vivo via `getent hosts` a partir da VM (`192.168.21.134`), todos resolvendo pro IP correto. Este PR tira o `hml-standalone-single` da fase "provisório via `*.nip.io`".

## O que muda

1. **Keycloak, Apicurio Registry e uniplus-api-host** trocam de `*.192.168.21.134.nip.io` para `*.unifesspa.edu.br` (hosts de ingress, `oidc.issuerUri`/`hostname.url`, `cors.allowedOrigins`). `uniplus-api-host` entrou no escopo depois de um rebase trazer `uniplusApiHost.enabled: true` (PR #480, mergeado enquanto este PR estava em progresso) — o Codex AI pegou 2 P1 reais nisso (issuer velho, Secret TLS velho), corrigidos.
2. **Realm do Keycloak renomeado de `uniplus` para `unifesspa`** — alinha com o `realm-export.json` já usado localmente em `uniplus-web`/`uniplus-api` (ambos já usam `"realm": "unifesspa"`), em preparação para a futura integração com o Keycloak institucional de produção.
3. **`uniplus-web` ligado — só o app `portal`**, servido na raiz de `uniplus-hml.unifesspa.edu.br` (sem `pathPrefix`), como smoke test do pipeline de deploy. `selecao`/`ingresso` continuam desligados; nenhum usa `pathPrefix` ainda porque `uniplus-web#448` (nginx.conf parametrizado por subpath) segue aberta — servir sob `/portal` quebraria `runtime-config.json`/`silent-check-sso.html` (âncoras sem prefixo no nginx.conf atual).
4. **Certificado TLS** renomeado de `uniplus-wildcard-nip-io-tls` para `uniplus-hml-unifesspa-tls`, `bootstrap.sh` atualizado para gerar o certificado autoassinado já com SANs dos 9 hostnames reais (evita que um re-bootstrap futuro recrie o Secret velho).
5. **Fix de chart**: `realm-reconcile-job.yaml` lia sempre `/realm/uniplus-realm.json` (hardcoded); parametrizado por `realmImport.realmName` — sem isso o Job quebraria em qualquer ambiente que sobrescreva o nome do realm.
6. **CORS do uniplus-api-host**: a lista antiga tinha 3 origens de subdomínio (`portal.*`, `selecao.*`, `ingresso.*`) que nunca existiram nesta topologia — as 3 SPAs vivem sob o mesmo host com `PathPrefix`. Reduzida à única origem real.

## Passos operacionais fora deste diff (coordenados com o merge)

- [ ] **Regenerar o Secret `uniplus-hml-unifesspa-tls` na VM** via SSH, cobrindo os SANs reais (script já preparado, roda o mesmo procedimento do `bootstrap.sh` atualizado). TLS confiável (Let's Encrypt/ICPEdu/PKI) segue pendente — Feature 6/CTIC.
- [ ] **Atualizar o client secret OIDC do `apicurio-registry` no Vault** (`secret/standalone/keycloak/clients/apicurio-registry`) — o realm novo (`unifesspa`) gera um client confidencial novo com secret próprio.
- [ ] **Atualizar o client secret OIDC do `uniplus-api-host` no Vault** (`secret/standalone/keycloak/clients/uniplus-api-host`, service account M2M → Apicurio SR) — mesmo problema, achado durante a correção dos P1 do Codex AI.
- [ ] Deletar o Secret `uniplus-wildcard-nip-io-tls` órfão após confirmar o novo funcionando.
- [ ] Realm antigo (`uniplus`) fica órfão no Postgres do Keycloak — limpeza manual futura, não bloqueia esta troca.

## Validação local

- `make helm-lint`, `make helm-template`, `make schema-validate`, `make yaml-lint`, `make markdown-lint` — verdes
- Render conferido manualmente: `IngressRoute` de Keycloak/Apicurio/uniplus-web/uniplus-api-host com os hosts corretos, `runtime-config.json` do portal com `apiUrl`/`keycloak.url`/`realm` corretos
- 2 rodadas de revisão via Codex CLI local (3 P1 + 1 P1/P3 corrigidos) + 1 rodada do Codex AI no PR (2 P1 corrigidos, threads resolvidos)

Refs #434
Closes #486