### PR TITLE
fix(keycloak): adiciona ao realm.json os roles que o frontend já usa

### DIFF
--- a/apps/keycloak-replica/files/uniplus-realm.json
+++ b/apps/keycloak-replica/files/uniplus-realm.json
@@ -461,7 +461,11 @@
     "realm": [
       { "name": "uniplus-user", "description": "Usuário autenticado básico do Uni+" },
       { "name": "uniplus-staff", "description": "Servidor/colaborador da Unifesspa" },
-      { "name": "uniplus-admin", "description": "Administrador da plataforma Uni+" }
+      { "name": "uniplus-admin", "description": "Administrador da plataforma Uni+" },
+      { "name": "admin", "description": "Acesso administrativo em Seleção/Ingresso (roleGuard uniplus-web)" },
+      { "name": "gestor", "description": "Gestor de processo seletivo em Seleção/Ingresso (roleGuard uniplus-web)" },
+      { "name": "avaliador", "description": "Avaliador de recursos/homologação em Seleção (roleGuard uniplus-web)" },
+      { "name": "plataforma-admin", "description": "Administrador da Configuração (cadastros base institucionais — roleGuard uniplus-web)" }
     ]
   },
   "requiredCredentials": ["password"],


### PR DESCRIPTION
## O que muda

Adiciona ao array `roles.realm` de `apps/keycloak-replica/files/uniplus-realm.json`: `admin`, `gestor`, `avaliador`, `plataforma-admin`.

## Por quê

`uniplus-web` controla acesso a Seleção/Ingresso/Configuração via `roleGuard()` (`libs/shared-auth/src/lib/guards/role.guard.ts`), checando `realm_access.roles` do token contra esses 4 roles (`apps/{selecao,ingresso,configuracao}/src/app/app.routes.ts`). Nenhum existia no `realm.json` — sem eles, ninguém passa do `/acesso-negado` nesses 3 apps, mesmo autenticado corretamente. Descoberto e já corrigido manualmente no Keycloak ao vivo de HML (`kcadm.sh`, não versionado — correto, é dado operacional) pra desbloquear testes; este PR corrige a fonte declarativa.

## Sobre os 3 roles pré-existentes (`uniplus-user`/`uniplus-staff`/`uniplus-admin`)

Não achei nenhum consumidor real deles em `uniplus-web` nem indício de uso em `uniplus-api` (buscas via GitHub code search). Deixo como estão — decisão sobre remover é à parte, não bloqueia este fix.

## Validação local

- `helm lint apps/keycloak-replica/` — verde
- `helm template ... -f environments/hml-standalone-single/values.yaml` — parseei o JSON do `ConfigMap` renderizado e confirmei os 7 roles presentes (3 originais + 4 novos)

## Nota operacional

Como o `realm-reconcile-job` só importa uma vez por realm (import não roda de novo em realm já existente), este PR **não precisa** de nenhuma ação em HML — já está com os roles aplicados manualmente. Só corrige a fonte pra ambientes futuros/reimportados.

Closes #498