### PR TITLE
feat(hml): liga selecao e ingresso, migra portal pro prefixo real

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -29,7 +29,9 @@
 #
 # Habilitados: Vault, External Secrets Operator, Traefik+TLS (autoassinado,
 # provisório — ADR/RUNBOOKS §21.2 item 2), Keycloak, Apicurio Registry,
-# StorageClass e uniplusApiHost. Kafka roda fora do K8s (systemd no data-host,
+# StorageClass, uniplusApiHost e uniplusWeb (portal + selecao + ingresso,
+# issue #488) — os 3 sob PathPrefix real (`/portal`, `/selecao`,
+# `/ingresso`) no mesmo host. Kafka roda fora do K8s (systemd no data-host,
 # escopo do script de bootstrap #442), mas permanece desativado no Host nesta
 # primeira publicação.
 #
@@ -42,11 +44,8 @@
 #     VM depende do certificado autoassinado gerado no bootstrap
 #     (#442/#445) — os apps .NET precisariam de `customCA.certPEM`,
 #     acompanhar quando o app for de fato ligado neste ambiente.
-#   - uniplusWeb — só o app `portal` ligado (issue #486), servido na raiz do
-#     host `uniplus-hml.unifesspa.edu.br` (sem `pathPrefix`) como smoke test
-#     do pipeline de deploy. `selecao`/`ingresso` continuam desligados, e
-#     nenhum dos três usa `PathPrefix`/subpath ainda — depende de
-#     `uniplus-web#447`/`#448`/`#449` (Feature 4, ainda abertas).
+#   - (removido — uniplusWeb saiu do "fora de escopo"; os 3 apps estão
+#     habilitados, ver bloco `uniplusWeb` abaixo e issue #488)
 #   - cert-manager, Vault Transit (auto-unseal), Vault Transit Bootstrap
 #     (engine transit local p/ idempotência do uniplus-api — sem consumidor
 #     enquanto uniplusApiHost não roda aqui), observabilidade completa
@@ -428,14 +427,14 @@ apicurioRegistry:
     enabled: false # sem Prometheus Operator habilitado nesta fase
 
 # ============================================================================
-# uniplus-web (chart apps/uniplus-web/) — só o app portal, servido na RAIZ
-# do host (sem pathPrefix). Smoke test do pipeline de deploy: valida que o
-# chart/IngressRoute/TLS funcionam ponta-a-ponta contra um hostname real.
-# `selecao`/`ingresso` continuam desligados (default do chart), e portal
-# continua sem pathPrefix — uniplus-web#448 (nginx.conf parametrizado por
-# subpath) ainda está aberta; servir sob `/portal` quebraria
-# runtime-config.json/silent-check-sso.html (âncoras sem prefixo no
-# nginx.conf hoje). Ativar pathPrefix quando #447/#448/#449 fecharem.
+# uniplus-web (chart apps/uniplus-web/) — os 3 apps (portal/selecao/ingresso)
+# ligados, cada um sob seu PathPrefix real (/portal, /selecao, /ingresso) no
+# mesmo host, sem StripPrefix (RUNBOOKS §21.3). uniplus-web#448 (nginx.conf
+# parametrizado por subpath) fechou via PR uniplus-web#556 — o base href
+# autofechado do build do Angular 21 não casava no sub_filter original,
+# corrigido e validado com docker build+run+curl. Imagem v0.2.2 (issue #488).
+# #447 (logout redireciona pro subpath) e #449 (validação E2E) da Feature
+# #444 seguem abertas, não bloqueiam este deploy.
 # ============================================================================
 uniplusWeb:
   enabled: true

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -440,10 +440,19 @@ apicurioRegistry:
 uniplusWeb:
   enabled: true
 
+  # Tag override: uniplus-web#448 (nginx.conf parametrizado por subpath)
+  # fechou via PR uniplus-web#556, publicado em v0.2.2 — mais recente que o
+  # default do chart (v0.2.1). Pin explícito aqui, não no chart, pra não
+  # afetar standalone-compact (segue no default até bump deliberado
+  # próprio). Ver issue #488.
   apps:
     portal:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
+      # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
+      # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
+      pathPrefix: /portal
+      tag: v0.2.2
       runtimeConfig:
         # uniplus-api-portal ainda não está ligado nesta fase (TLS real
         # depende do customCA do certificado autoassinado — ver "Escopo
@@ -452,6 +461,35 @@ uniplusWeb:
         # em docs/RUNBOOKS.md §21.2 (host uniplus-api-hml, path /api/portal);
         # apiUrl vazio não é aceito pelo chart (ADR-0021 assertNaoEhPlaceholder).
         apiUrl: https://uniplus-api-hml.unifesspa.edu.br/api/portal
