### PR TITLE
fix(uniplus-web): renderiza runtime-config.json no contrato OIDC neutro

### DIFF
--- a/apps/uniplus-web/templates/configmap-runtime.yaml
+++ b/apps/uniplus-web/templates/configmap-runtime.yaml
@@ -4,14 +4,17 @@
 {{- if not $cfg.runtimeConfig.apiUrl -}}
 {{- fail (printf "uniplusWeb.apps.%s.runtimeConfig.apiUrl é obrigatório (URL pública da API correspondente, ex.: https://api-%s.standalone.portaluni.com.br). Sem URL real, runtime-config.json contém placeholder e o app aborta o bootstrap (ADR-0021 assertNaoEhPlaceholder)." $app $app) -}}
 {{- end -}}
+{{- if not $cfg.runtimeConfig.oidc.issuerUrl -}}
+{{- fail (printf "uniplusWeb.apps.%s.runtimeConfig.oidc.issuerUrl é obrigatório (URL completa do realm, ex.: https://standalone.portaluni.com.br/auth/realms/uniplus)." $app) -}}
+{{- end -}}
+{{- if not $cfg.runtimeConfig.oidc.clientId -}}
+{{- fail (printf "uniplusWeb.apps.%s.runtimeConfig.oidc.clientId é obrigatório (ex.: uniplus-portal)." $app) -}}
+{{- end -}}
 {{- if not $cfg.runtimeConfig.keycloak.url -}}
-{{- fail (printf "uniplusWeb.apps.%s.runtimeConfig.keycloak.url é obrigatório (URL do realm Keycloak, ex.: https://standalone.portaluni.com.br/auth)." $app) -}}
+{{- fail (printf "uniplusWeb.apps.%s.runtimeConfig.keycloak.url é obrigatório — mantido em paralelo a oidc.issuerUrl enquanto standalone-compact/lab rodam v0.2.1 (pré-contrato neutro)." $app) -}}
 {{- end -}}
 {{- if not $cfg.runtimeConfig.keycloak.realm -}}
 {{- fail (printf "uniplusWeb.apps.%s.runtimeConfig.keycloak.realm é obrigatório (ex.: uniplus)." $app) -}}
-{{- end -}}
-{{- if not $cfg.runtimeConfig.keycloak.clientId -}}
-{{- fail (printf "uniplusWeb.apps.%s.runtimeConfig.keycloak.clientId é obrigatório (ex.: uniplus-portal)." $app) -}}
 {{- end }}
 ---
 # ConfigMap montado sobre /usr/share/nginx/html/assets/runtime-config.json
@@ -21,6 +24,16 @@
 # bumps de ConfigMap chegam imediatamente ao browser sem rolling restart
 # do pod (mas restart não dói — `data.runtime-config.json` muda hash do
 # objeto, ConfigMap reload é automático via subPath no volume).
+#
+# Renderiza os dois formatos de OIDC em paralelo — "oidc" (contrato
+# neutro, uniplus-web commit 9884c64, 2026-05-31) e "keycloak" (formato
+# anterior). standalone-compact/lab seguem pinados em v0.2.1 (chart
+# default), publicada ANTES da mudança de contrato — o binário dessa tag
+# só entende "keycloak". HML já roda v0.2.2+, que só lê "oidc". Um campo
+# extra e desconhecido no JSON não quebra nenhum dos dois lados
+# (`resolveOidcConfig` em app-config.model.ts só valida a chave que usa).
+# Remover "keycloak" quando standalone-compact/lab também migrarem pra
+# uma tag pós-contrato-neutro.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -31,10 +44,14 @@ data:
   runtime-config.json: |
     {
       "apiUrl": {{ $cfg.runtimeConfig.apiUrl | quote }},
+      "oidc": {
+        "issuerUrl": {{ $cfg.runtimeConfig.oidc.issuerUrl | quote }},
+        "clientId": {{ $cfg.runtimeConfig.oidc.clientId | quote }}
+      },
       "keycloak": {
         "url": {{ $cfg.runtimeConfig.keycloak.url | quote }},
         "realm": {{ $cfg.runtimeConfig.keycloak.realm | quote }},
-        "clientId": {{ $cfg.runtimeConfig.keycloak.clientId | quote }}
+        "clientId": {{ $cfg.runtimeConfig.oidc.clientId | quote }}
       }
     }
 {{- end }}

--- a/apps/uniplus-web/values.yaml
+++ b/apps/uniplus-web/values.yaml
@@ -80,10 +80,17 @@ uniplusWeb:
       # app-config.model.ts do uniplus-web (ADR-0021).
       runtimeConfig:
         apiUrl: ""  # ex.: https://api-portal.standalone.portaluni.com.br
