### PR TITLE
feat(hml): habilita configuracao como 4o app do uniplus-web

### DIFF
--- a/apps/uniplus-web/values.yaml
+++ b/apps/uniplus-web/values.yaml
@@ -145,6 +145,32 @@ uniplusWeb:
           cpu: 250m
           memory: 128Mi
 
+    configuracao:
+      enabled: false  # ativar em environments/<env>/values.yaml
+      replicas: 2
+      # v0.2.1/v0.2.2 não publicaram esta imagem (matrix de publish-images.yml
+      # só ganhou o módulo configuracao na issue #558) — primeira tag
+      # publicada com uniplus-web-configuracao é v0.2.3.
+      image: uniplus-web-configuracao
+      tag: v0.2.3
+      host: ""
+      pathPrefix: ""  # subpath opcional — ver nota em apps.portal.pathPrefix. Ex. HML: /configuracao
+      runtimeConfig:
+        apiUrl: ""
+        oidc:
+          issuerUrl: ""
+          clientId: uniplus-portal
+        keycloak:
+          url: ""
+          realm: uniplus
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 250m
+          memory: 128Mi
+
   ingress:
     enabled: true
     entryPoint: websecure

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -29,23 +29,27 @@
 #
 # Habilitados: Vault, External Secrets Operator, Traefik+TLS (autoassinado,
 # provisório — ADR/RUNBOOKS §21.2 item 2), Keycloak, Apicurio Registry,
-# StorageClass, uniplusApiHost e uniplusWeb (portal + selecao + ingresso,
-# issue #488) — os 3 sob PathPrefix real (`/portal`, `/selecao`,
-# `/ingresso`) no mesmo host. Kafka roda fora do K8s (systemd no data-host,
-# escopo do script de bootstrap #442), mas permanece desativado no Host nesta
-# primeira publicação.
+# StorageClass, uniplusApiHost e uniplusWeb (portal + selecao + ingresso +
+# configuracao, issues #488/#491) — os 4 sob PathPrefix real (`/portal`,
+# `/selecao`, `/ingresso`, `/configuracao`) no mesmo host. Kafka roda fora
+# do K8s (systemd no data-host, escopo do script de bootstrap #442), mas
+# permanece desativado no Host nesta primeira publicação.
 #
 # Deliberadamente FORA de escopo:
 #   - unifesspaGeoApi — registrado no ApplicationSet (story #457); imagem já
-#     publicada em GHCR, mas `enabled: false` aqui até o provisionamento dos
-#     secrets (Vault: postgres/geo, redis, geo/encryption) e a decisão do
-#     hostname de ingress — follow-up ainda sem issue própria.
+#     publicada em GHCR, `enabled: false` aqui até o provisionamento dos
+#     secrets no Vault (postgres/geo, geo/encryption — redis/default já
+#     existe, reutilizado). Hostname de ingress já decidido e registrado
+#     pela CTIC (`geo-api-hml.unifesspa.edu.br`, RUNBOOKS §21.2) e o
+#     database `uniplus_geo` (role `uniplus_geo_app`, template PostGIS) já
+#     restaurado no Postgres da VM — só falta o Vault (custódia Shamir
+#     manual, ADR-014). Acompanhar em uniplus-infra#492.
 #   - uniplusApiPortal — já registrado, imagem publicada, mas TLS real desta
 #     VM depende do certificado autoassinado gerado no bootstrap
 #     (#442/#445) — os apps .NET precisariam de `customCA.certPEM`,
 #     acompanhar quando o app for de fato ligado neste ambiente.
-#   - (removido — uniplusWeb saiu do "fora de escopo"; os 3 apps estão
-#     habilitados, ver bloco `uniplusWeb` abaixo e issue #488)
+#   - (removido — uniplusWeb saiu do "fora de escopo"; os 4 apps estão
+#     habilitados, ver bloco `uniplusWeb` abaixo e issues #488/#491)
 #   - cert-manager, Vault Transit (auto-unseal), Vault Transit Bootstrap
 #     (engine transit local p/ idempotência do uniplus-api — sem consumidor
 #     enquanto uniplusApiHost não roda aqui), observabilidade completa
@@ -334,13 +338,14 @@ uniplusApiHost:
 
   cors:
     allowedOrigins:
-      # As 3 SPAs (portal/selecao/ingresso) vivem sob o MESMO host com
-      # PathPrefix (/portal, /selecao, /ingresso — RUNBOOKS §21.2/§21.3),
-      # não em subdomínios próprios. CORS compara só esquema+host+porta,
-      # nunca o path, então esta é a única origem efetiva das três —
-      # `portal.*`/`selecao.*`/`ingresso.*` do valor anterior eram
-      # subdomínios que nunca existiram nesta topologia (nem em nip.io,
-      # nem nos 9 hostnames registrados pela CTIC — RUNBOOKS §21.2).
+      # As 4 SPAs (portal/selecao/ingresso/configuracao) vivem sob o MESMO
+      # host com PathPrefix (/portal, /selecao, /ingresso, /configuracao —
+      # RUNBOOKS §21.2/§21.3), não em subdomínios próprios. CORS compara só
+      # esquema+host+porta, nunca o path, então esta é a única origem
+      # efetiva das quatro — `portal.*`/`selecao.*`/`ingresso.*` do valor
+      # anterior eram subdomínios que nunca existiram nesta topologia (nem
+      # em nip.io, nem nos 9 hostnames registrados pela CTIC — RUNBOOKS
+      # §21.2).
       - https://uniplus-hml.unifesspa.edu.br
 
   encryption:
