### PR TITLE
feat(hml): habilita unifesspa-geo-api em hml-standalone-single

### DIFF
--- a/apps/unifesspa-geo-api/README.md
+++ b/apps/unifesspa-geo-api/README.md
@@ -35,6 +35,10 @@ Transit). Health: /health (readiness agregado), /health/live (liveness),
 | unifesspaGeoApi.containerSecurityContext.runAsNonRoot | bool | `true` |  |
 | unifesspaGeoApi.containerSecurityContext.runAsUser | int | `999` |  |
 | unifesspaGeoApi.cors.allowedOrigins | list | `[]` |  |
+| unifesspaGeoApi.customCA.certPEM | string | `""` |  |
+| unifesspaGeoApi.customCA.enabled | bool | `false` |  |
+| unifesspaGeoApi.customCA.existingSecretKey | string | `"tls.crt"` |  |
+| unifesspaGeoApi.customCA.existingSecretName | string | `""` |  |
 | unifesspaGeoApi.database.connectionStringName | string | `"GeoDb"` |  |
 | unifesspaGeoApi.database.host | string | `""` |  |
 | unifesspaGeoApi.database.name | string | `"uniplus_geo"` |  |
@@ -76,6 +80,8 @@ Transit). Health: /health (readiness agregado), /health/live (liveness),
 | unifesspaGeoApi.networkPolicy.keycloakPort | int | `8080` |  |
 | unifesspaGeoApi.networkPolicy.keycloakService | string | `"keycloak-replica"` |  |
 | unifesspaGeoApi.networkPolicy.monitoringNamespace | string | `"observability-prometheus"` |  |
+| unifesspaGeoApi.networkPolicy.oidcIssuerCIDR | string | `""` |  |
+| unifesspaGeoApi.networkPolicy.oidcIssuerPort | int | `443` |  |
 | unifesspaGeoApi.networkPolicy.otelCollectorNamespace | string | `"observability-otelcol"` |  |
 | unifesspaGeoApi.networkPolicy.traefikNamespace | string | `"traefik"` |  |
 | unifesspaGeoApi.networkPolicy.vaultNamespace | string | `"vault"` |  |

--- a/apps/unifesspa-geo-api/templates/configmap-custom-ca.yaml
+++ b/apps/unifesspa-geo-api/templates/configmap-custom-ca.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.unifesspaGeoApi.enabled .Values.unifesspaGeoApi.customCA.enabled -}}
+{{- if and .Values.unifesspaGeoApi.enabled .Values.unifesspaGeoApi.customCA.enabled (not .Values.unifesspaGeoApi.customCA.existingSecretName) -}}
 {{- if not .Values.unifesspaGeoApi.customCA.certPEM -}}
 {{- fail "unifesspaGeoApi.customCA.certPEM é obrigatório quando customCA.enabled=true." -}}
 {{- end -}}

--- a/apps/unifesspa-geo-api/templates/deployment.yaml
+++ b/apps/unifesspa-geo-api/templates/deployment.yaml
@@ -210,10 +210,57 @@ spec:
           resources:
             {{- toYaml .Values.unifesspaGeoApi.resources | nindent 12 }}
       {{- if .Values.unifesspaGeoApi.customCA.enabled }}