+        # Contrato neutro (uniplus-web commit 9884c64): oidc.issuerUrl já
+        # inclui o path do realm. keycloak.{url,realm} mantido em paralelo
+        # (template renderiza os dois) enquanto standalone-compact/lab
+        # rodam v0.2.1, publicada antes da mudança de contrato — ver
+        # comentário em templates/configmap-runtime.yaml.
+        oidc:
+          issuerUrl: ""  # ex.: https://standalone.portaluni.com.br/auth/realms/uniplus
+          clientId: uniplus-portal
         keycloak:
           url: ""  # ex.: https://standalone.portaluni.com.br/auth
           realm: uniplus
-          clientId: uniplus-portal
       resources:
         requests:
           cpu: 50m
@@ -101,10 +108,12 @@ uniplusWeb:
       pathPrefix: ""  # subpath opcional — ver nota em apps.portal.pathPrefix. Ex. HML: /selecao
       runtimeConfig:
         apiUrl: ""
+        oidc:
+          issuerUrl: ""
+          clientId: uniplus-portal
         keycloak:
           url: ""
           realm: uniplus
-          clientId: uniplus-portal
       resources:
         requests:
           cpu: 50m
@@ -122,10 +131,12 @@ uniplusWeb:
       pathPrefix: ""  # subpath opcional — ver nota em apps.portal.pathPrefix. Ex. HML: /ingresso
       runtimeConfig:
         apiUrl: ""
+        oidc:
+          issuerUrl: ""
+          clientId: uniplus-portal
         keycloak:
           url: ""
           realm: uniplus
-          clientId: uniplus-portal
       resources:
         requests:
           cpu: 50m

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -462,10 +462,12 @@ uniplusWeb:
         # arquivo) — chamadas à API vão falhar em runtime até lá. apiUrl
         # vazio não é aceito pelo chart (ADR-0021 assertNaoEhPlaceholder).
         apiUrl: https://uniplus-api-hml.unifesspa.edu.br
+        oidc:
+          issuerUrl: https://uniplus-oidc-hml.unifesspa.edu.br/auth/realms/unifesspa
+          clientId: uniplus-portal
         keycloak:
           url: https://uniplus-oidc-hml.unifesspa.edu.br/auth
           realm: unifesspa
-          clientId: uniplus-portal
 
     selecao:
       enabled: true
@@ -477,10 +479,12 @@ uniplusWeb:
         # monta /api/selecao/... no cliente. Backend real: já roteado no
         # uniplus-api-host (pathPrefixes acima).
         apiUrl: https://uniplus-api-hml.unifesspa.edu.br
+        oidc:
+          issuerUrl: https://uniplus-oidc-hml.unifesspa.edu.br/auth/realms/unifesspa
+          clientId: uniplus-portal
         keycloak:
           url: https://uniplus-oidc-hml.unifesspa.edu.br/auth
           realm: unifesspa
-          clientId: uniplus-portal
 
     ingresso:
       enabled: true
@@ -493,10 +497,12 @@ uniplusWeb:
         # mas o módulo Ingresso ainda não tem controller HTTP implementado
         # (RUNBOOKS §21.3) — chamadas à API vão 404 até lá.
         apiUrl: https://uniplus-api-hml.unifesspa.edu.br
+        oidc:
+          issuerUrl: https://uniplus-oidc-hml.unifesspa.edu.br/auth/realms/unifesspa
+          clientId: uniplus-portal
         keycloak:
           url: https://uniplus-oidc-hml.unifesspa.edu.br/auth
           realm: unifesspa
-          clientId: uniplus-portal
 
   ingress:
     enabled: true

--- a/environments/lab-standalone-single/values.yaml
+++ b/environments/lab-standalone-single/values.yaml
@@ -545,6 +545,8 @@ uniplusWeb:
       host: portal.192.168.1.65.nip.io
       runtimeConfig:
         apiUrl: https://api-portal.192.168.1.65.nip.io
+        oidc:
+          issuerUrl: https://keycloak.192.168.1.65.nip.io/auth/realms/uniplus
         keycloak:
           url: https://keycloak.192.168.1.65.nip.io/auth
 
@@ -554,6 +556,8 @@ uniplusWeb:
       host: selecao.192.168.1.65.nip.io
       runtimeConfig:
         apiUrl: https://api-host.192.168.1.65.nip.io
+        oidc:
+          issuerUrl: https://keycloak.192.168.1.65.nip.io/auth/realms/uniplus
         keycloak:
           url: https://keycloak.192.168.1.65.nip.io/auth
 
@@ -563,6 +567,8 @@ uniplusWeb:
       host: ingresso.192.168.1.65.nip.io
       runtimeConfig:
         apiUrl: https://api-host.192.168.1.65.nip.io
