### PR TITLE
feat(hml): redireciona a raiz nua do host pro portal

### DIFF
--- a/apps/uniplus-web/README.md
+++ b/apps/uniplus-web/README.md
@@ -57,6 +57,8 @@ templates/
 | `apps.selecao.pathPrefix` / `apps.ingresso.pathPrefix` | `""` | Mesmo comportamento de subpath do Portal |
 | `ingress.enabled` | `true` | Habilita os IngressRoutes das SPAs ativas |
 | `ingress.tls.enabled` | `true` | Configura TLS para os IngressRoutes |
+| `ingress.rootRedirect.enabled` | `false` | Redireciona a raiz nua do host (`Host()` sem `PathPrefix`, sem app próprio) pra um dos apps habilitados. Só relevante em ambientes com múltiplos apps sob o mesmo host (subpath) — não muda nada quando cada app tem host próprio |
+| `ingress.rootRedirect.to` | `""` | Path de destino do redirect, com barra final (ex.: `/portal/`) — precisa bater com o `pathPrefix` de um app habilitado, senão o chart falha o render |
 
 ## Roteamento path-based
 

--- a/apps/uniplus-web/templates/ingressroute-root-redirect.yaml
+++ b/apps/uniplus-web/templates/ingressroute-root-redirect.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.uniplusWeb.enabled .Values.uniplusWeb.ingress.enabled .Values.uniplusWeb.ingress.rootRedirect.enabled -}}
+{{- $rr := .Values.uniplusWeb.ingress.rootRedirect -}}
+{{- if not $rr.to -}}
+{{- fail "uniplusWeb.ingress.rootRedirect.to é obrigatório quando rootRedirect.enabled=true (ex.: /portal/)." -}}
+{{- end -}}
+{{- $targetApp := "" -}}
+{{- $host := "" -}}
+{{- range $app, $cfg := .Values.uniplusWeb.apps -}}
+{{- if $cfg.enabled -}}
+{{- if not $host -}}{{- $host = $cfg.host -}}{{- end -}}
+{{- if eq (printf "%s/" (trimSuffix "/" $cfg.pathPrefix)) $rr.to -}}
+{{- $targetApp = $app -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if not $host -}}
+{{- fail "uniplusWeb.ingress.rootRedirect.enabled=true mas nenhum app em uniplusWeb.apps está habilitado com host definido." -}}
+{{- end -}}
+{{- if not $targetApp -}}
+{{- fail (printf "uniplusWeb.ingress.rootRedirect.to (%s) não corresponde ao pathPrefix de nenhum app habilitado — confira a barra final e o valor exato de apps.<app>.pathPrefix." $rr.to) -}}
+{{- end -}}
+# Middleware + IngressRoute dedicados: só casam a raiz nua (Path exato "/"),
+# nunca conflitam com o PathPrefix de cada app (Traefik prioriza regras mais
+# longas automaticamente, mas o match explícito por Path evita qualquer
+# ambiguidade). O Service referenciado abaixo nunca é de fato chamado — o
+# CRD IngressRoute exige um `services` válido mesmo quando o Middleware
+# intercepta a resposta antes do proxy.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "uniplusWeb.fullname" . }}-root-redirect
+  labels:
+    {{- include "uniplusWeb.labels" (dict "ctx" $ "app" "root-redirect") | nindent 4 }}
+spec:
+  redirectRegex:
+    regex: "^https://([^/]+)/$"
+    replacement: "https://${1}{{ $rr.to }}"
+    permanent: false
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "uniplusWeb.fullname" . }}-root-redirect
+  labels:
+    {{- include "uniplusWeb.labels" (dict "ctx" $ "app" "root-redirect") | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.uniplusWeb.ingress.entryPoint }}
+  routes:
+    - match: Host(`{{ $host }}`) && Path(`/`)
+      kind: Rule
+      middlewares:
+        - name: {{ include "uniplusWeb.fullname" . }}-root-redirect
+      services:
+        - name: {{ include "uniplusWeb.appFullname" (dict "ctx" $ "app" $targetApp) }}
+          port: 8080
+  {{- if .Values.uniplusWeb.ingress.tls.enabled }}
+  tls:
+    secretName: {{ .Values.uniplusWeb.ingress.tls.secretName | default (printf "%s-root-redirect-tls" (include "uniplusWeb.fullname" .)) }}
+  {{- end }}
+{{- end }}

--- a/apps/uniplus-web/templates/ingressroute-root-redirect.yaml
+++ b/apps/uniplus-web/templates/ingressroute-root-redirect.yaml
@@ -3,18 +3,16 @@
 {{- if not $rr.to -}}
 {{- fail "uniplusWeb.ingress.rootRedirect.to é obrigatório quando rootRedirect.enabled=true (ex.: /portal/)." -}}
 {{- end -}}
