### PR TITLE
chore(hml): promove uniplus-web v0.2.7

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -537,7 +537,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.2.6
+      tag: v0.2.7
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -559,7 +559,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.2.6
+      tag: v0.2.7
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.2.6
+      tag: v0.2.7
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -598,7 +598,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.2.6
+      tag: v0.2.7
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Aponta os quatro apps de `uniplusWeb` em `hml-standalone-single` para a release corrente.

## Mudança

| Componente | De | Para |
|---|---|---|
| `uniplusWeb.apps.portal.tag` | `v0.2.6` | `v0.2.7` |
| `uniplusWeb.apps.selecao.tag` | `v0.2.6` | `v0.2.7` |
| `uniplusWeb.apps.ingresso.tag` | `v0.2.6` | `v0.2.7` |
| `uniplusWeb.apps.configuracao.tag` | `v0.2.6` | `v0.2.7` |

Quatro linhas. `uniplusApiHost` permanece em `v0.6.0` — não há release nova da API, e o diff não o
toca.

## Conteúdo da release

`v0.2.7` corrige o limite de página inválido nos lookups de Oferta de Curso, no módulo de
Configuração, com cobertura de teste do caso reprovado. Dois commits desde `v0.2.6` (`fix` + `test`),
sem `BREAKING CHANGE`.

## Verificação local

- `make lint` e `make validate` passam (exit 0)
- `helm template` do ambiente renderiza as quatro imagens em `v0.2.7` e o `uniplus-api-host` inalterado em `v0.6.0`

## Impacto

Só `hml-standalone-single` — o pin permanece no values do ambiente, não no default do chart.

Como o ApplicationSet sincroniza `main` com `automated`/`selfHeal`, o merge deste PR é o deploy. Não
mergear antes de as quatro imagens estarem publicadas em GHCR.

Closes #516