### PR TITLE
fix(uniplus-web): configura geoApiUrl real em HML e renderiza no chart

### DIFF
--- a/apps/uniplus-web/templates/configmap-runtime.yaml
+++ b/apps/uniplus-web/templates/configmap-runtime.yaml
@@ -25,6 +25,12 @@
 # do pod (mas restart não dói — `data.runtime-config.json` muda hash do
 # objeto, ConfigMap reload é automático via subPath no volume).
 #
+# geoApiUrl é opcional (issue #508): só renderiza quando
+# $cfg.runtimeConfig.geoApiUrl está definido, sem `fail` de validação —
+# nem todo app consome endpoints geo. Necessário quando geo-api é
+# deployable separado do apiUrl (host próprio, ex. HML); o frontend cai
+# no apiUrl quando o campo está ausente (dev local, gateway único).
+#
 # Renderiza os dois formatos de OIDC em paralelo — "oidc" (contrato
 # neutro, uniplus-web commit 9884c64, 2026-05-31) e "keycloak" (formato
 # anterior). standalone-compact/lab seguem pinados em v0.2.1 (chart
@@ -44,6 +50,9 @@ data:
   runtime-config.json: |
     {
       "apiUrl": {{ $cfg.runtimeConfig.apiUrl | quote }},
+      {{- if $cfg.runtimeConfig.geoApiUrl }}
+      "geoApiUrl": {{ $cfg.runtimeConfig.geoApiUrl | quote }},
+      {{- end }}
       "oidc": {
         "issuerUrl": {{ $cfg.runtimeConfig.oidc.issuerUrl | quote }},
         "clientId": {{ $cfg.runtimeConfig.oidc.clientId | quote }}

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -523,7 +523,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.2.4
+      tag: v0.2.5
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -545,12 +545,16 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.2.4
+      tag: v0.2.5
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
         # uniplus-api-host (pathPrefixes acima).
         apiUrl: https://uniplus-api-hml.unifesspa.edu.br
+        # geo-api é deployable separado (issue #508) — próprio host, não
+        # atrás do uniplus-api-host. Sem isso, GET /api/cidades (wizard de
+        # processo seletivo) caía no apiUrl errado.
+        geoApiUrl: https://geo-api-hml.unifesspa.edu.br
         oidc:
           issuerUrl: https://uniplus-oidc-hml.unifesspa.edu.br/auth/realms/unifesspa
           clientId: uniplus-portal
@@ -562,7 +566,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.2.4
+      tag: v0.2.5
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -580,7 +584,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.2.4
+      tag: v0.2.5
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já
@@ -590,6 +594,9 @@ uniplusWeb:
         # ao contrário do portal/ingresso, este módulo deve responder de
         # verdade, não só servir o shell estático.
         apiUrl: https://uniplus-api-hml.unifesspa.edu.br
+        # geo-api é deployable separado (issue #508) — usado no formulário
+        # de endereço (busca de CEP/cidade). Ver comentário do selecao acima.
+        geoApiUrl: https://geo-api-hml.unifesspa.edu.br
         oidc:
           issuerUrl: https://uniplus-oidc-hml.unifesspa.edu.br/auth/realms/unifesspa
           clientId: uniplus-portal


### PR DESCRIPTION
## O que muda

1. \`apps/uniplus-web/templates/configmap-runtime.yaml\`: renderiza \`"geoApiUrl"\` no \`runtime-config.json\` quando \`$cfg.runtimeConfig.geoApiUrl\` está definido (campo opcional, sem \`fail\` de validação).
2. \`environments/hml-standalone-single/values.yaml\`: \`geoApiUrl: https://geo-api-hml.unifesspa.edu.br\` pros apps \`selecao\`/\`configuracao\`; bump dos 4 apps pra tag \`v0.2.5\`.

## Por quê

Em HML, \`selecao\`/\`configuracao\` chamavam \`/api/cidades\` e \`/api/cep\` pro host errado (\`uniplus-api-hml\` em vez de \`geo-api-hml\`, deployable separado, host próprio). Causa: o frontend (\`uniplus-web\` \`v0.2.5\`, issue #570) agora lê um campo \`geoApiUrl\` opcional do \`runtime-config.json\` — mas o chart deste repositório nunca renderizava esse campo, e os apps em HML não tinham o valor configurado.

## Validação

- \`helm template\` confirma \`geoApiUrl\` presente e correto nos ConfigMaps de \`selecao\`/\`configuracao\`, ausente (JSON ainda válido) nos de \`portal\`/\`ingresso\`.
- \`make helm-lint\` / \`make yaml-lint\` / \`make schema-validate\` limpos.
- Pós-merge: \`GET /api/cidades\` chamado do wizard de processo seletivo vai pro host certo, com token anexado, sem CORS/401.

Closes #508