### PR TITLE
chore(hml): promove api v0.7.0 e web v0.3.0 com o regime de turno da oferta

### DIFF
--- a/apps/uniplus-api-host/templates/deployment.yaml
+++ b/apps/uniplus-api-host/templates/deployment.yaml
@@ -44,11 +44,24 @@ metadata:
     {{- include "uniplusApiHost.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.uniplusApiHost.replicas }}
+  # RollingUpdate por padrão: o pod novo precisa ficar pronto antes de o antigo
+  # sair, e a api segue atendendo durante a promoção.
+  #
+  # `Recreate` existe para o caso em que isso é justamente o problema: as
+  # migrations rodam no boot do pod (MigrationHostedService, sem job Helm), então
+  # uma migration destrutiva altera o schema enquanto o pod da versão anterior
+  # continua pronto e atendendo contra um banco que já não é o dele. Nessa
+  # situação, derrubar antes de subir troca alguns segundos de indisponibilidade
+  # por uma janela em que ninguém serve o schema errado.
   strategy:
+    {{- if eq .Values.uniplusApiHost.deploymentStrategy "Recreate" }}
+    type: Recreate
+    {{- else }}
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+    {{- end }}
   selector:
     matchLabels:
       {{- include "uniplusApiHost.selectorLabels" . | nindent 6 }}

--- a/apps/uniplus-api-host/values.yaml
+++ b/apps/uniplus-api-host/values.yaml
@@ -34,6 +34,12 @@ uniplusApiHost:
   # API stateless. Em standalone 1 réplica para reduzir uso de recursos.
   replicas: 1
 
+  # Estratégia de atualização do Deployment: `RollingUpdate` (padrão) ou
+  # `Recreate`. Use `Recreate` na promoção que carrega migration destrutiva — as
+  # migrations rodam no boot do pod, e no RollingUpdate o pod anterior continua
+  # pronto enquanto o schema já mudou sob ele.
+  deploymentStrategy: RollingUpdate
+
   resources:
     # Processo único hospedando 4 módulos — requests/limits maiores que os
     # charts de API single-módulo (uniplus-api-portal usa 100m/256Mi).

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.6.0
+    tag: v0.7.0
 
   # Override de memória: o default do chart (512Mi/1Gi) fica abaixo do consumo
   # real deste ambiente — o processo assenta em ~861Mi, 84% do teto de 1Gi, e o
@@ -537,7 +537,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.2.7
+      tag: v0.3.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -559,7 +559,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.2.7
+      tag: v0.3.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.2.7
+      tag: v0.3.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -598,7 +598,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.2.7
+      tag: v0.3.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -335,6 +335,13 @@ uniplusApiHost:
   image:
     tag: v0.7.0
 
+  # `Recreate` nesta promoção: a migration AdicionaRegimeDeTurnoOferta remove a
+  # coluna `turno` no boot do pod novo. Sob RollingUpdate o pod da versão
+  # anterior continua pronto e atendendo enquanto o schema já mudou sob ele —
+  # qualquer leitura de oferta de curso naquele pod falharia. Em homologação,
+  # alguns segundos sem a api custam menos que essa janela.
+  deploymentStrategy: Recreate
+
   # Override de memória: o default do chart (512Mi/1Gi) fica abaixo do consumo
   # real deste ambiente — o processo assenta em ~861Mi, 84% do teto de 1Gi, e o
   # pico de inicialização (migrations EF no StartAsync + warmup de criptografia

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -348,6 +348,11 @@ uniplusApiHost:
   # promover, e forçar o refresh do ArgoCD logo após, em vez de esperar o
   # polling. Se falhar mesmo assim: remover as linhas e deixar o pod subir; a
   # migration não chegou a aplicar, então não há rollback a fazer.
+  #
+  # Esta chave é para VOLTAR a RollingUpdate assim que a promoção estiver
+  # validada — deixá-la ligada faria toda atualização de imagem seguinte
+  # derrubar o único pod da api sem necessidade, inclusive as que não carregam
+  # migration alguma. Rastreado na issue #520.
   deploymentStrategy: Recreate
 
   # Override de memória: o default do chart (512Mi/1Gi) fica abaixo do consumo

--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -340,6 +340,14 @@ uniplusApiHost:
   # anterior continua pronto e atendendo enquanto o schema já mudou sob ele —
   # qualquer leitura de oferta de curso naquele pod falharia. Em homologação,
   # alguns segundos sem a api custam menos que essa janela.
+  #
+  # A contrapartida, para quem repetir a promoção: aqui uma migration que falhe
+  # deixa a api inteira fora, e não a versão anterior de pé. O que a faria
+  # falhar é linha em `configuracao.oferta_curso` — as colunas novas são NOT
+  # NULL sem default. Conferir que a tabela está vazia imediatamente antes de
+  # promover, e forçar o refresh do ArgoCD logo após, em vez de esperar o
+  # polling. Se falhar mesmo assim: remover as linhas e deixar o pod subir; a
+  # migration não chegou a aplicar, então não há rollback a fazer.
   deploymentStrategy: Recreate
 
   # Override de memória: o default do chart (512Mi/1Gi) fica abaixo do consumo


### PR DESCRIPTION
## O que muda

As cinco tags de imagem de `environments/hml-standalone-single/values.yaml`, promovendo o **regime de turno da oferta de curso** (`UNI-REQ-0137`):

| Chave | De | Para |
|---|---|---|
| `uniplusApiHost.image.tag` | `v0.6.0` | `v0.7.0` |
| `uniplusWeb.apps.portal.tag` | `v0.2.7` | `v0.3.0` |
| `uniplusWeb.apps.selecao.tag` | `v0.2.7` | `v0.3.0` |
| `uniplusWeb.apps.ingresso.tag` | `v0.2.7` | `v0.3.0` |
| `uniplusWeb.apps.configuracao.tag` | `v0.2.7` | `v0.3.0` |

## Por que num PR só

A api nova **recusa** o payload que o web antigo envia: `turno` saiu do contrato de oferta de curso, e `regimeDeTurno` + `turnos` entraram como obrigatórios. Promover a api sozinha deixaria o cadastro de oferta quebrado em homologação até o web subir — daí um único bump com as cinco tags, e não dois sequenciais.

## Migration

`AdicionaRegimeDeTurnoOferta` roda no boot do pod (`MigrationHostedService`, sem job Helm), então migration que falha impede o pod de subir. Ela remove a coluna `turno` e adiciona `regime_de_turno` e `turnos` como `NOT NULL` **sem default**, mais três CHECK constraints.

Aplica limpo porque `configuracao.oferta_curso` está vazia em homologação — conferido em `GET /api/configuracao/ofertas-curso`, que devolve lista vazia. É a mesma razão pela qual a migration não carrega backfill nem coluna de transição.

## Estratégia de atualização: `Recreate` em homologação

As migrations rodam no boot do pod, e a estratégia do chart era `RollingUpdate` com `maxUnavailable: 0` **fixa no template**. Nessa combinação o pod da versão anterior segue pronto e atendendo enquanto a migration da nova já removeu a coluna `turno` — qualquer leitura de oferta naquele pod encontraria um schema que não é o dele. Pior: se o pod novo falhasse no boot depois disso, o antigo continuaria servindo contra o schema alterado, e voltar a imagem não desfaria a migration.

A estratégia passou a ser configurável por values, com `RollingUpdate` como padrão — nenhum outro ambiente muda —, e homologação usa `Recreate` nesta promoção. O pod antigo morre antes de a migration rodar, ao custo de alguns segundos sem api.

**O trade-off que isso cria, declarado:** com `Recreate`, uma migration que falhe deixa a api inteira fora, em vez de manter a versão anterior de pé. O cenário que a faria falhar é uma oferta criada entre a verificação da tabela e o rollout — exige token de `plataforma-admin`, num realm sem password grant e sem automação que escreva nessa tabela.

Mitigação, na ordem:

1. `GET /api/configuracao/ofertas-curso` reconferido imediatamente antes do merge — devolve `[]`.
2. Refresh do ArgoCD **forçado** logo após o merge, em vez de esperar o polling: a janela entre verificação e rollout encolhe para o intervalo entre dois comandos.
3. Se ainda assim a migration falhar por linha existente, o sintoma é imediato (pod em `CrashLoopBackOff` com erro de `NOT NULL`) e a recuperação é curta: remover as linhas — ofertas dos minutos anteriores, sem regime nem turnos no modelo novo — e deixar o pod subir. Sem rollback, porque a migration não chegou a aplicar.

## Imagens conferidas antes do bump

Todas as seis respondem `200` no registry (consulta anônima ao GHCR, não à API de packages do GitHub — que devolve 403 por falta de scope nas contas do projeto):

- `uniplus-api-host:v0.7.0`, `uniplus-api-portal:v0.7.0`
- `uniplus-portal:v0.3.0`, `uniplus-web-selecao:v0.3.0`, `uniplus-web-ingresso:v0.3.0`, `uniplus-web-configuracao:v0.3.0`

## Verificação local

- `make lint` e `make validate` — exit 0.
- `helm template` dos dois charts com o values do ambiente: as seis imagens renderizam nas versões novas.
- `helm template` confirma `Recreate` em homologação e `RollingUpdate` no ambiente de laboratório.
- O pin permanece no values do ambiente, não no default do chart — `standalone-compact` e `lab-standalone-single` seguem intocados.

## Depois do merge

O sync do ArgoCD é por polling nesta topologia (sem webhook), então o refresh será forçado e a promoção confirmada **pela imagem em execução no pod**, não pelo painel.

## Contexto

- `unifesspa-edu-br/uniplus-api#1287` — domínio, migration e contrato.
- `unifesspa-edu-br/uniplus-web#588` — cadastro de oferta com regime e turnos.
- `unifesspa-edu-br/uniplus-developers#194` — catálogo público de erros.

Closes #518
