### PR TITLE
chore(hml): promove uniplus-api v0.6.0 e uniplus-web v0.2.6

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.5.1
+    tag: v0.6.0
 
   database:
     host: 192.168.21.134
@@ -523,7 +523,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.2.5
+      tag: v0.2.6
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -545,7 +545,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.2.5
+      tag: v0.2.6
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -566,7 +566,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.2.5
+      tag: v0.2.6
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -584,7 +584,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.2.5
+      tag: v0.2.6
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Aponta `hml-standalone-single` para as releases correntes dos dois repositórios de aplicação.

## Mudança

| Componente | De | Para |
|---|---|---|
| `uniplusApiHost.image.tag` | `v0.5.1` | `v0.6.0` |
| `uniplusWeb.apps.portal.tag` | `v0.2.5` | `v0.2.6` |
| `uniplusWeb.apps.selecao.tag` | `v0.2.5` | `v0.2.6` |
| `uniplusWeb.apps.ingresso.tag` | `v0.2.5` | `v0.2.6` |
| `uniplusWeb.apps.configuracao.tag` | `v0.2.5` | `v0.2.6` |

Cinco linhas, nenhuma outra alteração no ambiente.

## Verificação local

- `make lint` e `make validate` passam (exit 0).
- `helm template` do ambiente renderiza exatamente as imagens esperadas:
  - `ghcr.io/unifesspa-edu-br/uniplus-api-host:v0.6.0`
  - `ghcr.io/unifesspa-edu-br/uniplus-portal:v0.2.6`
  - `ghcr.io/unifesspa-edu-br/uniplus-web-selecao:v0.2.6`
  - `ghcr.io/unifesspa-edu-br/uniplus-web-ingresso:v0.2.6`
  - `ghcr.io/unifesspa-edu-br/uniplus-web-configuracao:v0.2.6`

## Impacto

Só `hml-standalone-single`. `standalone-compact` e `lab-standalone-single` seguem nos pins próprios,
porque o override permanece no values do ambiente e não no default do chart.

Como o ApplicationSet sincroniza `main` com `automated`/`selfHeal`, o merge deste PR é o deploy.
Não mergear antes de as duas imagens estarem publicadas em GHCR, sob pena de `ImagePullBackOff`.

## Nota operacional

A `v0.6.0` carrega três migrations, aplicadas no boot do pod pelo `MigrationHostedService` — não há
job Helm separado, então uma migration que falhe impede o pod de subir. Uma delas
(`AdicionaCodigoTipoDeficiencia`) executa `DELETE FROM configuracao.tipo_deficiencia` antes de
adicionar a coluna `NOT NULL`; a tabela está vazia em homologação no momento da abertura deste PR.

Closes #510