### PR TITLE
fix(hml): eleva memória do uniplus-api-host para 2Gi

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -335,6 +335,20 @@ uniplusApiHost:
   image:
     tag: v0.6.0
 
+  # Override de memória: o default do chart (512Mi/1Gi) fica abaixo do consumo
+  # real deste ambiente — o processo assenta em ~861Mi, 84% do teto de 1Gi, e o
+  # pico de inicialização (migrations EF no StartAsync + warmup de criptografia
+  # + subida do Wolverine) estoura a margem restante e causa OOMKill. Fica aqui,
+  # e não no default do chart, para não arrastar standalone-compact nem
+  # lab-standalone-single, que não têm a mesma medição. Ver issue #512.
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+
   database:
     host: 192.168.21.134
 


### PR DESCRIPTION
O pod do `uniplus-api-host` em homologação é morto por OOM e reinicia. Este PR eleva o teto.

## Medição

| | Valor |
|---|---|
| Limite atual | `1Gi` |
| Consumo em regime (`kubectl top`, pod estabilizado) | **861Mi** (84% do teto) |
| Último término do container | `OOMKilled`, exit 137, 2026-08-25T16:59:24Z |
| Uso de memória do node | 5834Mi (18%) |

A margem entre o consumo de regime e o teto é de ~163Mi, e o pico de boot a consome: as migrations
EF são aplicadas no `StartAsync` pelo `MigrationHostedService`, junto do warmup de criptografia e da
subida do Wolverine.

## Mudança

| | De | Para |
|---|---|---|
| `requests.memory` | `512Mi` | `1Gi` |
| `limits.memory` | `1Gi` | `2Gi` |

`cpu` fica como está — 182m observados contra teto de 2000m.

## Onde

No values de `hml-standalone-single`, não no default do chart — mesmo critério já usado para o pin
de tag, para não arrastar `standalone-compact` nem `lab-standalone-single`, que não têm a mesma
medição.

## Não é regressão de versão

O pod anterior, em `v0.5.1`, já acumulava 4 restarts com o mesmo teto. A `v0.6.0` apenas tornou o
estouro mais provável ao trazer três migrations para o boot.

## Verificação local

- `make validate` passa (exit 0)
- `helm template` do ambiente renderiza `limits.memory: 2Gi` / `requests.memory: 1Gi`

Closes #512