### PR TITLE
docs(hml): registra uso do certificado real da CTIC em produção

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -4011,9 +4011,12 @@ rotas de negócio do host raiz.
    **Decisão final (uniplus-infra#460/#495):** alternativa **(b)**. CTIC (Idelvandro Fonseca,
    15/07/2026) confirmou participação no ICPEdu Corporativo e emitiu **wildcard**
    `*.unifesspa.edu.br` (não SAN por host, como o texto acima cogitava — simplifica: cobre os 9
-   hostnames do §21.2 de uma vez, inclusive futuros sob o mesmo domínio) via
-   `RNP ICPEdu GR46 OV TLS CA 2025` → `GlobalSign Root R46`, cadeia nativamente confiável em
-   qualquer navegador/runtime padrão. Em uso desde 21/08/2026 — ver nota em §21.1.
+   hostnames do §21.2 de uma vez, inclusive futuros hosts de 1 nível direto sob o domínio, ex.
+   `novo-servico.unifesspa.edu.br`) via `RNP ICPEdu GR46 OV TLS CA 2025` → `GlobalSign Root R46`,
+   cadeia nativamente confiável em qualquer navegador/runtime padrão. Em uso desde 21/08/2026 —
+   ver nota em §21.1. **Atenção:** wildcard cobre só 1 label — `*.unifesspa.edu.br` casa
+   `foo.unifesspa.edu.br`, não `foo.hml.unifesspa.edu.br` (2 níveis); hostname aninhado mais
+   fundo exige SAN adicional ou outro wildcard, não é coberto por este certificado.
 
    Sem viabilidade de (a), (b) ou (c) com confiança ampla, o ambiente sobe com certificado
    manual/importado — aceitável só como paliativo explícito de bring-up administrativo (nunca

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -3940,6 +3940,13 @@ homologação**. Um certificado temporário (autoassinado ou importado manualmen
 durante o bootstrap administrativo (smoke tests internos da equipe), nunca para a fase de
 homologação com usuários — ver §21.2, item 2.
 
+**Resolvido (uniplus-infra#495):** o Secret `uniplus-hml-unifesspa-tls` (namespaces `uniplus` e
+`geo`) serve o certificado real desde 21/08/2026 — decisão **(b) AC SSL Corporativa ICPEdu/RNP**
+(cadeia GlobalSign, reconhecida nativamente pelos navegadores, sem aviso de certificado
+inválido). Wildcard `*.unifesspa.edu.br`, `notBefore=2026-05-11`, **`notAfter=2026-11-26`
+— renovar antes dessa data**. Material (chave privada + full chain) mantido só na VM
+(`/home/uniplus/`), nunca neste repositório.
+
 ### 21.2 Hostnames DNS a solicitar à CTIC
 
 | # | Hostname | Tipo | Aponta para | Papel |
@@ -4000,6 +4007,14 @@ rotas de negócio do host raiz.
      institucionais gerenciadas, ou também navegadores de usuários externos à rede gerenciada?
      Se a raiz já for amplamente confiável no público-alvo deste HML, (c) pode ser **solução
      definitiva**, não apenas paliativa.
+
+   **Decisão final (uniplus-infra#460/#495):** alternativa **(b)**. CTIC (Idelvandro Fonseca,
+   15/07/2026) confirmou participação no ICPEdu Corporativo e emitiu **wildcard**
+   `*.unifesspa.edu.br` (não SAN por host, como o texto acima cogitava — simplifica: cobre os 9
+   hostnames do §21.2 de uma vez, inclusive futuros sob o mesmo domínio) via
+   `RNP ICPEdu GR46 OV TLS CA 2025` → `GlobalSign Root R46`, cadeia nativamente confiável em
+   qualquer navegador/runtime padrão. Em uso desde 21/08/2026 — ver nota em §21.1.
+
    Sem viabilidade de (a), (b) ou (c) com confiança ampla, o ambiente sobe com certificado
    manual/importado — aceitável só como paliativo explícito de bring-up administrativo (nunca
    para a fase de homologação com usuários reais), já que um certificado importado manualmente

--- a/scripts/hml-standalone-single/bootstrap.sh
+++ b/scripts/hml-standalone-single/bootstrap.sh
@@ -677,6 +677,15 @@ step_setup_kafka() {
 # customCA.certPEM — ver comentário em
 # environments/hml-standalone-single/values.yaml) — só o Secret Kubernetes,
 # consumido diretamente pelos IngressRoute via `tls.secretName`.
+#
+# ATUALIZAÇÃO (uniplus-infra#495, 21/08/2026): este step só GERA um
+# autoassinado quando o Secret ainda não existe — já preserva, sem
+# sobrescrever, qualquer conteúdo prévio. O Secret em produção hoje já foi
+# substituído manualmente pelo certificado real da CTIC (alternativa (b)
+# ICPEdu/RNP, ver RUNBOOKS §21.2 item 2) — este step só volta a gerar
+# autoassinado se o Secret for apagado/recriado do zero (ex. bootstrap
+# limpo numa VM nova), cenário em que alguém precisa repetir a substituição
+# manual (material em `/home/uniplus/` na VM, nunca neste repositório).
 # ============================================================================
 
 step_generate_tls_secret() {


### PR DESCRIPTION
## O que muda

Documenta a substituição do Secret TLS autoassinado pelo certificado real da CTIC, já executada ao vivo na VM. Não há mudança de comportamento de código — o step `step_generate_tls_secret` já preservava qualquer Secret existente (não sobrescreve), então nenhum ajuste de lógica foi necessário, só o comentário explicando a origem atual do material.

## Contexto

CTIC (Idelvandro Fonseca) já tinha respondido o pedido de TLS em 15/07/2026 (`uniplus-infra#460`, já `CLOSED`) com decisão pela alternativa **(b) AC SSL Corporativa ICPEdu/RNP** — um wildcard `*.unifesspa.edu.br` (cadeia `RNP ICPEdu GR46 OV TLS CA 2025` → `GlobalSign Root R46`), mas a substituição em si nunca tinha sido executada — o ambiente seguia no autoassinado provisório.

## Validação

Substituição feita manualmente hoje (`kubectl create secret tls ... --dry-run=client -o yaml | kubectl apply -f -` nos namespaces `uniplus` e `geo`, seguido de `rollout restart` dos deployments com `customCA.enabled` pra recarregar o bundle):

- Modulus do cert/chave conferido (par válido) antes de aplicar
- `curl` **sem** `--insecure` retorna 200 em `uniplus-hml`, `geo-api-hml`, `uniplus-oidc-hml` — cadeia pública reconhecida nativamente, sem trust store customizado
- Pods `uniplus-api-host` e `unifesspa-geo-api` reiniciados e `2/2 Running`

## Pendente (fora do escopo deste PR, registrado em uniplus-infra#495)

- Avaliar se `customCA.enabled` ainda é necessário pros apps .NET — a cadeia agora resolve pra uma raiz (GlobalSign) já confiável nativamente, então o initContainer/sidecar de CA customizada pode estar redundante. Mudança de comportamento maior, melhor testada em separado.
- Lembrete de renovação antes de 2026-11-26 (validade ~6 meses, padrão OV).

Closes #495