### PR TITLE
fix(uniplus-api-host): adiciona /api/organizacao ao pathPrefixes de HML

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -384,6 +384,7 @@ uniplusApiHost:
       - /api/ingresso
       - /api/selecao
       - /api/configuracao
+      - /api/organizacao
       - /api/publicacoes
       - /api/auth
       - /api/profile


### PR DESCRIPTION
## O que muda

Adiciona `/api/organizacao` à allowlist `pathPrefixes` do `IngressRoute` do `uniplus-api-host` em `environments/hml-standalone-single/values.yaml` — mesmo padrão já usado para habilitar `configuracao`, `ingresso` e `selecao`.

## Por quê

O frontend `configuracao` chama `GET /api/organizacao/unidades`, que o navegador reporta como bloqueio de CORS. Causa raiz: o módulo `organizacao-institucional` já está compilado e rodando no pod do monólito (`uniplus-api-host:v0.4.1`, desde junho — o endpoint aparece em `/openapi/organizacao.json`), mas nunca foi incluído na lista de `pathPrefixes` do Traefik em HML. O Traefik responde 404 antes da requisição chegar no Kestrel, então sem o header `Access-Control-Allow-Origin` do middleware CORS do .NET — daí o navegador reportar CORS, quando na verdade é rota ausente no Ingress.

Como `uniplus-api-hml.unifesspa.edu.br` é servido por um único backend (o monólito), a lista de `pathPrefixes` não separa serviços diferentes — funciona como ativação explícita por módulo.

## Validação

- `make helm-lint` / `make yaml-lint` / `make schema-validate` limpos.
- `helm template` confirma a nova rota `PathPrefix(\`/api/organizacao\`)` no `IngressRoute` renderizado.
- Pós-merge: validação end-to-end em HML (curl + Playwright) confirmando `200` no endpoint e a tela `/configuracao/unidades` carregando sem erro de console.

Closes #502