+{{- if eq $rr.to "/" -}}
+{{- fail "uniplusWeb.ingress.rootRedirect.to não pode ser \"/\" — redirecionaria a raiz pra ela mesma (loop infinito). Precisa apontar pro pathPrefix de um app com subpath real, ex.: /portal/." -}}
+{{- end -}}
 {{- $targetApp := "" -}}
 {{- $host := "" -}}
 {{- range $app, $cfg := .Values.uniplusWeb.apps -}}
-{{- if $cfg.enabled -}}
-{{- if not $host -}}{{- $host = $cfg.host -}}{{- end -}}
-{{- if eq (printf "%s/" (trimSuffix "/" $cfg.pathPrefix)) $rr.to -}}
+{{- if and $cfg.enabled (eq (printf "%s/" (trimSuffix "/" $cfg.pathPrefix)) $rr.to) -}}
 {{- $targetApp = $app -}}
+{{- $host = $cfg.host -}}
 {{- end -}}
-{{- end -}}
-{{- end -}}
-{{- if not $host -}}
-{{- fail "uniplusWeb.ingress.rootRedirect.enabled=true mas nenhum app em uniplusWeb.apps está habilitado com host definido." -}}
 {{- end -}}
 {{- if not $targetApp -}}
 {{- fail (printf "uniplusWeb.ingress.rootRedirect.to (%s) não corresponde ao pathPrefix de nenhum app habilitado — confira a barra final e o valor exato de apps.<app>.pathPrefix." $rr.to) -}}

--- a/apps/uniplus-web/templates/ingressroute-root-redirect.yaml
+++ b/apps/uniplus-web/templates/ingressroute-root-redirect.yaml
@@ -31,8 +31,12 @@ metadata:
     {{- include "uniplusWeb.labels" (dict "ctx" $ "app" "root-redirect") | nindent 4 }}
 spec:
   redirectRegex:
-    regex: "^https://([^/]+)/$"
-    replacement: "https://${1}{{ $rr.to }}"
+    # Query string opcional e preservada — sem o grupo "(\?.*)?", uma URL como
+    # "/?utm_source=..." não bate no fim ancorado ($), e a requisição passa
+    # direto pro Service (Portal servido incorretamente sob "/" em vez de
+    # redirecionar pra "/portal/") — achado do Codex AI, uniplus-infra#499.
+    regex: "^https://([^/]+)/(\\?.*)?$"
+    replacement: "https://${1}{{ $rr.to }}${2}"
     permanent: false
 ---
 apiVersion: traefik.io/v1alpha1

--- a/apps/uniplus-web/templates/ingressroute-root-redirect.yaml
+++ b/apps/uniplus-web/templates/ingressroute-root-redirect.yaml
@@ -31,12 +31,15 @@ metadata:
     {{- include "uniplusWeb.labels" (dict "ctx" $ "app" "root-redirect") | nindent 4 }}
 spec:
   redirectRegex:
-    # Query string opcional e preservada — sem o grupo "(\?.*)?", uma URL como
-    # "/?utm_source=..." não bate no fim ancorado ($), e a requisição passa
-    # direto pro Service (Portal servido incorretamente sob "/" em vez de
-    # redirecionar pra "/portal/") — achado do Codex AI, uniplus-infra#499.
-    regex: "^https://([^/]+)/(\\?.*)?$"
-    replacement: "https://${1}{{ $rr.to }}${2}"
+    # Scheme capturado e reusado (não hardcoded "https://") — ingress.tls é
+    # opcional no chart; com tls.enabled=false a requisição chega via HTTP
+    # puro e uma regex fixa em "https://" nunca bateria, deixando passar
+    # direto pro Service sem redirecionar. Query string opcional e
+    # preservada — sem o grupo "(\?.*)?", uma URL como "/?utm_source=..."
+    # não bate no fim ancorado ($) pelo mesmo motivo. Achados do Codex AI,
+    # uniplus-infra#499.
+    regex: "^(https?)://([^/]+)/(\\?.*)?$"
+    replacement: "${1}://${2}{{ $rr.to }}${3}"
     permanent: false
 ---
 apiVersion: traefik.io/v1alpha1

--- a/apps/uniplus-web/templates/ingressroute-root-redirect.yaml
+++ b/apps/uniplus-web/templates/ingressroute-root-redirect.yaml
@@ -56,6 +56,11 @@ spec:
           port: 8080
   {{- if .Values.uniplusWeb.ingress.tls.enabled }}
   tls:
