### PR TITLE
chore: bump uniplus-api-host para v0.5.0 e uniplus-web para v0.2.4 em HML

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.4.1
+    tag: v0.5.0
 
   database:
     host: 192.168.21.134
@@ -523,7 +523,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.2.2
+      tag: v0.2.4
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -545,7 +545,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.2.2
+      tag: v0.2.4
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -562,7 +562,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.2.2
+      tag: v0.2.4
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.2.3
+      tag: v0.2.4
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.5.0
+    tag: v0.5.1
 
   database:
     host: 192.168.21.134


### PR DESCRIPTION
## O que muda

- `uniplusApiHost.image.tag`: `v0.4.1` → `v0.5.0`
- `uniplusWeb.apps.{portal,selecao,ingresso,configuracao}.tag`: todos → `v0.2.4` (lockstep, corrige a divergência entre `v0.2.2`/`v0.2.3`)

## Por quê

HML estava rodando `v0.4.1` (16/07/2026), ~440 commits atrás de main — 37 migrations e endpoints já implementados no código (`/api/organizacao/unidades`, `/api/configuracao/tipos-processo`) nunca tinham sido publicados. `uniplus-web` também nunca seguiu o lockstep de publicação (`configuracao` num tag, os outros 3 em outro).

Releases já publicadas em GHCR a partir de main: `uniplus-api` `v0.5.0`, `uniplus-web` `v0.2.4` (inclui a correção de CSP `style-src-elem`, #565).

## Risco e acompanhamento

37 migrations EF Core aplicam automaticamente no boot do `uniplus-api-host` (`MigrationHostedService` por `DbContext`) — sem passo manual, mas se qualquer uma falhar o pod entra em `CrashLoopBackOff`. **Vou acompanhar o log do pod logo após o rollout antes de declarar concluído.**

## Validação

- `make helm-lint` / `make yaml-lint` / `make schema-validate` limpos.
- Pós-merge: log de boot do `uniplus-api-host` confirmando migrations aplicadas; `GET /api/organizacao/unidades` e `GET /api/configuracao/tipos-processo` sem 404; os 4 apps web sem violação de CSP no console.

Closes #504