+        # Volumes projected de Secret são atualizados pelo kubelet sem mudar o
+        # PodTemplate. O initContainer acima só executa na criação do Pod,
+        # portanto um Secret TLS rotacionado deixaria o bundle em emptyDir
+        # obsoleto. Este sidecar observa o PEM e recompõe o bundle do sistema;
+        # a substituição de ca-certificates.crt é atômica para que novas
+        # conexões TLS da API usem a CA atual sem rollout manual.
+        - name: refresh-custom-ca
+          image: "{{ .Values.unifesspaGeoApi.image.registry }}/{{ .Values.unifesspaGeoApi.image.repository }}:{{ .Values.unifesspaGeoApi.image.tag }}"
+          imagePullPolicy: {{ .Values.unifesspaGeoApi.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -eu
+              previous_hash=""
+              while true; do
+                current_hash=$(sha256sum /custom-ca/ca.crt | awk '{print $1}')
+                if [ "$current_hash" != "$previous_hash" ]; then
+                  install -D -m 0644 /custom-ca/ca.crt /usr/local/share/ca-certificates/lab-custom-ca.crt
+                  update-ca-certificates
+                  temp_bundle=$(mktemp /merged-ca-certs/.ca-certificates.crt.XXXXXX)
+                  cp /etc/ssl/certs/ca-certificates.crt "$temp_bundle"
+                  chmod 0644 "$temp_bundle"
+                  mv "$temp_bundle" /merged-ca-certs/ca-certificates.crt
+                  previous_hash="$current_hash"
+                fi
+                sleep 15
+              done
+          volumeMounts:
+            - name: custom-ca-source
+              mountPath: /custom-ca
+              readOnly: true
+            - name: merged-ca-certs
+              mountPath: /merged-ca-certs
+      {{- end }}
+      {{- if .Values.unifesspaGeoApi.customCA.enabled }}
       volumes:
         - name: custom-ca-source
+          {{- if .Values.unifesspaGeoApi.customCA.existingSecretName }}
+          secret:
+            secretName: {{ .Values.unifesspaGeoApi.customCA.existingSecretName }}
+            items:
+              - key: {{ .Values.unifesspaGeoApi.customCA.existingSecretKey }}
+                path: ca.crt
+          {{- else }}
           configMap:
             name: {{ include "unifesspaGeoApi.fullname" . }}-custom-ca
+          {{- end }}
         - name: merged-ca-certs
           emptyDir: {}
       {{- end }}

--- a/apps/unifesspa-geo-api/values.yaml
+++ b/apps/unifesspa-geo-api/values.yaml
@@ -81,7 +81,16 @@ unifesspaGeoApi:
   # apps/uniplus-api-host/values.yaml customCA. ===
   customCA:
     enabled: false
-    certPEM: ""
+    certPEM: ""                 # PEM completo do certificado (não a chave privada)
+    # Alternativa ao PEM versionado: Secret TLS existente no namespace da
+    # aplicação. Preferir esta opção quando o certificado é o mesmo servido
+    # pelo Traefik (autoassinado de bootstrap) — nunca versionar esse PEM em
+    # git (CLAUDE.md "nunca commitar... certificados"). O sidecar
+    # refresh-custom-ca observa mudanças no volume projetado e recompõe
+    # atomically /etc/ssl/certs/ca-certificates.crt; a rotação do Secret não
+    # depende de rollout manual do Deployment.
+    existingSecretName: ""
+    existingSecretKey: tls.crt
 
   # === Cifragem (Geo:Encryption — AES-GCM local ou Vault Transit) ===
   # Provider=local exige LocalKey (Base64, 32 bytes) via Secret; Provider=vault

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -4063,7 +4063,7 @@ fechada, e confirmar via observação real do tráfego durante o primeiro bootst
 | `uniplus-api-hml...` | `/api/portal` | `apps/uniplus-api-portal` | Sim | **Código** — idem. Hoje o Portal só tem endpoint-esqueleto (`/api/portal/ping`) — API de negócio ainda não implementada |
 | `uniplus-api-hml...` | `/api/ingresso`, `/api/selecao`, `/api/publicacoes` | `apps/uniplus-api-host` (composition root — Selecao+Ingresso+Configuracao+OrganizacaoInstitucional+Publicacoes, [ADR-0097](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md)/[ADR-0105](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0105-modulo-publicacoes-registro-central-dos-atos.md) do `uniplus-api`) | Sim (já suportado) | **Imagem publicada** — já registrado no ApplicationSet (story #457, ver nota abaixo) e o `templates/ingressroute.yaml` já suporta `ingress.pathPrefixes` (sem `StripPrefix`); falta só o build do Host em GHCR, então segue `enabled: false`. `/api/ingresso` é reserva de rota: módulo Ingresso ainda sem controller HTTP implementado |
 | `uniplus-oidc-hml...` | `/auth` | `apps/keycloak-replica` | Sim (já suportado) | Só `values.yaml` |
-| `geo-api-hml...` | `/` | `apps/unifesspa-geo-api` | Não | Já registrado no ApplicationSet (story #457, ver nota abaixo); imagem publicada em GHCR — falta só `values.yaml` (`unifesspaGeoApi.enabled: true` + secrets do Vault, follow-up ainda sem issue própria) |
+| `geo-api-hml...` | `/` | `apps/unifesspa-geo-api` | Não | **Habilitado** (uniplus-infra#492) — `unifesspaGeoApi.enabled: true`, database `uniplus_geo` (PostGIS) restaurado de dump real, secrets no Vault |
 | `grafana-hml...` | `/` | `platform/observability/grafana` | Não (`pathPrefix: ""`) | `values.yaml` — o template já suporta os dois modos (subpath e subdomínio); **falta provisionar o `Certificate`/`secretName`** que a IngressRoute referencia — o chart não cria o certificado sozinho |
 | `kafka-ui-hml...`, `apicurio-hml...`, `redis-ui-hml...`, `minio-hml...` | `/` | charts respectivos | Não | Só `values.yaml` |
 
@@ -4077,16 +4077,15 @@ zero (`lab-standalone-single` nem entra na comparação: não tem cluster ArgoCD
 aplicado manualmente via `helm install/upgrade -f`, fora do escopo deste ApplicationSet).
 `uniplus-api-host` roda no namespace `uniplus` (mesmo bounded context do Portal/Selecao/Ingresso);
 `unifesspa-geo-api` roda em namespace próprio, `geo` — aplicação independente, só compartilha o
-emissor OIDC com as demais APIs. Como os dois charts vêm com `enabled: false` por default e a
-`hml-standalone-single` não sobrescreve isso (ver `environments/hml-standalone-single/values.yaml`),
-a `Application` em HML sincroniza com zero manifests — `Synced`/`Healthy` sem `Deployment`/`Service`,
-mesmo padrão hoje usado por `uniplusWeb` nesse ambiente (a proteção `allowEmpty: false` existe para
-impedir prune acidental de todos os recursos de uma Application que **já estava populada**, não
-bloqueia uma Application que nasce vazia por design). Ligar o workload de fato é decisão
-independente, por chart: `uniplus-api-host` aguarda a primeira imagem publicada em GHCR;
-`unifesspa-geo-api` já tem imagem, mas aguarda o provisionamento dos secrets do Vault (follow-up
-ainda sem issue própria) antes de
-`unifesspaGeoApi.enabled: true`.
+emissor OIDC com as demais APIs. Ambos os charts vêm com `enabled: false` por default; quando a
+`Application` correspondente não é sobrescrita, ela sincroniza com zero manifests —
+`Synced`/`Healthy` sem `Deployment`/`Service` (a proteção `allowEmpty: false` existe para impedir
+prune acidental de todos os recursos de uma Application que **já estava populada**, não bloqueia
+uma Application que nasce vazia por design). Ligar o workload de fato é decisão independente, por
+chart: `unifesspa-geo-api` já está ligado (uniplus-infra#492 — hostname registrado pela CTIC,
+database `uniplus_geo`/PostGIS provisionado e restaurado de dump real, secrets no Vault via
+custódia Shamir manual, ADR-014; namespace `geo` recebe cópia do mesmo Secret TLS que o Traefik
+serve, sincronizada por `scripts/hml-standalone-single/bootstrap.sh`).
 
 **`uniplus-api-hml.../api/{ingresso,selecao,publicacoes}` é servido pelo `uniplus-api-host`, não
 pelos charts legados `apps/uniplus-api-{selecao,ingresso}`** — decisão deliberada, já que este HML

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -29,21 +29,16 @@
 #
 # Habilitados: Vault, External Secrets Operator, Traefik+TLS (autoassinado,
 # provisório — ADR/RUNBOOKS §21.2 item 2), Keycloak, Apicurio Registry,
-# StorageClass, uniplusApiHost e uniplusWeb (portal + selecao + ingresso +
+# StorageClass, uniplusApiHost, uniplusWeb (portal + selecao + ingresso +
 # configuracao, issues #488/#491) — os 4 sob PathPrefix real (`/portal`,
-# `/selecao`, `/ingresso`, `/configuracao`) no mesmo host. Kafka roda fora
-# do K8s (systemd no data-host, escopo do script de bootstrap #442), mas
-# permanece desativado no Host nesta primeira publicação.
+# `/selecao`, `/ingresso`, `/configuracao`) no mesmo host — e unifesspaGeoApi
+# (issue #492: hostname `geo-api-hml.unifesspa.edu.br` já registrado pela
+# CTIC, database `uniplus_geo` com PostGIS restaurado de dump real, secrets
+# em Vault via custódia Shamir manual — ADR-014). Kafka roda fora do K8s
+# (systemd no data-host, escopo do script de bootstrap #442), mas permanece
+# desativado no Host nesta primeira publicação.
 #
 # Deliberadamente FORA de escopo:
-#   - unifesspaGeoApi — registrado no ApplicationSet (story #457); imagem já
-#     publicada em GHCR, `enabled: false` aqui até o provisionamento dos
-#     secrets no Vault (postgres/geo, geo/encryption — redis/default já
-#     existe, reutilizado). Hostname de ingress já decidido e registrado
-#     pela CTIC (`geo-api-hml.unifesspa.edu.br`, RUNBOOKS §21.2) e o
-#     database `uniplus_geo` (role `uniplus_geo_app`, template PostGIS) já
-#     restaurado no Postgres da VM — só falta o Vault (custódia Shamir
-#     manual, ADR-014). Acompanhar em uniplus-infra#492.
 #   - uniplusApiPortal — já registrado, imagem publicada, mas TLS real desta
 #     VM depende do certificado autoassinado gerado no bootstrap
 #     (#442/#445) — os apps .NET precisariam de `customCA.certPEM`,
@@ -382,6 +377,53 @@ uniplusApiHost:
 
   otel:
     enabled: false
+
+# ============================================================================
+# unifesspa-geo-api (chart apps/unifesspa-geo-api/) — localidades/CEP/
+# georreferenciamento institucional. Habilitado após uniplus-infra#492:
+# hostname já registrado pela CTIC, DB `uniplus_geo` (role `uniplus_geo_app`,
+# PostGIS via TEMPLATE=template_postgis) provisionado e restaurado a partir
+# de dump real no Postgres compartilhado da VM, secrets gravados no Vault
+# (postgres/geo, geo/encryption — redis/default reaproveitado).
+# ============================================================================
+unifesspaGeoApi:
+  enabled: true
+
+  database:
+    host: 192.168.21.134
+
+  redis:
+    host: 192.168.21.134
+
+  oidc:
+    issuerUri: https://uniplus-oidc-hml.unifesspa.edu.br/auth/realms/unifesspa
+
+  # customCA via Secret existente (não PEM versionado — CLAUDE.md "nunca
+  # commitar certificados"), mesmo padrão de uniplusApiHost acima: o mesmo
+  # certificado autoassinado que o Traefik já serve, referenciado pelo
+  # Secret que o bootstrap criou (não uma cópia estática que ficaria
+  # desatualizada quando o certificado real da CTIC substituir o
+  # autoassinado — Feature 6).
+  customCA:
+    enabled: true
+    existingSecretName: uniplus-hml-unifesspa-tls
+    existingSecretKey: tls.crt
+
+  cors:
+    allowedOrigins:
+      - https://uniplus-hml.unifesspa.edu.br
+
+  networkPolicy:
+    dataHostCIDR: 192.168.21.134/32
+    oidcIssuerCIDR: 10.42.0.0/16
+    oidcIssuerPort: 8443
+
+  ingress:
+    enabled: true
+    host: geo-api-hml.unifesspa.edu.br
+    tls:
+      enabled: true
+      secretName: uniplus-hml-unifesspa-tls
 
 # ============================================================================
 # Apicurio Registry (chart apps/apicurio-registry/) — Schema Registry.

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -118,16 +118,39 @@ vaultTransit:
 vaultTransitBootstrap:
   enabled: false
 
-# NetworkPolicy compartilhada pelos wrappers platform/vault/ e
-# platform/external-secrets/ — kubeApiCidrs precisa do CIDR do host, não só
-# do service CIDR (K3s: apiserver roda como processo no host, não Pod; o
-# kube-router avalia egress DEPOIS do DNAT do kube-proxy — mesmo bug
-# documentado em lab-standalone-single/standalone-compact).
+# NetworkPolicy compartilhada pelos wrappers platform/vault/,
+# platform/external-secrets/ e platform/traefik/ — cada chart lê só as
+# sub-chaves que reconhece do MESMO bloco (convenção deste repo: 1 única
+# chave `networkPolicy:` de topo por environment, nunca uma por chart —
+# ver platform/vault/values.yaml, platform/external-secrets/values.yaml e
+# platform/traefik/values.yaml, os 3 default esse mesmo formato). Duas
+# chaves `networkPolicy:` de topo no MESMO arquivo colidem silenciosamente
+# no parse YAML (a última sobrescreve a primeira, sem erro) — achado do
+# Codex AI (uniplus-infra#492) que quase reproduziu esse bug ao acrescentar
+# appNamespaces num segundo bloco separado.
+#
+# kubeApiCidrs precisa do CIDR do host, não só do service CIDR (K3s:
+# apiserver roda como processo no host, não Pod; o kube-router avalia
+# egress DEPOIS do DNAT do kube-proxy — mesmo bug documentado em
+# lab-standalone-single/standalone-compact).
+#
+# appNamespaces (consumida só pelo platform/traefik/) é override total —
+# Helm não faz merge de listas — por isso repete o default do chart
+# (uniplus, vault, keycloak) e acrescenta `geo`: unifesspa-geo-api roda em
+# namespace próprio (bounded context dedicado, argocd/applicationset.yaml),
+# fora do `uniplus` compartilhado pelas demais apps. Sem `geo` aqui, a
+# NetworkPolicy do Traefik bloqueia egress pro Service da geo-api mesmo com
+# o pod Healthy — 502/503 silencioso.
 networkPolicy:
   enabled: true
   kubeApiCidrs:
     - 10.43.0.0/16
     - 192.168.21.134/32
+  appNamespaces:
+    - uniplus
+    - vault
+    - keycloak
+    - geo
 
 ingress:
   enabled: false # acesso administrativo via kubectl port-forward / túnel VPN

--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -71,7 +71,14 @@ ARGOCD_VERSION="v2.14.3"
 DRY_RUN=false
 
 DATA_BASE="/var/lib/uniplus"
-TLS_NAMESPACE="uniplus"
+# uniplus: portal/selecao/ingresso/configuracao + uniplus-api-host +
+# Keycloak/Apicurio. geo: unifesspa-geo-api — bounded context próprio,
+# namespace dedicado (argocd/applicationset.yaml) — precisa do MESMO
+# Secret (IngressRoute e customCA.existingSecretName são namespace-scoped).
+# O primeiro da lista é o namespace onde o certificado é de fato gerado;
+# os demais recebem cópia do mesmo Secret (mesma identidade, nunca cert
+# novo por namespace).
+TLS_NAMESPACES="uniplus geo"
 TLS_SECRET_NAME="uniplus-hml-unifesspa-tls"
 # 9 hostnames de docs/RUNBOOKS.md §21.2, já registrados pela CTIC
 # (issue #486) — substitui o SAN provisório *.${NODE_IP}.nip.io usado
@@ -675,53 +682,87 @@ step_setup_kafka() {
 step_generate_tls_secret() {
     log_info "Gerando certificado TLS autoassinado provisório..."
 
+    local primary_ns
+    primary_ns=$(awk '{print $1}' <<< "$TLS_NAMESPACES")
+
     if $DRY_RUN; then
-        echo "[DRY-RUN] kubectl create namespace $TLS_NAMESPACE (idempotente)"
+        for ns in $TLS_NAMESPACES; do
+            echo "[DRY-RUN] kubectl create namespace $ns (idempotente)"
+        done
         echo "[DRY-RUN] openssl req -x509 -newkey rsa:2048 ... SAN=$TLS_SANS"
-        echo "[DRY-RUN] kubectl create secret tls $TLS_SECRET_NAME -n $TLS_NAMESPACE (se ainda não existir)"
+        echo "[DRY-RUN] kubectl create secret tls $TLS_SECRET_NAME -n $primary_ns (se ainda não existir)"
+        for ns in $TLS_NAMESPACES; do
+            [ "$ns" = "$primary_ns" ] && continue
+            echo "[DRY-RUN] replicar Secret $TLS_SECRET_NAME de $primary_ns para $ns (se ainda não existir)"
+        done
         return
     fi
 
-    kubectl create namespace "$TLS_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+    for ns in $TLS_NAMESPACES; do
+        kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+    done
 
-    if kubectl get secret "$TLS_SECRET_NAME" -n "$TLS_NAMESPACE" &>/dev/null; then
-        log_success "Secret $TLS_SECRET_NAME já existe em $TLS_NAMESPACE — preservando."
-        return
+    if kubectl get secret "$TLS_SECRET_NAME" -n "$primary_ns" &>/dev/null; then
+        log_success "Secret $TLS_SECRET_NAME já existe em $primary_ns — preservando."
+    else
+        # Subshell + trap EXIT (não RETURN): sob `set -e`, uma falha no meio do
+        # bloco (openssl, kubectl create) sai do subshell sem passar por um
+        # `return` normal — trap RETURN não dispara nesse caminho, deixando a
+        # chave privada órfã em /tmp. trap EXIT roda em qualquer saída do
+        # subshell (sucesso, erro, sinal), mesmo padrão já usado em
+        # scripts/lab-standalone-single/bootstrap.sh (step_configure_vault_auth)
+        # para material sensível. `kubectl create secret` (não idempotente) trocado
+        # por gerar+aplicar via `apply`, seguro para re-run se a checagem acima
+        # falhar por race entre dois bootstraps concorrentes.
+        (
+            tmpdir=$(mktemp -d)
+            trap 'shred -u "$tmpdir"/*.key 2>/dev/null; rm -rf "$tmpdir"' EXIT
+            chmod 700 "$tmpdir"
+
+            openssl req -x509 -newkey rsa:2048 -nodes \
+                -keyout "$tmpdir/tls.key" -out "$tmpdir/tls.crt" -days 825 \
+                -subj "/CN=uniplus-hml.unifesspa.edu.br" \
+                -addext "subjectAltName=$TLS_SANS" \
+                >/dev/null 2>&1
+
+            kubectl create secret tls "$TLS_SECRET_NAME" \
+                --cert="$tmpdir/tls.crt" --key="$tmpdir/tls.key" -n "$primary_ns" \
+                --dry-run=client -o yaml | kubectl apply -f -
+        )
+
+        log_warn "Certificado autoassinado gerado (SAN: $TLS_SANS) — chave privada descartada após criar o Secret."
+        log_success "Secret $TLS_SECRET_NAME criado em $primary_ns."
     fi
 
-    # Subshell + trap EXIT (não RETURN): sob `set -e`, uma falha no meio do
-    # bloco (openssl, kubectl create) sai do subshell sem passar por um
-    # `return` normal — trap RETURN não dispara nesse caminho, deixando a
-    # chave privada órfã em /tmp. trap EXIT roda em qualquer saída do
-    # subshell (sucesso, erro, sinal), mesmo padrão já usado em
-    # scripts/lab-standalone-single/bootstrap.sh (step_configure_vault_auth)
-    # para material sensível. `kubectl create secret` (não idempotente) trocado
-    # por gerar+aplicar via `apply`, seguro para re-run se a checagem acima
-    # falhar por race entre dois bootstraps concorrentes.
-    (
-        tmpdir=$(mktemp -d)
-        trap 'shred -u "$tmpdir"/*.key 2>/dev/null; rm -rf "$tmpdir"' EXIT
-        chmod 700 "$tmpdir"
+    # Replica o MESMO Secret (cert+key) pros demais namespaces consumidores —
+    # nunca gera identidade nova por namespace. IngressRoute e
+    # customCA.existingSecretName são namespace-scoped: sem a cópia, apps com
+    # namespace próprio (unifesspa-geo-api usa `geo` — bounded context
+    # dedicado, argocd/applicationset.yaml) não enxergam o Secret e o pod
+    # fica pending pra sempre (achado do Codex AI na habilitação da geo-api,
+    # uniplus-infra#492).
+    for ns in $TLS_NAMESPACES; do
+        [ "$ns" = "$primary_ns" ] && continue
+        if kubectl get secret "$TLS_SECRET_NAME" -n "$ns" &>/dev/null; then
+            log_success "Secret $TLS_SECRET_NAME já existe em $ns — preservando."
+            continue
+        fi
+        kubectl get secret "$TLS_SECRET_NAME" -n "$primary_ns" -o json \
+            | jq --arg ns "$ns" 'del(.metadata.namespace,.metadata.uid,.metadata.resourceVersion,.metadata.creationTimestamp,.metadata.selfLink,.metadata.ownerReferences,.metadata.managedFields) | .metadata.namespace = $ns' \
+            | kubectl apply -f -
+        log_success "Secret $TLS_SECRET_NAME replicado para $ns."
+    done
 
-        openssl req -x509 -newkey rsa:2048 -nodes \
-            -keyout "$tmpdir/tls.key" -out "$tmpdir/tls.crt" -days 825 \
-            -subj "/CN=uniplus-hml.unifesspa.edu.br" \
-            -addext "subjectAltName=$TLS_SANS" \
-            >/dev/null 2>&1
-
-        kubectl create secret tls "$TLS_SECRET_NAME" \
-            --cert="$tmpdir/tls.crt" --key="$tmpdir/tls.key" -n "$TLS_NAMESPACE" \
-            --dry-run=client -o yaml | kubectl apply -f -
-    )
-
-    log_warn "Certificado autoassinado gerado (SAN: $TLS_SANS) — chave privada descartada após criar o Secret."
-    log_success "Secret $TLS_SECRET_NAME criado em $TLS_NAMESPACE."
-
-    # O Host mescla a CA no trust store durante o initContainer. Quando uma
-    # recuperação recria este Secret, reiniciar o Deployment faz o init rodar
-    # com o novo tls.crt; sem isso o emptyDir do Pod preservaria a CA antiga.
-    kubectl get deployment -n "$TLS_NAMESPACE" -l app.kubernetes.io/name=uniplus-api-host -o name \
-        | xargs -r kubectl -n "$TLS_NAMESPACE" rollout restart
+    # O Host/API mescla a CA no trust store durante o initContainer. Quando
+    # uma recuperação recria este Secret, reiniciar o Deployment faz o init
+    # rodar com o novo tls.crt; sem isso o emptyDir do Pod preservaria a CA
+    # antiga. Cobre os 2 consumidores atuais de customCA.existingSecretName.
+    for ns in $TLS_NAMESPACES; do
+        kubectl get deployment -n "$ns" -l app.kubernetes.io/name=uniplus-api-host -o name \
+            | xargs -r kubectl -n "$ns" rollout restart
+        kubectl get deployment -n "$ns" -l app.kubernetes.io/name=unifesspa-geo-api -o name \
+            | xargs -r kubectl -n "$ns" rollout restart
+    done
 }
 
 summary() {

--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -686,6 +686,7 @@ step_generate_tls_secret() {
     primary_ns=$(awk '{print $1}' <<< "$TLS_NAMESPACES")
 
     if $DRY_RUN; then
+        echo "[DRY-RUN] apt-get install -y jq (se ainda não instalado)"
         for ns in $TLS_NAMESPACES; do
             echo "[DRY-RUN] kubectl create namespace $ns (idempotente)"
         done
@@ -693,14 +694,29 @@ step_generate_tls_secret() {
         echo "[DRY-RUN] kubectl create secret tls $TLS_SECRET_NAME -n $primary_ns (se ainda não existir)"
         for ns in $TLS_NAMESPACES; do
             [ "$ns" = "$primary_ns" ] && continue
-            echo "[DRY-RUN] replicar Secret $TLS_SECRET_NAME de $primary_ns para $ns (se ainda não existir)"
+            echo "[DRY-RUN] sincronizar Secret $TLS_SECRET_NAME de $primary_ns para $ns (se divergente)"
         done
         return
+    fi
+
+    # jq faz a transformação de namespace do Secret replicado abaixo — este
+    # host segue o mesmo pré-requisito documentado (Ubuntu 24.04.4), mas
+    # nada nos steps anteriores (docker/k3s/helm/argocd) garante jq
+    # instalado. Sem checagem, `set -euo pipefail` aborta aqui num host
+    # limpo, deixando o Deployment da geo-api habilitado sem Secret pra
+    # montar (achado do Codex AI, uniplus-infra#492).
+    if ! command -v jq &>/dev/null; then
+        log_info "Instalando jq..."
+        run "sudo apt-get update -qq"
+        run "sudo apt-get install -y jq"
+        log_success "jq instalado."
     fi
 
     for ns in $TLS_NAMESPACES; do
         kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
     done
+
+    local changed=false
 
     if kubectl get secret "$TLS_SECRET_NAME" -n "$primary_ns" &>/dev/null; then
         log_success "Secret $TLS_SECRET_NAME já existe em $primary_ns — preservando."
@@ -732,31 +748,50 @@ step_generate_tls_secret() {
 
         log_warn "Certificado autoassinado gerado (SAN: $TLS_SANS) — chave privada descartada após criar o Secret."
         log_success "Secret $TLS_SECRET_NAME criado em $primary_ns."
+        changed=true
     fi
 
-    # Replica o MESMO Secret (cert+key) pros demais namespaces consumidores —
-    # nunca gera identidade nova por namespace. IngressRoute e
-    # customCA.existingSecretName são namespace-scoped: sem a cópia, apps com
-    # namespace próprio (unifesspa-geo-api usa `geo` — bounded context
+    # Sincroniza o MESMO Secret (cert+key) pros demais namespaces
+    # consumidores — nunca gera identidade nova por namespace. IngressRoute
+    # e customCA.existingSecretName são namespace-scoped: sem a cópia, apps
+    # com namespace próprio (unifesspa-geo-api usa `geo` — bounded context
     # dedicado, argocd/applicationset.yaml) não enxergam o Secret e o pod
     # fica pending pra sempre (achado do Codex AI na habilitação da geo-api,
     # uniplus-infra#492).
+    #
+    # Compara pelo próprio dado (tls.crt), não só "existe?" — um guard de
+    # existência preservaria pra sempre uma cópia desatualizada quando o
+    # Secret primário for rotacionado (ex.: certificado real da CTIC
+    # substituindo o autoassinado, Feature 6): a IngressRoute e o sidecar
+    # refresh-custom-ca de geo continuariam servindo/confiando na
+    # identidade antiga, só a cópia primária se atualizaria (2º achado do
+    # Codex AI, uniplus-infra#492).
     for ns in $TLS_NAMESPACES; do
         [ "$ns" = "$primary_ns" ] && continue
-        if kubectl get secret "$TLS_SECRET_NAME" -n "$ns" &>/dev/null; then
-            log_success "Secret $TLS_SECRET_NAME já existe em $ns — preservando."
+        src_crt=$(kubectl get secret "$TLS_SECRET_NAME" -n "$primary_ns" -o jsonpath='{.data.tls\.crt}')
+        dst_crt=$(kubectl get secret "$TLS_SECRET_NAME" -n "$ns" -o jsonpath='{.data.tls\.crt}' 2>/dev/null || true)
+        if [ "$src_crt" = "$dst_crt" ]; then
+            log_success "Secret $TLS_SECRET_NAME em $ns já está sincronizado — preservando."
             continue
         fi
         kubectl get secret "$TLS_SECRET_NAME" -n "$primary_ns" -o json \
             | jq --arg ns "$ns" 'del(.metadata.namespace,.metadata.uid,.metadata.resourceVersion,.metadata.creationTimestamp,.metadata.selfLink,.metadata.ownerReferences,.metadata.managedFields) | .metadata.namespace = $ns' \
             | kubectl apply -f -
-        log_success "Secret $TLS_SECRET_NAME replicado para $ns."
+        log_success "Secret $TLS_SECRET_NAME sincronizado para $ns."
+        changed=true
     done
 
+    if ! $changed; then
+        return
+    fi
+
     # O Host/API mescla a CA no trust store durante o initContainer. Quando
-    # uma recuperação recria este Secret, reiniciar o Deployment faz o init
-    # rodar com o novo tls.crt; sem isso o emptyDir do Pod preservaria a CA
-    # antiga. Cobre os 2 consumidores atuais de customCA.existingSecretName.
+    # o Secret muda (criação, recuperação ou resync de rotação — acima),
+    # reiniciar o Deployment faz o init rodar com o tls.crt atual; sem isso
+    # o emptyDir do Pod preservaria a CA antiga. Só roda quando algo de fato
+    # mudou — reruns idempotentes do bootstrap não devem reiniciar pods
+    # saudáveis à toa. Cobre os 2 consumidores atuais de
+    # customCA.existingSecretName.
     for ns in $TLS_NAMESPACES; do
         kubectl get deployment -n "$ns" -l app.kubernetes.io/name=uniplus-api-host -o name \
             | xargs -r kubectl -n "$ns" rollout restart

--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -768,9 +768,15 @@ step_generate_tls_secret() {
     # Codex AI, uniplus-infra#492).
     for ns in $TLS_NAMESPACES; do
         [ "$ns" = "$primary_ns" ] && continue
+        # Compara cert E chave, não só o cert — um par divergente (ex.: tls.crt
+        # certo mas tls.key desatualizado/corrompido por edição manual parcial)
+        # deixaria Traefik/geo com mismatch mesmo com este guard "sincronizado"
+        # (achado do Codex AI, uniplus-infra#492).
         src_crt=$(kubectl get secret "$TLS_SECRET_NAME" -n "$primary_ns" -o jsonpath='{.data.tls\.crt}')
+        src_key=$(kubectl get secret "$TLS_SECRET_NAME" -n "$primary_ns" -o jsonpath='{.data.tls\.key}')
         dst_crt=$(kubectl get secret "$TLS_SECRET_NAME" -n "$ns" -o jsonpath='{.data.tls\.crt}' 2>/dev/null || true)
-        if [ "$src_crt" = "$dst_crt" ]; then
+        dst_key=$(kubectl get secret "$TLS_SECRET_NAME" -n "$ns" -o jsonpath='{.data.tls\.key}' 2>/dev/null || true)
+        if [ "$src_crt" = "$dst_crt" ] && [ "$src_key" = "$dst_key" ]; then
             log_success "Secret $TLS_SECRET_NAME em $ns já está sincronizado — preservando."
             continue
         fi


### PR DESCRIPTION
## O que muda

Habilita `unifesspaGeoApi.enabled: true` em `environments/hml-standalone-single/values.yaml`, fechando o último bloqueio registrado em uniplus-infra#492:

- **Hostname**: `geo-api-hml.unifesspa.edu.br`, já registrado pela CTIC (RUNBOOKS §21.2).
- **Database**: `uniplus_geo` (role `uniplus_geo_app`, criado com `TEMPLATE=template_postgis`) provisionado no Postgres compartilhado da VM (`192.168.21.134`) e restaurado a partir de dump real — 1.663.134 logradouros, 74.347 bairros, 5.571 cidades, 27 estados.
- **Secrets no Vault**: `secret/standalone/postgres/geo` e `secret/standalone/geo/encryption` gravados (custódia Shamir manual, ADR-014). `secret/standalone/redis/default` reaproveitado (já existia, usado pelo `redis-ui-in-cluster`).
- **OIDC**: `issuerUri` público (`https://uniplus-oidc-hml.unifesspa.edu.br/auth/realms/unifesspa`), mesmo padrão de `uniplusApiHost`/`apicurioRegistry`.

## Mudança de chart: `customCA.existingSecretName`

O chart `unifesspa-geo-api` só suportava `customCA.certPEM` (PEM estático versionado em `values.yaml`). `CLAUDE.md` proíbe explicitamente commitar certificados — e mesmo sendo só a parte pública, um PEM estático ficaria desatualizado assim que o certificado real da CTIC substituir o autoassinado (Feature 6), exigindo um novo commit manual toda rotação.

Estendi `apps/unifesspa-geo-api` pra suportar `customCA.existingSecretName` (referencia o `Secret` TLS que o Traefik já serve), replicando **exatamente** o padrão já implementado e validado em `uniplusApiHost` — mesmo initContainer `install-custom-ca`, mesmo sidecar `refresh-custom-ca` (observa o volume projetado do Secret e recompõe o bundle de CAs do sistema sem precisar de rollout manual quando o Secret rotacionar):

- `values.yaml`: `customCA.existingSecretName`/`existingSecretKey` (mantém `certPEM` pra paridade com outros ambientes)
- `templates/configmap-custom-ca.yaml`: só renderiza o ConfigMap quando `existingSecretName` está vazio
- `templates/deployment.yaml`: sidecar `refresh-custom-ca` + volume `custom-ca-source` branch entre `Secret` (existingSecretName) e `ConfigMap` (certPEM)
- `README.md` regenerado via `helm-docs`

## Validação local

- `helm lint apps/unifesspa-geo-api/` — verde
- `make helm-lint` — verde (todos os charts)
- `make helm-template` — `unifesspa-geo-api × hml-standalone-single` renderiza 8 recursos (era 0, chart inteiro desabilitado). Inspecionei manualmente: `ConnectionStrings__GeoDb` aponta pro DB certo, `Auth__Authority` pro issuer certo, os 3 `ExternalSecret`s referenciam exatamente os paths gravados no Vault (`secret/standalone/postgres/geo`, `secret/standalone/redis/default`, `secret/standalone/geo/encryption`), volume `custom-ca-source` usa `Secret uniplus-hml-unifesspa-tls`/`tls.crt` (não ConfigMap — confirma que a mudança de chart funcionou), `IngressRoute` com `Host(geo-api-hml.unifesspa.edu.br)`.

## Deploy e validação ao vivo

Após merge, ArgoCD sincroniza (`selfHeal: true`) — vou forçar refresh se necessário (já observado nesta sessão: um PR tocando 2 Applications ao mesmo tempo, como este que também mexe no `uniplus-api-host` indiretamente não — este PR só toca `unifesspa-geo-api`). Vou validar `https://geo-api-hml.unifesspa.edu.br/health` + pelo menos 1 endpoint de consulta real (CEP/logradouro) contra os dados restaurados.

Closes #492