-    secretName: {{ .Values.uniplusWeb.ingress.tls.secretName | default (printf "%s-root-redirect-tls" (include "uniplusWeb.fullname" .)) }}
+    # Fallback reusa o Secret do app-alvo (certificate.yaml só cria Secret
+    # por-app, "<appFullname>-tls" — um "-root-redirect-tls" nunca existiria
+    # nesse chart). Correto por construção: a rota do redirect serve sob o
+    # MESMO host do app-alvo, TLS é por host, não por path (achado do Codex
+    # AI, uniplus-infra#499).
+    secretName: {{ .Values.uniplusWeb.ingress.tls.secretName | default (printf "%s-tls" (include "uniplusWeb.appFullname" (dict "ctx" $ "app" $targetApp))) }}
   {{- end }}
 {{- end }}

--- a/apps/uniplus-web/values.yaml
+++ b/apps/uniplus-web/values.yaml
@@ -186,6 +186,16 @@ uniplusWeb:
         enabled: true
         clusterIssuer: letsencrypt-prod
 
+    # Redirect opcional da raiz nua do host (Host() sem PathPrefix — sem rota
+    # própria por design quando múltiplos apps dividem o mesmo FQDN via
+    # subpath, RUNBOOKS §21.3; sem isso, a raiz cai no 404 do Traefik). Só
+    # tem efeito com `enabled: true` — default desligado, não muda nada em
+    # ambientes com host próprio por app (standalone-compact). `to` precisa
+    # apontar pro pathPrefix de um app habilitado, com barra final.
+    rootRedirect:
+      enabled: false
+      to: ""  # ex.: /portal/
+
   # NetworkPolicy: ingress só do namespace Traefik; egress só DNS (CoreDNS).
   # Nginx-unprivileged não chama upstream — todas as requests externas
   # (Keycloak, API) são feitas pelo browser do usuário, não pelo pod.

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -604,6 +604,12 @@ uniplusWeb:
       secretName: uniplus-hml-unifesspa-tls
       certManager:
         enabled: false
+    # Raiz nua (https://uniplus-hml.unifesspa.edu.br/) não tem app próprio —
+    # redireciona pro portal, o app padrão dos 4 sob subpath. Sem isso, cai
+    # no 404 do Traefik (RUNBOOKS §21.3).
+    rootRedirect:
+      enabled: true
+      to: /portal/
 
 kubePrometheusStack:
   enabled: false


### PR DESCRIPTION
## O que muda

`https://uniplus-hml.unifesspa.edu.br/` retornava 404 (raiz sem app próprio por design, RUNBOOKS §21.3). Adiciona `uniplusWeb.ingress.rootRedirect` genérico ao chart — `Middleware` `redirectRegex` + `IngressRoute` dedicado casando `Path` exato `/` (nunca conflita com o `PathPrefix` de cada app) — e habilita em HML redirecionando pro `/portal/`.

Desligado por default (`enabled: false`) — zero impacto em `standalone-compact`, onde cada app já tem host próprio.

## Detalhe de implementação

O CRD `IngressRoute` exige um `services` válido mesmo quando o `Middleware` intercepta a resposta antes do proxy (o service nunca é de fato chamado). Resolvo o app-alvo pelo `pathPrefix` que bate com `rootRedirect.to`, não "o primeiro app do map" — `range` sobre map no Go template itera em ordem alfabética das chaves (`configuracao` vem antes de `portal`), então pegar "o primeiro" apontaria pro app errado no manifest (confuso na leitura, mesmo não afetando o redirect real). Falha o render com mensagem clara se `to` não corresponder a nenhum app habilitado.

## Validação local

- `helm lint apps/uniplus-web/` — verde
- `helm template ... -f environments/hml-standalone-single/values.yaml` — `IngressRoute` renderiza `Host(uniplus-hml.unifesspa.edu.br) && Path(/)`, `Middleware` com regex `^https://([^/]+)/$` → `https://${1}/portal/`, service-alvo `uniplus-web-uniplus-web-portal` (corrigido — antes da correção acima, apontava incorretamente pra `configuracao`)
- Testei a validação de erro: `--set uniplusWeb.ingress.rootRedirect.to=/naoexiste/` falha o render com mensagem clara
- `helm template ... -f environments/standalone-compact/values.yaml` — 0 recursos `root-redirect` (confirma zero impacto, default off)
- README do chart atualizado manualmente (é escrito à mão, não segue o padrão `helm-docs` — rodei `helm-docs` por engano, vi que reescreveria 220 linhas de conteúdo narrativo customizado, revertei e editei só a tabela relevante)

## Deploy e validação ao vivo

Após merge, vou confirmar `curl -sk -o /dev/null -w '%{http_code} -> %{redirect_url}' https://uniplus-hml.unifesspa.edu.br/` retornando 302/307 pro `/portal/`.

Closes #499