### PR TITLE
fix(uniplus-api-host): adiciona ConnectionStrings__DiscentesDb ao template

### DIFF
--- a/apps/uniplus-api-host/templates/deployment.yaml
+++ b/apps/uniplus-api-host/templates/deployment.yaml
@@ -125,10 +125,10 @@ spec:
             - name: ASPNETCORE_URLS
               value: {{ .Values.uniplusApiHost.aspnet.urls | quote }}
             # === Postgres — banco único `uniplus`, schema-por-módulo (ADR-0097).
-            # As 6 connection strings (UniPlusDb/ConfiguracaoDb/OrganizacaoDb/
-            # SelecaoDb/IngressoDb/PublicacoesDb) apontam para o MESMO
-            # host/database/role — cada DbContext usa seu próprio schema via
-            # HasDefaultSchema. UniPlusDb é consumida pelo outbox Wolverine
+            # As 7 connection strings (UniPlusDb/ConfiguracaoDb/OrganizacaoDb/
+            # SelecaoDb/IngressoDb/PublicacoesDb/DiscentesDb) apontam para o
+            # MESMO host/database/role — cada DbContext usa seu próprio schema
+            # via HasDefaultSchema. UniPlusDb é consumida pelo outbox Wolverine
             # (schema `wolverine`) e pelos health checks
             # (AddUniPlusHealthChecks connectionStringName). ===
             - name: POSTGRES_PASSWORD
@@ -137,7 +137,7 @@ spec:
                   name: {{ include "uniplusApiHost.postgresSecretName" . }}
                   key: POSTGRES_PASSWORD
             {{- $db := .Values.uniplusApiHost.database }}
-            {{- range list "UniPlusDb" "ConfiguracaoDb" "OrganizacaoDb" "SelecaoDb" "IngressoDb" "PublicacoesDb" }}
+            {{- range list "UniPlusDb" "ConfiguracaoDb" "OrganizacaoDb" "SelecaoDb" "IngressoDb" "PublicacoesDb" "DiscentesDb" }}
             - name: ConnectionStrings__{{ . }}
               value: "Host={{ $db.host }};Port={{ $db.port }};Database={{ $db.name }};Username={{ $db.username }};Password=$(POSTGRES_PASSWORD)"
             {{- end }}

--- a/apps/uniplus-api-host/values.yaml
+++ b/apps/uniplus-api-host/values.yaml
@@ -74,9 +74,9 @@ uniplusApiHost:
     urls: "http://+:8080"
 
   # === Backend Postgres — banco único `uniplus`, schema-por-módulo
-  # (ADR-0097). As 6 connection strings do host (UniPlusDb, ConfiguracaoDb,
-  # OrganizacaoDb, SelecaoDb, IngressoDb, PublicacoesDb — renderizadas
-  # incondicionalmente pelo template) apontam todas para host/database/
+  # (ADR-0097). As 7 connection strings do host (UniPlusDb, ConfiguracaoDb,
+  # OrganizacaoDb, SelecaoDb, IngressoDb, PublicacoesDb, DiscentesDb —
+  # renderizadas incondicionalmente pelo template) apontam todas para host/database/
   # username abaixo; cada DbContext usa seu próprio schema via
   # HasDefaultSchema. UniPlusDb é consumida pelo outbox Wolverine (schema
   # `wolverine`) e pelos health checks (AddUniPlusHealthChecks


### PR DESCRIPTION
## O que muda

Adiciona \`DiscentesDb\` à lista de connection strings renderizadas por \`apps/uniplus-api-host/templates/deployment.yaml\` (6 → 7), e atualiza o comentário correspondente em \`values.yaml\`.

## Por quê

Rollout da v0.5.1 em HML: pod novo entra em \`CrashLoopBackOff\` — \`ConnectionStrings:DiscentesDb não configurada\`. O módulo \`Discentes\` (novo desde a v0.4.1, ~440 commits atrás) registra seu \`DbContext\` com o mesmo padrão dos outros 6 módulos, mas o template do chart nunca foi atualizado pra incluir essa 7ª connection string. Mesmo banco Postgres único, schema-por-módulo (ADR-0097) — não precisa de banco/role novo, só a env var a mais.

Sem outage: o pod anterior (v0.4.1) segue \`Running\` normalmente durante o rollout falho (ArgoCD/K8s não substitui o pod saudável por um que não passa no readiness).

## Validação

- \`helm template\` confirma \`ConnectionStrings__DiscentesDb\` renderizado corretamente, mesmo host/database/username dos outros 6.
- \`make helm-lint\` / \`make yaml-lint\` limpos.
- Pós-merge: pod novo sobe \`2/2 Running\`, log confirma schema \`discentes\` aplicado.

Closes #506