+        oidc:
+          issuerUrl: https://keycloak.192.168.1.65.nip.io/auth/realms/uniplus
         keycloak:
           url: https://keycloak.192.168.1.65.nip.io/auth
 

--- a/environments/standalone-compact/values.yaml
+++ b/environments/standalone-compact/values.yaml
@@ -1207,10 +1207,12 @@ uniplusWeb:
       host: portal.standalone.portaluni.com.br
       runtimeConfig:
         apiUrl: https://api-portal.standalone.portaluni.com.br
+        oidc:
+          issuerUrl: https://standalone.portaluni.com.br/auth/realms/uniplus
+          clientId: uniplus-portal
         keycloak:
           url: https://standalone.portaluni.com.br/auth
           realm: uniplus
-          clientId: uniplus-portal
 
     selecao:
       enabled: true
@@ -1219,10 +1221,12 @@ uniplusWeb:
       host: selecao.standalone.portaluni.com.br
       runtimeConfig:
         apiUrl: https://api-selecao.standalone.portaluni.com.br
+        oidc:
+          issuerUrl: https://standalone.portaluni.com.br/auth/realms/uniplus
+          clientId: uniplus-portal
         keycloak:
           url: https://standalone.portaluni.com.br/auth
           realm: uniplus
-          clientId: uniplus-portal
 
     ingresso:
       enabled: true
@@ -1231,10 +1235,12 @@ uniplusWeb:
       host: ingresso.standalone.portaluni.com.br
       runtimeConfig:
         apiUrl: https://api-ingresso.standalone.portaluni.com.br
+        oidc:
+          issuerUrl: https://standalone.portaluni.com.br/auth/realms/uniplus
+          clientId: uniplus-portal
         keycloak:
           url: https://standalone.portaluni.com.br/auth
           realm: uniplus
-          clientId: uniplus-portal
 
 # ----------------------------------------------------------------------------
 # Componentes stateful no data-host (Postgres, Kafka, MinIO, Redis) rodam


### PR DESCRIPTION
## Contexto — regressão em produção-de-homologação

Ao habilitar `selecao`/`ingresso` no HML (PR #489) e mover o `portal` pro `PathPrefix` real, testei o login e quebrou nos 3 apps: `Error: runtime-config.json deve conter o bloco "oidc" com issuerUrl e clientId.`

O chart `apps/uniplus-web` gerava `{"keycloak": {url, realm, clientId}}`, mas o frontend (`uniplus-web`) adotou o contrato OIDC neutro em 2026-05-31 (commit `9884c64`, `feat(auth)!: adota contrato OIDC neutro`) — a interface `AppConfig` exige `{"oidc": {issuerUrl, clientId}}` desde então.

## O que muda

- `apps/uniplus-web/templates/configmap-runtime.yaml` — renderiza **os dois** blocos em paralelo (`oidc` e `keycloak`) no mesmo `runtime-config.json`
- `apps/uniplus-web/values.yaml` (default) + os 3 `environments/*/values.yaml` — cada app declara `runtimeConfig.oidc.{issuerUrl,clientId}` **e** `runtimeConfig.keycloak.{url,realm}`

## Por que os dois, não só um

1ª versão deste PR trocava só pro schema novo — Codex AI achou o problema real: `standalone-compact`/`lab-standalone-single` seguem pinados em `v0.2.1` (chart default), publicada **antes** da mudança de contrato. Trocar o schema quebraria esses 2 ambientes na próxima reconciliação do ArgoCD (`v0.2.1` só lê `keycloak`, não `oidc`). HML já roda `v0.2.2` (cortada hoje pra fechar `uniplus-web#448`), que só lê `oidc`.

Renderizar os dois é seguro pros dois lados — um campo JSON extra e desconhecido não quebra nada (`resolveOidcConfig` em `app-config.model.ts` só valida a chave que usa). Remover `keycloak` do template fica pra quando `standalone-compact`/`lab` também migrarem pra uma tag pós-contrato-neutro.

## Mitigação já aplicada (fora deste diff)

Pra restaurar o serviço imediatamente na VM (ArgoCD com `selfHeal` reverteria em minutos sem o fix em Git), apliquei `kubectl patch` nos 3 ConfigMaps do HML + `rollout restart` — paliativo, substituído pela reconciliação normal do ArgoCD assim que este PR mergear.

## Validação local

- `make helm-lint`, `make helm-template`, `make schema-validate`, `make yaml-lint` — verdes
- Render conferido nos 3 ambientes: os dois blocos (`oidc` + `keycloak`) presentes e corretos em `standalone-compact`, `lab-standalone-single`, `hml-standalone-single`
- Validado ao vivo na VM: login funcionando nos 3 apps (portal/selecao/ingresso) após o patch paliativo