@@ -360,6 +365,7 @@ uniplusApiHost:
     pathPrefixes:
       - /api/ingresso
       - /api/selecao
+      - /api/configuracao
       - /api/publicacoes
       - /api/auth
       - /api/profile
@@ -496,6 +502,27 @@ uniplusWeb:
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
         # mas o módulo Ingresso ainda não tem controller HTTP implementado
         # (RUNBOOKS §21.3) — chamadas à API vão 404 até lá.
+        apiUrl: https://uniplus-api-hml.unifesspa.edu.br
+        oidc:
+          issuerUrl: https://uniplus-oidc-hml.unifesspa.edu.br/auth/realms/unifesspa
+          clientId: uniplus-portal
+        keycloak:
+          url: https://uniplus-oidc-hml.unifesspa.edu.br/auth
+          realm: unifesspa
+
+    configuracao:
+      enabled: true
+      host: uniplus-hml.unifesspa.edu.br
+      pathPrefix: /configuracao
+      tag: v0.2.3
+      runtimeConfig:
+        # apiUrl é só a origem (ver comentário do portal acima) — o app já
+        # monta /api/configuracao/... no cliente. Módulo Configuração já
+        # tem controllers HTTP reais no uniplus-api-host (Campi, Cursos,
+        # Modalidades, TiposBanca, FasesCanonicas etc. — bem mais completo
+        # que Ingresso) e /api/configuracao entrou no pathPrefixes acima —
+        # ao contrário do portal/ingresso, este módulo deve responder de
+        # verdade, não só servir o shell estático.
         apiUrl: https://uniplus-api-hml.unifesspa.edu.br
         oidc:
           issuerUrl: https://uniplus-oidc-hml.unifesspa.edu.br/auth/realms/unifesspa


### PR DESCRIPTION
## O que muda

Adiciona o bloco `configuracao` ao chart `apps/uniplus-web` (mesma estrutura de `portal`/`selecao`/`ingresso`) e habilita em `environments/hml-standalone-single/values.yaml`:

- `apps.configuracao`: `enabled: true`, `pathPrefix: /configuracao`, `tag: v0.2.3` (primeira release que publicou `uniplus-web-configuracao` — v0.2.1/v0.2.2 não tinham essa imagem, ver uniplus-web#558)
- `uniplusApiHost.ingress.pathPrefixes`: adiciona `/api/configuracao` — o módulo já tem controllers HTTP reais (`CampiController`, `CursosController`, `ModalidadesController`, `TiposBancaController`, `FasesCanonicasController` etc., 19 controllers no total), diferente de `portal`/`ingresso` cujas APIs ainda não respondem
- Comentário de escopo da fase (topo do arquivo) atualizado de "3 apps" pra "4 apps"
- Comentário de CORS atualizado (mesma origem única, sem mudança funcional)

Reaproveita o client OIDC `uniplus-portal` já existente no realm (`redirectUris: https://uniplus-hml.unifesspa.edu.br/*` já cobre `/configuracao`) — sem client novo no Keycloak.

Templates (`deployment.yaml`, `ingressroute.yaml`, `configmap-runtime.yaml`, `networkpolicy.yaml`, `service.yaml`, `serviceaccount.yaml`, `certificate.yaml`) já iteram genericamente sobre `Values.uniplusWeb.apps` (`range $app, $cfg`) — nenhuma mudança de template necessária, só validado.

## Validação local

- `make helm-lint` — verde
- `make helm-template` — `uniplus-web × hml-standalone-single` renderiza 24 recursos (era 21 antes, +3 pelo novo app: NetworkPolicy/ServiceAccount/ConfigMap/Service/Deployment/Certificate contam por app). Falhas pré-existentes em 10 charts de platform (`cert-manager`, `vault`, `traefik` etc.) por dependência de subchart não baixada localmente — confirmado via `git stash` que já falhavam antes desta mudança, não relacionado.
- `make schema-validate` — mesmas 20 falhas pré-existentes (mesmos charts, `uniplus-web` não tem `values.schema.json`, não é coberto por este alvo)
- Inspecionei manualmente o render: `image: ghcr.io/unifesspa-edu-br/uniplus-web-configuracao:v0.2.3` correto no Deployment; `PathPrefix(/api/configuracao)` correto no IngressRoute do `uniplus-api-host`

## Deploy e validação ao vivo

Após merge, ArgoCD sincroniza automaticamente (`selfHeal: true`). Vou validar `https://uniplus-hml.unifesspa.edu.br/configuracao/` (shell + OIDC + pelo menos 1 chamada real de API) via Playwright, mesmo padrão de #488/#489.

Closes #491