+        keycloak:
+          url: https://uniplus-oidc-hml.unifesspa.edu.br/auth
+          realm: unifesspa
+          clientId: uniplus-portal
+
+    selecao:
+      enabled: true
+      host: uniplus-hml.unifesspa.edu.br
+      pathPrefix: /selecao
+      tag: v0.2.2
+      runtimeConfig:
+        # /api/selecao já roteado no uniplus-api-host (pathPrefixes acima) —
+        # backend real, diferente do portal.
+        apiUrl: https://uniplus-api-hml.unifesspa.edu.br/api/selecao
+        keycloak:
+          url: https://uniplus-oidc-hml.unifesspa.edu.br/auth
+          realm: unifesspa
+          clientId: uniplus-portal
+
+    ingresso:
+      enabled: true
+      host: uniplus-hml.unifesspa.edu.br
+      pathPrefix: /ingresso
+      tag: v0.2.2
+      runtimeConfig:
+        # /api/ingresso roteado no uniplus-api-host, mas o módulo Ingresso
+        # ainda não tem controller HTTP implementado (RUNBOOKS §21.3) —
+        # chamadas à API vão 404 até lá; host é real, só falta o backend.
+        apiUrl: https://uniplus-api-hml.unifesspa.edu.br/api/ingresso
         keycloak:
           url: https://uniplus-oidc-hml.unifesspa.edu.br/auth
           realm: unifesspa

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -454,13 +454,15 @@ uniplusWeb:
       pathPrefix: /portal
       tag: v0.2.2
       runtimeConfig:
-        # uniplus-api-portal ainda não está ligado nesta fase (TLS real
-        # depende do customCA do certificado autoassinado — ver "Escopo
-        # desta fase" no topo do arquivo) — chamadas à API vão falhar em
-        # runtime até lá. URL segue a convenção de roteamento já reservada
-        # em docs/RUNBOOKS.md §21.2 (host uniplus-api-hml, path /api/portal);
-        # apiUrl vazio não é aceito pelo chart (ADR-0021 assertNaoEhPlaceholder).
-        apiUrl: https://uniplus-api-hml.unifesspa.edu.br/api/portal
+        # apiUrl é só a origem — os apps já montam o path com o prefixo do
+        # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
+        # (/api/portal/api/portal/...). Mesmo padrão de
+        # environments/lab-standalone-single/values.yaml. uniplus-api-portal
+        # ainda não está ligado nesta fase (TLS real depende do customCA do
+        # certificado autoassinado — ver "Escopo desta fase" no topo do
+        # arquivo) — chamadas à API vão falhar em runtime até lá. apiUrl
+        # vazio não é aceito pelo chart (ADR-0021 assertNaoEhPlaceholder).
+        apiUrl: https://uniplus-api-hml.unifesspa.edu.br
         keycloak:
           url: https://uniplus-oidc-hml.unifesspa.edu.br/auth
           realm: unifesspa
@@ -472,9 +474,10 @@ uniplusWeb:
       pathPrefix: /selecao
       tag: v0.2.2
       runtimeConfig:
-        # /api/selecao já roteado no uniplus-api-host (pathPrefixes acima) —
-        # backend real, diferente do portal.
-        apiUrl: https://uniplus-api-hml.unifesspa.edu.br/api/selecao
+        # apiUrl é só a origem (ver comentário do portal acima) — o app já
+        # monta /api/selecao/... no cliente. Backend real: já roteado no
+        # uniplus-api-host (pathPrefixes acima).
+        apiUrl: https://uniplus-api-hml.unifesspa.edu.br
         keycloak:
           url: https://uniplus-oidc-hml.unifesspa.edu.br/auth
           realm: unifesspa
@@ -486,10 +489,11 @@ uniplusWeb:
       pathPrefix: /ingresso
       tag: v0.2.2
       runtimeConfig:
-        # /api/ingresso roteado no uniplus-api-host, mas o módulo Ingresso
-        # ainda não tem controller HTTP implementado (RUNBOOKS §21.3) —
-        # chamadas à API vão 404 até lá; host é real, só falta o backend.
-        apiUrl: https://uniplus-api-hml.unifesspa.edu.br/api/ingresso
+        # apiUrl é só a origem (ver comentário do portal acima) — o app já
+        # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
+        # mas o módulo Ingresso ainda não tem controller HTTP implementado
+        # (RUNBOOKS §21.3) — chamadas à API vão 404 até lá.
+        apiUrl: https://uniplus-api-hml.unifesspa.edu.br
         keycloak:
           url: https://uniplus-oidc-hml.unifesspa.edu.br/auth
           realm: unifesspa


### PR DESCRIPTION
## Contexto

`uniplus-web#448` fechou via PR unifesspa-edu-br/uniplus-web#556 (fix real: base href autofechado do Angular 21 não casava no `sub_filter` original — validado com docker build+run+curl). Imagem `v0.2.2` publicada no GHCR (3 packages: uniplus-portal, uniplus-web-selecao, uniplus-web-ingresso).

Isso desbloqueia o desenho final de `docs/RUNBOOKS.md §21.3`: os 3 apps sob o mesmo host, cada um com `PathPrefix` real, sem `StripPrefix`.

## O que muda

- `portal` migra do smoke provisório na raiz (issue #486) pro `PathPrefix: /portal`
- `selecao` e `ingresso` ligados, `/selecao` e `/ingresso` respectivamente
- Tag `v0.2.2` pinada só neste ambiente (`environments/hml-standalone-single/values.yaml`), não no chart — `standalone-compact` segue no default até bump próprio
- `apiUrl` do `selecao` aponta pro `/api/selecao` real (já roteado no `uniplus-api-host`); `apiUrl` do `ingresso` aponta pro `/api/ingresso` (rota existe, módulo ainda sem controller HTTP — 404 esperado até lá)

## Validação local

- `make helm-lint`, `make helm-template`, `make schema-validate`, `make yaml-lint` — verdes
- Render conferido: 3 `IngressRoute`s com `Host() && PathPrefix()` corretos, tags `v0.2.2` nas 3 imagens

Refs #434
Closes #488