### PR TITLE
chore(ci): cron prepara o bump quando há versão nova no GHCR

### DIFF
--- a/.github/workflows/bump-tags-hml.yml
+++ b/.github/workflows/bump-tags-hml.yml
@@ -1,0 +1,332 @@
+# Abre PR quando há versão nova publicada no GHCR.
+#
+# Por que agendamento e não notificação: a VM de homologação não é alcançável de
+# fora da VPN, então o ArgoCD não recebe webhook do GitHub. Mas o que falta
+# automatizar não é a perna Git -> cluster — essa já é automática, por polling do
+# próprio ArgoCD. É a anterior: descobrir que há imagem publicada e escrever a tag
+# no values. Era 100% manual, e foi por isso que homologação já ficou cinco semanas
+# atrasada.
+#
+# Por que aqui e não um dispatch da uniplus-api: um evento entre repositórios
+# exigiria PAT ou GitHub App com escrita neste repositório. Rodando aqui, a consulta
+# ao registry é anônima (as imagens são públicas) e o PR sai com o GITHUB_TOKEN que
+# o Actions já fornece — nenhum segredo novo.
+#
+# O que este workflow entrega é a branch pronta e validada, mais uma issue com as
+# migrations do intervalo. Abrir o PR fica com uma pessoa: evento originado pelo
+# GITHUB_TOKEN não dispara workflows, então um PR criado aqui nasceria sem checks e
+# com o gate obrigatório pendente para sempre. Contornar isso exigiria um PAT ou
+# GitHub App com escrita neste repositório, e essa credencial não se justifica para
+# economizar um clique.
+name: Bump de tags (HML)
+
+on:
+  schedule:
+    # A cada 10 minutos. O custo de um ciclo é uma consulta ao registry; o custo de
+    # não rodar é homologação envelhecendo em silêncio.
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  # Um ciclo por vez: dois em paralelo abririam PRs concorrentes para o mesmo bump.
+  group: bump-tags-hml
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  # Só leitura: o workflow nunca cria nem edita PR — precisa apenas descobrir se já
+  # existe um aberto para a branch, para não reescrevê-la por baixo de quem revisa.
+  pull-requests: read
+
+env:
+  VALUES: environments/hml-standalone-single/values.yaml
+  BRANCH: chore/bump-tags-hml
+  # A base é sempre o branch padrão, e nunca o ref que disparou. No agendamento os
+  # dois coincidem, mas `workflow_dispatch` permite escolher qualquer ref: de uma
+  # branch de trabalho, o bump sairia carregando commits que ninguém pediu e o link
+  # de compare apontaria para ela; de uma tag, `origin/<tag>` não existe e o ciclo
+  # morreria depois de já ter validado tudo.
+  BASE: ${{ github.event.repository.default_branch }}
+
+jobs:
+  verificar:
+    name: Verificar versões e abrir PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          # O histórico completo é necessário para comparar a branch de bump já
+          # publicada com o que este ciclo propõe.
+          fetch-depth: 0
+
+      - name: Preparar as ferramentas
+        # As mesmas de que `make validate` depende no workflow de validação: yamllint
+        # vem por pip e o helm por action — nenhum dos dois está no runner. Sem eles a
+        # validação abaixo morre em `command not found`, e o ciclo terminaria sem
+        # publicar branch nem issue, justamente quando há versão nova a promover.
+        # PyYAML é do leitor/escritor de tags.
+        run: pip install --quiet pyyaml yamllint
+
+      - name: Preparar o Helm
+        uses: azure/setup-helm@v4
+
+      - name: Consultar o registry
+        id: comparar
+        run: |
+          set -euo pipefail
+          if ! PYTHONPATH=tools/bump-tags python3 tools/bump-tags/verificar_versoes.py \
+                 --values "$VALUES" > /tmp/comparacao.json; then
+            # Consulta que falha não autoriza promover o resto: sem saber em que
+            # versão uma das imagens está, o values sairia com um pin escolhido às
+            # cegas ao lado de pins conferidos.
+            echo "::warning::Consulta ao registry falhou; nada será promovido neste ciclo."
+            cat /tmp/comparacao.json || true
+            # `erro`, `aguardando` e `em-dia` são estados distintos de propósito. Os
+            # três não geram bump, mas só o último autoriza encerrar o aviso pendente:
+            # um ciclo que não apurou, ou que apurou um release pela metade, não sabe
+            # se o pendente ainda existe, e fechar a issue ali apagaria um aviso real.
+            echo "estado=erro" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cat /tmp/comparacao.json
+
+          ADIADAS=$(jq '.adiadas | length' /tmp/comparacao.json)
+          if [ "$ADIADAS" != "0" ]; then
+            # Release publica uma imagem por vez, e o ciclo caiu no meio. Esperar os
+            # dez minutos do próximo custa menos que promover versões misturadas do
+            # mesmo frontend.
+            jq -r '.adiadas[] | "::notice::adiada \(.imagem): \(.motivo)"' /tmp/comparacao.json
+          fi
+
+          if [ "$(jq '.desatualizadas | length' /tmp/comparacao.json)" != "0" ]; then
+            echo "estado=bump" >> "$GITHUB_OUTPUT"
+          elif [ "$ADIADAS" != "0" ]; then
+            echo "Há versão nova, mas o release ainda está publicando. Próximo ciclo."
+            echo "estado=aguardando" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tudo em dia."
+            echo "estado=em-dia" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Encerrar o aviso quando o bump já chegou à base
+        if: steps.comparar.outputs.estado == 'em-dia'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Sem isto a issue continuaria aberta depois do merge, anunciando uma
+          # promoção que já aconteceu — e um aviso que sobrevive ao próprio motivo
+          # ensina quem o lê a ignorá-lo.
+          ABERTA=$(gh issue list --label bump-pendente --state open --json number --jq '.[0].number // empty')
+          if [ -z "$ABERTA" ]; then
+            echo "Nada pendente."
+          else
+            gh issue close "$ABERTA" --comment \
+              "As tags do values já são as versões mais recentes publicadas no registry: o bump chegou à \`${BASE}\`."
+            echo "Issue #$ABERTA encerrada."
+          fi
+
+      - name: Buscar as migrations do intervalo
+        if: steps.comparar.outputs.estado == 'bump'
+        # Falhar aqui não pode abortar o ciclo: a lista de migrations é o que torna o
+        # bump revisável, não o que o autoriza. Sem este checkout — indisponibilidade,
+        # limite de requisições — o texto sai dizendo que não foi possível apurar, que
+        # é a mensagem certa e já está implementada. Perder o bump inteiro por causa
+        # disso seria trocar uma informação a menos por nenhuma promoção.
+        #
+        # `fetch-depth: 0` traz o histórico E as tags, que é o que o intervalo compara.
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          repository: unifesspa-edu-br/uniplus-api
+          path: .uniplus-api
+          fetch-depth: 0
+
+      - name: Aplicar o bump
+        if: steps.comparar.outputs.estado == 'bump'
+        run: |
+          set -euo pipefail
+          PYTHONPATH=tools/bump-tags python3 tools/bump-tags/aplicar_bump.py \
+            --values "$VALUES" \
+            --comparacao /tmp/comparacao.json \
+            --repo-api .uniplus-api \
+            --saida-corpo /tmp/corpo.md
+
+          # Antes de validar: `make markdown-lint` varre `**/*.md`, e com o checkout
+          # da api no lugar ele lintaria a documentação de outro repositório — que não
+          # segue as regras deste e reprovaria o ciclo por um motivo alheio ao bump.
+          rm -rf .uniplus-api
+
+      - name: Validar o chart com as versões novas
+        if: steps.comparar.outputs.estado == 'bump'
+        run: |
+          set -euo pipefail
+          # A validação roda aqui porque não rodará no PR: eventos originados pelo
+          # GITHUB_TOKEN não disparam workflows. Sem isto, a branch chegaria a quem
+          # revisa sem nenhuma verificação — pior que não automatizar.
+          #
+          # Só `validate`, e não `lint` antes: o alvo já tem `lint` entre seus
+          # prerequisitos, e o Makefile é explícito em que `helm-deps` precisa vir
+          # primeiro. Chamar `lint` sozinho numa checkout nova falha em `helm-lint`,
+          # porque os charts dependentes ainda não foram baixados.
+          make validate
+
+      - name: Publicar a branch e avisar
+        if: steps.comparar.outputs.estado == 'bump'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          TITULO="chore(hml): promove $(jq -r '[.desatualizadas[] | "\(.imagem) \(.para)"] | join(", ")' /tmp/comparacao.json)"
+
+          # O values já editado, antes de tocar em qualquer branch. É por ele que se
+          # decide se há algo novo a publicar.
+          PROPOSTO=$(git hash-object "$VALUES")
+
+          # Duas comparações, porque as duas decisões perguntam coisas diferentes.
+          #
+          # Publicar olha o ARQUIVO inteiro: se a base recebeu qualquer edição no
+          # values, a branch está defasada e republicá-la a rebaseia — o PR deixa de
+          # carregar uma reversão silenciosa dessa edição.
+          #
+          # Avisar que existe versão mais nova olha só as TAGS. Uma edição alheia na
+          # base muda o hash do arquivo sem mudar um pin sequer, e a issue passaria a
+          # anunciar versão nova que não existe.
+          PUBLICADO=""
+          TAGS_DA_BRANCH=""
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch --quiet origin "$BRANCH"
+            if git cat-file -p "origin/$BRANCH:$VALUES" > /tmp/values-da-branch.yaml 2>/dev/null; then
+              PUBLICADO=$(git hash-object /tmp/values-da-branch.yaml)
+              TAGS_DA_BRANCH=$(PYTHONPATH=tools/bump-tags python3 tools/bump-tags/verificar_versoes.py \
+                                 --values /tmp/values-da-branch.yaml --somente-fixadas)
+            fi
+          fi
+          TAGS_PROPOSTAS=$(PYTHONPATH=tools/bump-tags python3 tools/bump-tags/verificar_versoes.py \
+                             --values "$VALUES" --somente-fixadas)
+          # `--head` filtra por NOME de branch e não aceita `dono:branch`, então um PR
+          # vindo de fork cuja branch tenha o mesmo nome entraria aqui — e o ciclo
+          # deixaria de publicar para sempre, apontando a issue para um PR alheio.
+          # `isCrossRepository` descarta o que não vem deste repositório.
+          PR_ABERTO=$(gh pr list --head "$BRANCH" --state open \
+            --json number,isCrossRepository \
+            --jq '[.[] | select(.isCrossRepository == false)] | .[0].number // empty')
+
+          # Três situações, e o que distingue as duas últimas é o CONTEÚDO da branch,
+          # não a existência do PR.
+          #
+          # A branch já propõe exatamente isto: nada a empurrar. É o caso comum
+          # enquanto o PR anterior não é mergeado — a base segue com as tags antigas e
+          # cada ciclo redescobre a mesma diferença. Republicar seria force-push de dez
+          # em dez minutos sem um byte novo, e anunciar "versão mais recente" seria
+          # falso.
+          #
+          # A branch propõe algo diferente E existe PR aberto: há versão mais nova de
+          # verdade, mas a branch não se toca. Um force-push trocaria a HEAD do PR de
+          # uma pessoa, e como o push sai do GITHUB_TOKEN os workflows `pull_request`
+          # não rodam para o SHA novo: validação e gate de autoria ficariam pendentes
+          # para sempre, e um PR a um clique do merge viraria immergível. É o mesmo
+          # motivo pelo qual este workflow não abre o PR. O bump espera o merge; a
+          # issue avisa.
+          #
+          # Sem PR aberto: publica.
+          if [ "$PROPOSTO" = "$PUBLICADO" ]; then
+            echo "A branch já propõe exatamente estas versões; nada a empurrar."
+            PUBLICAR=nao
+            MAIS_NOVO=nao
+          elif [ -n "$PR_ABERTO" ]; then
+            echo "PR #$PR_ABERTO está aberto; a branch não será reescrita."
+            PUBLICAR=nao
+            if [ "$TAGS_PROPOSTAS" = "$TAGS_DA_BRANCH" ]; then
+              MAIS_NOVO=nao
+            else
+              MAIS_NOVO=sim
+            fi
+          else
+            PUBLICAR=sim
+            MAIS_NOVO=nao
+          fi
+
+          if [ "$PUBLICAR" = "sim" ]; then
+            # Sempre a partir da base, e não do que a branch acumulou: o alvo é "as
+            # versões mais recentes agora".
+            git stash push -- "$VALUES"
+            git checkout -B "$BRANCH" "origin/${BASE}"
+            git stash pop
+
+            git add "$VALUES"
+            git commit -m "$TITULO" -m "$(cat /tmp/corpo.md)"
+
+            # Reconferido aqui, e não só lá em cima: entre a primeira consulta e este
+            # ponto passam alguns segundos, e é tempo suficiente para alguém abrir o
+            # pull request pelo link da issue. Reescrever a branch nesse instante
+            # deixaria os checks obrigatórios pendentes para sempre num PR recém-aberto
+            # — o mesmo estrago que a checagem anterior existe para impedir.
+            SURGIU=$(gh pr list --head "$BRANCH" --state open \
+              --json number,isCrossRepository \
+              --jq '[.[] | select(.isCrossRepository == false)] | .[0].number // empty')
+            if [ -n "$SURGIU" ]; then
+              echo "::warning::PR #$SURGIU foi aberto durante este ciclo; a branch não será reescrita."
+              exit 0
+            fi
+
+            git push --force-with-lease origin "$BRANCH"
+          fi
+
+          # A branch fica pronta, mas quem abre o PR é uma pessoa — e é deliberado.
+          #
+          # PR criado com o GITHUB_TOKEN não dispara `pull_request`, então nasceria sem
+          # nenhum check: o gate obrigatório de autoria ficaria pendente para sempre e o
+          # PR não poderia ser mergeado. Um PR permanentemente bloqueado é pior que
+          # nenhum. A alternativa seria um PAT ou GitHub App com escrita aqui, e
+          # introduzir essa credencial não se justifica para economizar um clique.
+          #
+          # O trabalho que custa continua automatizado: detectar a versão, editar o
+          # values, listar as migrations e validar o chart. Sobra abrir o PR.
+          COMPARE="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${BASE}...${BRANCH}?expand=1"
+          {
+            if [ -n "$PR_ABERTO" ] && [ "$MAIS_NOVO" = "sim" ]; then
+              echo "> **Há versão mais recente que a proposta no #$PR_ABERTO.** A branch não foi"
+              echo "> reescrita: trocar a HEAD de um PR aberto com o token do Actions deixaria os"
+              echo "> checks obrigatórios pendentes para sempre. Depois que o #$PR_ABERTO for"
+              echo "> mergeado, o próximo ciclo publica o bump abaixo."
+            elif [ -n "$PR_ABERTO" ]; then
+              echo "O #$PR_ABERTO já propõe estas mesmas versões, e o chart foi validado neste"
+              echo "ciclo. Falta mergear."
+            else
+              echo "A branch \`$BRANCH\` está pronta com o bump, e o chart já foi validado neste ciclo."
+              echo
+              echo "**[Abrir o pull request]($COMPARE)** — o PR precisa partir de uma conta de pessoa"
+              echo "para que os checks obrigatórios rodem."
+            fi
+            echo
+            cat /tmp/corpo.md
+          } > /tmp/issue.md
+
+          # A issue é decidida pelo TEXTO, não pelo estado da branch. As duas coisas
+          # mudam em ritmos diferentes: a lista de migrations depende de a tag Git da
+          # api já existir, e no primeiro ciclo depois de a imagem aparecer no registry
+          # ela costuma não existir ainda — o aviso sai como intervalo indeterminado.
+          # Amarrar a issue ao hash do values deixaria esse aviso congelado para
+          # sempre, porque a tag Git chegar não muda um byte do values. Quem revisa
+          # leria "não foi possível determinar" num intervalo que já é determinável.
+          ABERTA=$(gh issue list --label bump-pendente --state open --json number --jq '.[0].number // empty')
+          if [ -z "$ABERTA" ]; then
+            gh issue create --label bump-pendente \
+              --title "$TITULO" --body-file /tmp/issue.md
+          else
+            # Normaliza a quebra de linha: o corpo volta da API com CRLF e compararia
+            # diferente a cada ciclo, reeditando a issue à toa.
+            ATUAL=$(gh issue view "$ABERTA" --json body --jq '.body' | tr -d '\r')
+            if [ "$ATUAL" = "$(tr -d '\r' < /tmp/issue.md)" ]; then
+              echo "Issue #$ABERTA já traz exatamente este texto."
+            else
+              gh issue edit "$ABERTA" --title "$TITULO" --body-file /tmp/issue.md
+              echo "Issue #$ABERTA atualizada."
+            fi
+          fi

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -4325,3 +4325,143 @@ Story #445 passar `--name in-cluster` explicitamente no registro deste cluster.
 ---
 
 *Documento mantido pelo CTIC/UNIFESSPA. Atualizações via Pull Request.*
+
+## 22. Promoção de versão em homologação
+
+### Como o deploy acontece hoje
+
+A perna Git → cluster é automática: o ApplicationSet usa `syncPolicy.automated` com `prune` e
+`selfHeal`, e o ArgoCD detecta por polling. **Mergear o bump é o deploy** — não há passo posterior.
+A latência medida é de até ~6 minutos, e não há webhook porque a VM não é alcançável de fora da VPN.
+
+O que não era automático é a perna anterior: descobrir que há imagem publicada e escrever a tag no
+values. É o que o workflow `bump-tags-hml.yml` passou a fazer.
+
+### O que o cron faz
+
+A cada 10 minutos, e também sob acionamento manual:
+
+1. Lê as tags de `uniplus-api-host` e dos quatro `uniplus-web-*` no GHCR, **anonimamente** — as
+   imagens são públicas, e assim o workflow não precisa de segredo além do `GITHUB_TOKEN`.
+2. Compara com o que está fixado em `environments/hml-standalone-single/values.yaml`.
+3. Havendo diferença, valida o chart (`make validate`), publica a branch
+   `chore/bump-tags-hml` e abre — ou atualiza — uma issue com a etiqueta `bump-pendente`,
+   trazendo o link para abrir o pull request.
+4. Não havendo diferença, encerra a issue pendente, se houver: o bump chegou à base e o
+   aviso perdeu o motivo. Falha de consulta ao registry **não** encerra nada — um ciclo que
+   não conseguiu apurar não sabe se o pendente ainda existe.
+
+Imagens do mesmo repositório sobem juntas ou não sobem. Um release publica uma imagem de
+cada vez, e um ciclo que caia no meio veria parte já no registry e parte ainda na versão
+anterior — o values sairia com versões misturadas do mesmo frontend, combinação que nunca
+foi construída junto. Quando isso acontece, o grupo é adiado e o ciclo registra o motivo;
+dez minutos depois o release terminou e tudo entra de uma vez. Origens diferentes seguem
+independentes: api e web têm ciclos próprios.
+
+A branch e a issue são decididas por sinais diferentes, e de propósito. A branch é reescrita
+só quando o conteúdo do values muda, para não virar force-push de dez em dez minutos enquanto
+o PR anterior não é mergeado. A issue é reescrita quando o **texto** muda — a lista de
+migrations depende de a tag Git da api já existir, e no primeiro ciclo depois de a imagem
+aparecer no registry ela costuma sair como intervalo indeterminado; amarrar a issue ao values
+deixaria esse aviso congelado, porque a tag Git chegar não muda um byte do arquivo.
+
+**Branch com pull request aberto não é reescrita.** Trocar a HEAD de um PR com o
+`GITHUB_TOKEN` deixaria os checks obrigatórios pendentes para sempre — pelo mesmo motivo de
+o cron não abrir o PR. Se surgir versão mais recente enquanto o PR está aberto, a issue diz
+isso, e o bump sai no ciclo seguinte ao merge.
+
+### O que o cron não faz
+
+**Não abre o PR.** Evento originado pelo `GITHUB_TOKEN` não dispara workflows, então um PR criado
+pelo cron nasceria sem nenhum check — e com o gate obrigatório de autoria pendente para sempre, o
+que o deixaria impossível de mergear. Contornar isso exigiria um PAT ou GitHub App com escrita no
+repositório, credencial que não se justifica para economizar um clique. O cron deixa a branch pronta
+e validada; abrir o PR leva um clique no link da issue.
+
+**Não merga.** A promoção continua sendo decisão humana, e é por isso que o texto traz as migrations
+do intervalo, marcando as que mexem no schema de forma incompatível com a versão anterior — um bump
+de tag sozinho não dá base para decidir se o merge pode ser rotineiro.
+
+A classificação olha **apenas o corpo do `Up()`**: numa migration aditiva o `Down()` traz as
+operações inversas, e classificar pelo arquivo inteiro marcaria como destrutiva justamente a
+migration mais comum e inofensiva.
+
+São duas categorias, e a distinção importa.
+
+**Destrutivas** querem dizer uma coisa só: o objeto que o código anterior **nomeia** deixa de
+existir com aquele nome. São `DropColumn`, `DropTable`, `DropSchema`, `DropSequence`,
+`RenameColumn`, `RenameTable` e `RenameSequence`. Ganham destaque próprio no topo da seção.
+
+**Exigem revisão** vão inline em cada migration, e nomeiam o que conferir:
+
+| Operação | Por quê |
+|---|---|
+| `AlterColumn` | tanto aumenta um tamanho, inofensivo, quanto muda o tipo ou torna a coluna obrigatória |
+| `AddColumn` obrigatória sem valor padrão | a migration é recusada se a tabela já tem linhas, e no rollout a versão anterior insere sem a coluna |
+| `AddForeignKey`, `AddCheckConstraint`, `AddUniqueConstraint`, `AddPrimaryKey`, `CreateIndex` com `unique: true` | recusam a linha que já viola **e** a escrita da versão anterior, que não conhece a regra |
+| `AlterSequence` | muda incremento ou limites, que podem recusar o próximo valor |
+| `RestartSequence` | reiniciar abaixo do que já foi usado faz o próximo insert colidir com chave existente |
+| `DropIndex` | a escrita segue válida, mas consulta que dependia dele pode degradar |
+| `DropForeignKey` | deixa de haver garantia de integridade referencial |
+| `DropPrimaryKey` | conferir se outra a substitui na mesma migration |
+| `UpdateData` | altera linha existente; a versão anterior pode interpretar o valor novo de outro jeito |
+| `DeleteData` | remove linha de seed; o efeito depende de o registro ainda ser referenciado |
+| `migrationBuilder.Sql(...)` | pode ser um índice novo ou um `DELETE`; o nome da operação não diz |
+
+**O que fica de fora, e por quê.** O critério é sempre a incompatibilidade com quem ainda
+responde, não a remoção ou a mudança em si:
+
+| Operação | Por que não marca |
+|---|---|
+| `DropUniqueConstraint`, `DropCheckConstraint` | removem estrutura, mas **relaxam** a regra: a versão anterior segue escrevendo dados que a restrição aceitava |
+| `AlterDatabase`, `AlterTable` | anotações de provider, sem efeito sobre a escrita |
+| `RenameIndex` | nada no código de escrita nomeia índice; só o DDL o referencia |
+| `CreateTable`, `CreateSequence`, `EnsureSchema`, `InsertData` | acrescentam, e o que a versão anterior não conhece ela não usa |
+| `CreateIndex` sem `unique` | não recusa escrita |
+| `AddColumn` anulável ou com valor padrão | a escrita antiga continua válida |
+
+A lista das operações veio **por reflexão** sobre o `MigrationBuilder` do EF Core, não escrita
+de memória — a versão à mão saiu incompleta. Cada uma das 32 está classificada como destrutiva,
+como exigindo revisão, ou deliberadamente fora.
+
+E a classificação é **total**: operação que não caia em nenhuma das três — uma que só exista numa
+versão futura do EF — vira o aviso "operação X, que esta classificação não conhece". O silêncio
+deixa de ser o desfecho padrão do desconhecido.
+
+Para reconferir depois de atualizar o EF Core:
+
+```csharp
+typeof(MigrationBuilder)
+    .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+    .Select(m => m.Name).Distinct().OrderBy(n => n)
+```
+Marcar categorias inteiras faria o aviso aparecer em quase todo bump, e aviso que sempre aparece
+deixa de ser lido. Distinguir exige ler os argumentos da chamada, e é por isso que a classificação
+usa um scanner que respeita literais de string em vez de busca por texto: um
+`defaultValueSql: "coalesce(a, 0)"` fecharia a chamada cedo demais numa contagem de parênteses.
+
+**Não silencia o que não conseguiu apurar.** Se a comparação das migrations falhar, o texto diz que
+não foi possível apurar, em vez de dizer que não há migration alguma.
+
+**Não promove parcialmente.** Se a consulta de qualquer imagem falhar, o ciclo termina sem publicar:
+api e web precisam andar juntas, e um bump pela metade por falha de rede seria pior que nenhum.
+
+**Não republica o que já propôs.** Enquanto o PR anterior não é mergeado, a comparação continua
+acusando a mesma diferença a cada ciclo. O workflow compara o values proposto com o que a branch já
+publica e não faz nada se forem iguais — sem isso, seria force-push de dez em dez minutos, com o CI
+reiniciando sem parar e os comentários da revisão pendurados em commits que deixaram de existir.
+
+### Como desligar
+
+Desabilitar o workflow em Actions, ou remover o bloco `schedule` de
+`.github/workflows/bump-tags-hml.yml`. O `workflow_dispatch` continua disponível para acionamento
+manual.
+
+### Quando a promoção carrega migration
+
+Desde a ADR-0127 do `uniplus-api`, as migrations são aplicadas por um Job `pre-upgrade`, e não no
+boot do pod. Uma migration que falha aborta o sync com os pods anteriores intactos, em vez de ser
+descoberta com o pod já removido. O que o Job **não** cobre é a compatibilidade do schema novo com a
+versão anterior da aplicação — durante o rollout, quem ainda responde é ela. Para migration
+destrutiva promovida sem indisponibilidade, a resposta continua sendo expandir e contrair em duas
+releases.

--- a/tools/bump-tags/aplicar_bump.py
+++ b/tools/bump-tags/aplicar_bump.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""Aplica no values as tags novas e monta o corpo do PR.
+
+A localização de cada pin vem do parser de YAML e a troca atinge só aquela linha
+(ver `values_tags`): reserializar o documento apagaria os comentários que explicam
+cada pin, e casar por texto trocaria de uma vez as quatro chaves que hoje
+compartilham a mesma tag.
+
+O corpo do PR traz as migrations do intervalo e marca as destrutivas — um bump de
+tag sozinho não dá base para decidir se o merge pode ser rotineiro.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+from values_tags import escrever, ler
+
+# Operações que tornam o schema incompatível com a versão anterior da aplicação —
+# que é o que importa aqui, porque durante o rollout quem ainda responde é ela.
+# Renomear conta: para o código antigo, a coluna sumiu.
+# Destrutiva aqui quer dizer uma coisa só: o objeto que o código anterior NOMEIA deixa
+# de existir com aquele nome. Coluna, tabela, schema e sequência — removidos ou
+# renomeados — quebram a escrita de quem ainda responde durante o rollout.
+DESTRUTIVAS = (
+    "DropColumn",
+    "DropTable",
+    "DropSchema",
+    "DropSequence",
+    "RenameColumn",
+    "RenameTable",
+    "RenameSequence",
+)
+
+# Remover restrição ou índice NÃO entra aqui, e a distinção é a mesma que já valia para
+# `DropUniqueConstraint` e `DropCheckConstraint`: essas operações RELAXAM a regra em vez
+# de apertá-la, e a versão anterior segue escrevendo dados que já eram aceitos. Chamá-las
+# de destrutivas daria o alerta mais forte do texto a uma troca rotineira de índice — e
+# alerta que exagera é alerta que se aprende a ignorar. Ficam na revisão, onde o impacto
+# real (integridade, desempenho) é o que se confere.
+#
+# Também ficam de fora, sem aviso algum:
+#
+# - `RenameIndex`: nada no código de escrita nomeia índice; só o DDL o referencia.
+# - `CreateTable`, `CreateSequence`, `EnsureSchema`, `InsertData`: acrescentam, e o
+#   que a versão anterior não conhece ela não usa.
+
+# Operações cujo efeito não é inferível só pelo nome. Ficam numa categoria própria em
+# vez de inflar a de destrutivas: marcar como destrutivo o que talvez não seja faria o
+# aviso aparecer em todo bump, e aviso que sempre aparece deixa de ser lido.
+AVISO_ALTER_COLUMN = "altera coluna existente — conferir tipo, tamanho e nulidade"
+AVISO_ALTER_SEQUENCE = (
+    "altera sequência existente — conferir incremento e limites, que podem recusar o "
+    "próximo valor"
+)
+AVISO_REINICIA_SEQUENCE = (
+    "reinicia sequência — se o valor novo ficar abaixo do que já foi usado, o próximo "
+    "insert colide com chave existente"
+)
+
+# As operações que o `MigrationBuilder` do EF Core expõe e que NÃO geram aviso, cada uma
+# por um motivo. A lista fecha a classificação: o que não está aqui nem nas categorias
+# acima cai no aviso de operação desconhecida, e é assim que uma operação nova de uma
+# versão futura do EF chega a quem revisa em vez de passar em silêncio.
+#
+# Obtida por reflexão sobre `MigrationBuilder` (EF Core 10.0.9), não de memória — a
+# lista escrita à mão já saiu incompleta uma vez.
+SEM_RISCO_DECLARADO = frozenset({
+    # Acrescentam: o que a versão anterior não conhece, ela não usa.
+    "CreateTable", "CreateSequence", "EnsureSchema", "InsertData",
+    # Relaxam a regra em vez de apertá-la.
+    "DropUniqueConstraint", "DropCheckConstraint",
+    # Não são nomeados pelo código de escrita.
+    "RenameIndex",
+    # Anotações de provider, sem efeito sobre a escrita.
+    "AlterDatabase", "AlterTable",
+    # Tratadas pelo conteúdo dos argumentos, não pelo nome (ver `avisos_da_migration`).
+    "AddColumn", "CreateIndex",
+})
+AVISO_OPERACAO_DESCONHECIDA = (
+    "operação {operacao}, que esta classificação não conhece — conferir o efeito sobre "
+    "a versão anterior"
+)
+AVISO_SQL_BRUTO = "contém SQL bruto — o efeito não é inferível pela operação"
+# Restrições novas recusam duas coisas ao mesmo tempo: a linha que já está no banco e
+# violaria, e a escrita que a versão anterior continua fazendo durante o rollout — ela
+# não conhece a regra e não tem como respeitá-la.
+AVISOS_DE_RESTRICAO = {
+    "AddForeignKey": "adiciona chave estrangeira — recusa referência órfã existente e escrita da versão anterior",
+    "AddCheckConstraint": "adiciona restrição de verificação — recusa linha que já viola e escrita da versão anterior",
+    "CreateCheckConstraint": "adiciona restrição de verificação — recusa linha que já viola e escrita da versão anterior",
+    "AddUniqueConstraint": "adiciona restrição de unicidade — recusa duplicata existente e escrita da versão anterior",
+    "AddPrimaryKey": "adiciona chave primária — recusa nulo e duplicata existentes",
+}
+# Remoção de linha de seed. Não some estrutura, então não é destrutiva no sentido do
+# schema — mas é uma exclusão de dado, e o efeito depende de o registro removido ainda
+# ser referenciado. Marcar SQL bruto porque PODE conter um DELETE e deixar passar a
+# operação que É um DELETE seria incoerente.
+AVISOS_DE_RELAXAMENTO = {
+    "DropIndex": "remove índice — a escrita segue válida, mas consulta que dependia dele pode degradar",
+    "DropForeignKey": "remove chave estrangeira — deixa de haver garantia de integridade referencial",
+    "DropPrimaryKey": "remove chave primária — conferir se outra a substitui na mesma migration",
+}
+AVISO_ATUALIZACAO_DE_DADO = (
+    "altera linhas — a versão anterior pode interpretar o valor novo de outro jeito"
+)
+AVISO_REMOCAO_DE_DADO = (
+    "remove linhas — conferir se o dado apagado ainda é referenciado pela versão anterior"
+)
+AVISO_INDICE_UNICO = (
+    "cria índice único — recusa duplicata existente e escrita da versão anterior"
+)
+AVISO_COLUNA_OBRIGATORIA = (
+    "adiciona coluna obrigatória sem valor padrão — falha se a tabela já tem linhas, "
+    "e durante o rollout a versão anterior insere sem ela"
+)
+
+
+def aplicar(values: str, mudancas: list[dict]) -> tuple[str, list[str]]:
+    """Troca cada tag pela nova, uma chave por vez."""
+    aplicadas = []
+    for mudanca in mudancas:
+        chave, de, para = mudanca["chave"], mudanca["de"], mudanca["para"]
+        atual = ler(values, chave)
+        if atual != de:
+            # O values mudou entre a verificação e a aplicação. Promover assim mesmo
+            # sobrescreveria a decisão de outra pessoa.
+            raise ValueError(
+                f"{chave} está em {atual}, e não em {de} como a verificação apurou; "
+                "o values mudou no meio do caminho"
+            )
+        values = escrever(values, chave, para)
+        aplicadas.append(f"{chave}: {de} → {para}")
+    return values, aplicadas
+
+
+class IntervaloIndeterminado(RuntimeError):
+    """Não foi possível apurar as migrations do intervalo."""
+
+
+def _fim_do_literal(texto: str, i: int) -> int:
+    """Índice logo após o literal que começa em `i`, ou `i` se ali não começa um."""
+    verbatim = False
+    if texto[i] in "@$":
+        j = i
+        while j < len(texto) and texto[j] in "@$":
+            verbatim = verbatim or texto[j] == "@"
+            j += 1
+        if j >= len(texto) or texto[j] != '"':
+            return i
+        i = j
+    if texto[i] == "'":
+        i += 1
+        while i < len(texto):
+            if texto[i] == "\\":
+                i += 2
+                continue
+            if texto[i] == "'":
+                return i + 1
+            i += 1
+        return i
+    if texto[i] != '"':
+        return i
+
+    # Raw string literal (C# 11+): abre com três ou mais aspas e fecha com a MESMA
+    # quantidade; entre elas, aspas soltas são conteúdo. Sem isto, `"""` é lido como
+    # uma string vazia seguida de outra string, e o texto seguinte passa a ser
+    # interpretado ao contrário — o que engoliria uma chamada destrutiva posterior
+    # como se fosse argumento do `Sql`. As migrations do projeto usam esta forma.
+    if texto.startswith('"""', i):
+        abertura = 0
+        while texto[i + abertura : i + abertura + 1] == '"':
+            abertura += 1
+        j = i + abertura
+        while j < len(texto):
+            if texto[j] != '"':
+                j += 1
+                continue
+            fechamento = 0
+            while texto[j + fechamento : j + fechamento + 1] == '"':
+                fechamento += 1
+            if fechamento >= abertura:
+                return j + fechamento
+            j += fechamento
+        return len(texto)
+
+    i += 1
+    while i < len(texto):
+        if verbatim:
+            if texto[i] == '"':
+                # Em literal verbatim a aspa é escapada duplicando-a. A aspa dupla
+                # CONTINUA o literal; só a solitária o encerra. Tratar `""` como fim
+                # partiria um `@"SELECT ""Coluna"" FROM t"` ao meio, e o resto do SQL
+                # seria lido como código.
+                if texto[i + 1 : i + 2] == '"':
+                    i += 2
+                    continue
+                return i + 1
+        elif texto[i] == "\\":
+            i += 2
+            continue
+        elif texto[i] == '"':
+            return i + 1
+        i += 1
+    return i
+
+
+def _fim_do_comentario(texto: str, i: int) -> int:
+    """Índice logo após o comentário que começa em `i`, ou `i` se ali não começa um."""
+    if texto.startswith("//", i):
+        quebra = texto.find("\n", i)
+        return len(texto) if quebra == -1 else quebra + 1
+    if texto.startswith("/*", i):
+        fim = texto.find("*/", i + 2)
+        return len(texto) if fim == -1 else fim + 2
+    return i
+
+
+def _avancar(texto: str, i: int, abre: str, fecha: str) -> int:
+    """Índice logo após o fechamento que corresponde ao `abre` na posição `i`."""
+    profundidade = 0
+    while i < len(texto):
+        for pular in (_fim_do_literal, _fim_do_comentario):
+            depois = pular(texto, i)
+            if depois != i:
+                i = depois
+                break
+        else:
+            if texto[i] == abre:
+                profundidade += 1
+            elif texto[i] == fecha:
+                profundidade -= 1
+                if profundidade == 0:
+                    return i + 1
+            i += 1
+    return i
+
+
+def chamadas_do_migration_builder(trecho: str) -> list[tuple[str, str]]:
+    """Cada chamada a `migrationBuilder.X(...)`, como (operação, argumentos).
+
+    A varredura respeita literais de string, e é por isso que ela existe em vez de uma
+    busca por texto: um `defaultValueSql: "coalesce(valor, 0)"` fecharia a chamada cedo
+    demais numa contagem ingênua de parênteses, e o resto dos argumentos passaria a ser
+    lido como outra chamada. Genéricos (`AddColumn<string>`) também são pulados como
+    par balanceado, porque podem aninhar.
+    """
+    chamadas = []
+    marcador = "migrationBuilder."
+    i = 0
+    while i < len(trecho):
+        # Literais e comentários são pulados ANTES de procurar o marcador, e não
+        # depois. Achar o candidato com uma busca de texto e só então perguntar onde
+        # ele estava reconheceria `// migrationBuilder.DropTable(...)` como chamada
+        # real — o mesmo defeito da classificação por substring, entrando pela outra
+        # ponta.
+        for pular in (_fim_do_literal, _fim_do_comentario):
+            depois = pular(trecho, i)
+            if depois != i:
+                i = depois
+                break
+        else:
+            if not trecho.startswith(marcador, i):
+                i += 1
+                continue
+            j = i + len(marcador)
+            inicio_do_nome = j
+            while j < len(trecho) and (trecho[j].isalnum() or trecho[j] == "_"):
+                j += 1
+            operacao = trecho[inicio_do_nome:j]
+            if j < len(trecho) and trecho[j] == "<":
+                j = _avancar(trecho, j, "<", ">")
+            if operacao and j < len(trecho) and trecho[j] == "(":
+                fim = _avancar(trecho, j, "(", ")")
+                chamadas.append((operacao, trecho[j + 1 : fim - 1]))
+                i = fim
+            else:
+                i = j
+    return chamadas
+
+
+def argumentos_nomeados(argumentos: str) -> dict[str, str]:
+    """Os argumentos `nome: valor` da chamada, separados no nível de fora."""
+    partes, atual, i, inicio = [], [], 0, 0
+    profundidade = 0
+    while i < len(argumentos):
+        depois = _fim_do_literal(argumentos, i)
+        if depois != i:
+            i = depois
+            continue
+        caractere = argumentos[i]
+        if caractere in "([{<":
+            profundidade += 1
+        elif caractere in ")]}>":
+            profundidade -= 1
+        elif caractere == "," and profundidade == 0:
+            partes.append(argumentos[inicio:i])
+            inicio = i + 1
+        i += 1
+    partes.append(argumentos[inicio:])
+
+    nomeados = {}
+    for parte in partes:
+        limpa = parte.strip()
+        separador = limpa.find(":")
+        if separador == -1:
+            continue
+        nome = limpa[:separador].strip()
+        if nome.isidentifier():
+            nomeados[nome] = limpa[separador + 1 :].strip()
+    return nomeados
+
+
+def avisos_da_migration(up: str) -> list[str]:
+    """O que, no corpo do `Up`, quem revisa o bump precisa conferir antes de promover."""
+    avisos = set()
+    for operacao, argumentos in chamadas_do_migration_builder(up):
+        if operacao == "Sql":
+            avisos.add(AVISO_SQL_BRUTO)
+        elif operacao == "DeleteData":
+            avisos.add(AVISO_REMOCAO_DE_DADO)
+        elif operacao == "UpdateData":
+            avisos.add(AVISO_ATUALIZACAO_DE_DADO)
+        elif operacao in AVISOS_DE_RELAXAMENTO:
+            avisos.add(AVISOS_DE_RELAXAMENTO[operacao])
+        elif operacao in AVISOS_DE_RESTRICAO:
+            avisos.add(AVISOS_DE_RESTRICAO[operacao])
+        elif operacao == "CreateIndex":
+            # Índice comum é inofensivo para quem escreve; único é uma restrição, e
+            # entra pelo mesmo motivo das demais.
+            if argumentos_nomeados(argumentos).get("unique", "").rstrip(",") == "true":
+                avisos.add(AVISO_INDICE_UNICO)
+        elif operacao == "AlterColumn":
+            avisos.add(AVISO_ALTER_COLUMN)
+        elif operacao == "AlterSequence":
+            avisos.add(AVISO_ALTER_SEQUENCE)
+        elif operacao == "RestartSequence":
+            avisos.add(AVISO_REINICIA_SEQUENCE)
+        elif operacao not in DESTRUTIVAS and operacao not in SEM_RISCO_DECLARADO:
+            avisos.add(AVISO_OPERACAO_DESCONHECIDA.format(operacao=operacao))
+        elif operacao == "AddColumn":
+            # Coluna nova é inofensiva, EXCETO obrigatória sem valor padrão, que falha
+            # de duas maneiras: a própria migration é recusada se a tabela já tem
+            # linhas, e durante o rollout o pod da versão anterior segue inserindo sem
+            # a coluna. Homologação caiu pelo primeiro caminho em 25/08 — a tabela
+            # parecia vazia pelo endpoint, mas guardava linhas com exclusão lógica. Com
+            # `defaultValue` ou `defaultValueSql` o padrão fica na coluna e os dois
+            # casos se resolvem.
+            nomeados = argumentos_nomeados(argumentos)
+            obrigatoria = nomeados.get("nullable", "").rstrip(",") == "false"
+            # Pelo VALOR, e não pela presença da chave: `defaultValue: null` declara
+            # explicitamente que não há padrão, e a coluna continua recusando as linhas
+            # existentes e a escrita da versão anterior.
+            sem_padrao = all(
+                nomeados.get(chave, "null").rstrip(",").strip() == "null"
+                for chave in ("defaultValue", "defaultValueSql")
+            )
+            if obrigatoria and sem_padrao:
+                avisos.add(AVISO_COLUNA_OBRIGATORIA)
+    return sorted(avisos)
+
+
+def corpo_do_up(conteudo: str) -> str:
+    """O corpo do método `Up`, e só ele.
+
+    O arquivo é gerado pelo EF, e numa migration aditiva o `Down()` traz as
+    operações inversas — `DropColumn` para uma coluna adicionada, `DropTable` para
+    uma tabela criada. Classificar pelo arquivo inteiro marcaria como destrutiva
+    justamente a migration mais comum e inofensiva, e o aviso de risco perderia o
+    sentido por excesso.
+
+    O recorte é entre as assinaturas dos dois métodos, que o EF sempre gera nessa
+    ordem. Vale por ser código gerado, com forma estável — não serviria para código
+    escrito à mão.
+    """
+    inicio = conteudo.find("void Up(")
+    if inicio == -1:
+        raise IntervaloIndeterminado("migration sem método Up reconhecível")
+    fim = conteudo.find("void Down(", inicio)
+    return conteudo[inicio:fim if fim != -1 else len(conteudo)]
+
+
+def migrations_do_intervalo(repo: str, de: str, para: str) -> list[dict]:
+    """Migrations adicionadas entre duas tags, com o aviso de destrutividade."""
+    try:
+        saida = subprocess.run(
+            ["git", "-C", repo, "diff", "--name-only", f"{de}..{para}", "--", "*/Migrations/*.cs"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError) as erro:
+        # Devolver lista vazia diria "nenhuma migration", que é o oposto de "não sei".
+        # Uma tag ausente no checkout esconderia migrations destrutivas justamente de
+        # quem vai decidir o merge com base nesta informação.
+        raise IntervaloIndeterminado(
+            f"não foi possível comparar {de}..{para} no checkout da api: {erro}"
+        ) from erro
+
+    encontradas = []
+    for caminho in saida.splitlines():
+        # Definido pelo que uma migration É, e não por uma lista do que ela não pode
+        # conter. O nome depois do timestamp é escolhido por quem cria, então qualquer
+        # exclusão por texto — `Designer`, `ModelSnapshot` — acaba descartando uma
+        # migration legítima, e as operações destrutivas dela somem do aviso sem que
+        # nada indique a omissão.
+        #
+        # O que distingue: migration sempre começa com o carimbo de 14 dígitos e o
+        # sublinhado que o EF gera; o snapshot do contexto e os arquivos `.Designer.cs`
+        # não têm esse prefixo (o snapshot) ou têm aquele sufixo exato.
+        nome = caminho.rsplit("/", 1)[-1]
+        e_migration = (
+            nome[:14].isdigit()
+            and nome[14:15] == "_"
+            and nome.endswith(".cs")
+            and not nome.endswith(".Designer.cs")
+        )
+        if not caminho or not e_migration:
+            continue
+        try:
+            conteudo = subprocess.run(
+                ["git", "-C", repo, "show", f"{para}:{caminho}"],
+                capture_output=True, text=True, check=True,
+            ).stdout
+        except subprocess.CalledProcessError as erro:
+            raise IntervaloIndeterminado(f"não foi possível ler {caminho}: {erro}") from erro
+
+        up = corpo_do_up(conteudo)
+        # Pelas chamadas que o scanner extraiu, e não por busca de texto no corpo. Um
+        # comentário ou nome de índice contendo "DropTable" marcaria a migration como
+        # destrutiva sem que a operação existisse — dando o alerta mais forte do texto
+        # a quem não o merece. É a mesma razão pela qual os avisos já saem daqui: uma
+        # fonte só sobre o que a migration realmente chama.
+        chamadas = {operacao for operacao, _ in chamadas_do_migration_builder(up)}
+        operacoes = sorted(chamadas & set(DESTRUTIVAS))
+        encontradas.append({
+            "arquivo": caminho.rsplit("/", 1)[-1],
+            "destrutiva": bool(operacoes),
+            "operacoes": operacoes,
+            "revisar": avisos_da_migration(up),
+        })
+    return encontradas
+
+
+def corpo_do_pr(mudancas: list[dict], migrations: list[dict] | None, aplicadas: list[str]) -> str:
+    linhas = [
+        "Versões novas publicadas no GHCR. Este PR **não** foi mergeado automaticamente:",
+        "promover para homologação continua sendo uma decisão humana.",
+        "",
+        "## Tags",
+        "",
+        "| Chave | De | Para |",
+        "|---|---|---|",
+    ]
+    linhas += [f"| `{m['chave']}` | `{m['de']}` | `{m['para']}` |" for m in mudancas]
+
+    destrutivas = [m for m in (migrations or []) if m["destrutiva"]]
+    linhas += ["", "## Migrations no intervalo", ""]
+    if migrations is None:
+        linhas += [
+            "> **Não foi possível apurar.** Conferir manualmente antes de promover — a ausência",
+            "> desta lista não significa que o bump não altera schema.",
+        ]
+    elif not migrations:
+        linhas.append("Nenhuma. O bump não altera schema.")
+    else:
+        if destrutivas:
+            uma = len(destrutivas) == 1
+            linhas += [
+                f"> **{len(destrutivas)} de {len(migrations)} "
+                f"{'é destrutiva' if uma else 'são destrutivas'}.** Uma migration que remove",
+                "> estrutura não é compatível com a versão anterior da aplicação: enquanto o rollout",
+                "> acontece, quem ainda responde é a versão antiga. Conferir antes de mergear.",
+                "",
+            ]
+        for m in migrations:
+            marcas = []
+            if m["destrutiva"]:
+                marcas.append(f"**destrutiva** ({', '.join(m['operacoes'])})")
+            marcas.extend(m["revisar"])
+
+            # Uma marca cabe na mesma linha; várias viram lista. Emendadas por
+            # ponto e vírgula, quatro avisos formam um parágrafo que ninguém lê até o
+            # fim — e o que se perde no fim é justamente o que motivou o aviso.
+            if not marcas:
+                linhas.append(f"- `{m['arquivo']}`")
+            elif len(marcas) == 1:
+                linhas.append(f"- `{m['arquivo']}` — {marcas[0]}")
+            else:
+                linhas.append(f"- `{m['arquivo']}`")
+                linhas += [f"  - {marca}" for marca in marcas]
+
+    linhas += [
+        "",
+        "## Verificação",
+        "",
+        "- Versões lidas do registry por consulta anônima — a API de packages do GitHub responde",
+        "  403 por falta de escopo nas contas do projeto, e usá-la faria a checagem parecer vazia.",
+        "- Todas as imagens existem: a versão só entra aqui porque foi encontrada publicada.",
+        "",
+        "<details><summary>Substituições aplicadas</summary>",
+        "",
+    ] + [f"- {a}" for a in aplicadas] + ["", "</details>"]
+    return "\n".join(linhas)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--values", required=True)
+    parser.add_argument("--comparacao", required=True, help="JSON produzido por verificar_versoes.py")
+    parser.add_argument("--repo-api", help="checkout da uniplus-api, para listar as migrations")
+    parser.add_argument("--saida-corpo", required=True)
+    args = parser.parse_args()
+
+    with open(args.comparacao, encoding="utf-8") as arquivo:
+        comparacao = json.load(arquivo)
+    mudancas = comparacao["desatualizadas"]
+    if not mudancas:
+        print("Nada a promover.")
+        return 1
+
+    with open(args.values, encoding="utf-8") as arquivo:
+        values = arquivo.read()
+    values, aplicadas = aplicar(values, mudancas)
+    with open(args.values, "w", encoding="utf-8") as arquivo:
+        arquivo.write(values)
+
+    migrations: list[dict] | None = []
+    api = next((m for m in mudancas if m["imagem"] == "uniplus-api-host"), None)
+    if api and args.repo_api:
+        try:
+            migrations = migrations_do_intervalo(args.repo_api, api["de"], api["para"])
+        except IntervaloIndeterminado as erro:
+            print(f"aviso: {erro}", file=sys.stderr)
+            migrations = None
+
+    with open(args.saida_corpo, "w", encoding="utf-8") as arquivo:
+        arquivo.write(corpo_do_pr(mudancas, migrations, aplicadas))
+
+    print("\n".join(aplicadas))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/bump-tags/values_tags.py
+++ b/tools/bump-tags/values_tags.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Lê e escreve as tags de imagem num values.yaml, sem perder comentários.
+
+A leitura usa o parser de YAML — `yaml.compose` devolve a árvore de nós com a marca
+de posição de cada um, o que dá a linha exata do escalar. Percorrer o arquivo com
+expressão regular por indentação pareceria funcionar e quebraria na primeira
+construção válida que não estivesse prevista: comentário inline, aspas, âncora,
+bloco literal.
+
+A escrita substitui **aquela linha**, e só ela. Reserializar o documento apagaria os
+comentários que explicam cada pin, que é a parte do values com mais valor para quem
+lê depois.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+
+class ChaveNaoEncontrada(LookupError):
+    """O caminho pedido não existe no documento."""
+
+
+def _no_do_caminho(raiz: yaml.Node, caminho: list[str]) -> yaml.ScalarNode:
+    atual: yaml.Node = raiz
+    for parte in caminho:
+        if not isinstance(atual, yaml.MappingNode):
+            raise ChaveNaoEncontrada(f"'{parte}' não está sob um mapeamento")
+        for chave, valor in atual.value:
+            if isinstance(chave, yaml.ScalarNode) and chave.value == parte:
+                atual = valor
+                break
+        else:
+            raise ChaveNaoEncontrada(parte)
+    if not isinstance(atual, yaml.ScalarNode):
+        raise ChaveNaoEncontrada(f"{'.'.join(caminho)} não é um valor escalar")
+    return atual
+
+
+def _quantas_vezes_aparece(raiz: yaml.Node, alvo: yaml.Node) -> int:
+    """Quantas posições da árvore referenciam o MESMO nó (identidade, não igualdade).
+
+    Mais de uma significa âncora compartilhada: `yaml.compose` devolve um único nó para
+    a âncora e para cada alias que a referencia.
+    """
+    total = 0
+    pilha = [raiz]
+    while pilha:
+        no = pilha.pop()
+        if no is alvo:
+            total += 1
+        if isinstance(no, yaml.MappingNode):
+            pilha.extend(valor for _, valor in no.value)
+            pilha.extend(chave for chave, _ in no.value)
+        elif isinstance(no, yaml.SequenceNode):
+            pilha.extend(no.value)
+    return total
+
+
+def ler(values: str, caminho: str) -> str:
+    """Valor escalar em `caminho` (ex.: `uniplusApiHost.image.tag`)."""
+    raiz = yaml.compose(values)
+    if raiz is None:
+        raise ChaveNaoEncontrada("documento vazio")
+    return _no_do_caminho(raiz, caminho.split(".")).value
+
+
+def escrever(values: str, caminho: str, novo_valor: str) -> str:
+    """Troca o valor em `caminho`, preservando o resto do arquivo intacto.
+
+    A troca é dirigida pela **chave**, não pelo valor: várias chaves compartilham a
+    mesma tag, e casar pelo valor mudaria todas de uma vez.
+    """
+    raiz = yaml.compose(values)
+    if raiz is None:
+        raise ChaveNaoEncontrada("documento vazio")
+
+    no = _no_do_caminho(raiz, caminho.split("."))
+
+    # Pin ancorado ou vindo de alias é recusado. `yaml.compose` resolve o alias e
+    # devolve o nó ANCORADO, cujas marcas apontam para a declaração da âncora — e não
+    # para o ponto onde o alias aparece. Escrever ali trocaria o valor compartilhado,
+    # mudando de tabela outras tags que ninguém pediu para promover. É o oposto exato
+    # da garantia deste módulo, que é a troca ser dirigida pela chave.
+    if _quantas_vezes_aparece(raiz, no) > 1:
+        raise ChaveNaoEncontrada(
+            f"{caminho} usa âncora ou alias de YAML, e o valor é compartilhado com "
+            "outra chave; promover aqui mudaria as duas. Escreva a tag literal."
+        )
+
+    if no.end_mark.line != no.start_mark.line:
+        # Escalar em mais de uma linha (bloco literal, dobrado, quebra em aspas). Não
+        # ocorre com tag de imagem, e recortar pela coluna comeria o resto do arquivo.
+        raise ChaveNaoEncontrada(f"{caminho} ocupa mais de uma linha; não é uma tag")
+
+    linhas = values.split("\n")
+    indice = no.start_mark.line
+    linha = linhas[indice]
+
+    # Repõe o estilo de aspas que estava lá. Sem isto, um pin escrito como
+    # `tag: "v0.7.0"` voltaria sem aspas — YAML igualmente válido, mas um diff que
+    # mexe no que ninguém pediu para mexer.
+    aspas = no.style if no.style in ('"', "'") else ""
+    inicio, fim = no.start_mark.column, no.end_mark.column
+    linhas[indice] = linha[:inicio] + aspas + novo_valor + aspas + linha[fim:]
+    resultado = "\n".join(linhas)
+
+    # Relê antes de devolver. A troca é cirúrgica de propósito, e o preço de ser
+    # cirúrgica é não ter o parser conferindo o resultado — este passo devolve essa
+    # conferência, e transforma qualquer caso de borda não previsto em erro em vez de
+    # values corrompido.
+    if ler(resultado, caminho) != novo_valor:
+        raise ChaveNaoEncontrada(f"a troca em {caminho} não produziu {novo_valor}")
+    return resultado

--- a/tools/bump-tags/verificar_versoes.py
+++ b/tools/bump-tags/verificar_versoes.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Compara as tags publicadas no GHCR com as fixadas no values de um ambiente.
+
+Existe porque a perna Git -> cluster já é automática (o ArgoCD reconcilia sozinho),
+mas a anterior não era: descobrir que há imagem nova e escrever a tag no values era
+100% manual, e foi por isso que homologação já ficou cinco semanas atrasada.
+
+Consulta o registry de forma anônima, de propósito: as imagens são públicas, e assim
+o workflow não precisa de segredo nenhum além do token que o próprio GitHub Actions
+já fornece ao repositório.
+
+A leitura do values usa o parser de YAML (ver `values_tags`), não varredura de texto.
+
+Não escreve nada. Devolve o que mudou, em JSON, para quem chama decidir.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+
+import yaml
+
+from values_tags import ChaveNaoEncontrada, ler
+
+yaml_error = yaml.YAMLError
+
+REGISTRY = "https://ghcr.io"
+ORG = "unifesspa-edu-br"
+
+# Cada imagem, o repositório que a publica e a chave que a fixa no values do ambiente.
+# O caminho é literal porque é o que aparece no arquivo — resolver YAML aqui esconderia
+# a ligação.
+#
+# A origem importa: as quatro imagens do web saem de um único release, e um release
+# publica uma imagem de cada vez. Um ciclo que caia no meio veria parte já no registry
+# e parte ainda na versão anterior. Ver `_agrupar_por_origem`.
+IMAGENS = {
+    "uniplus-api-host": ("uniplus-api", "uniplusApiHost.image.tag"),
+    "uniplus-portal": ("uniplus-web", "uniplusWeb.apps.portal.tag"),
+    "uniplus-web-selecao": ("uniplus-web", "uniplusWeb.apps.selecao.tag"),
+    "uniplus-web-ingresso": ("uniplus-web", "uniplusWeb.apps.ingresso.tag"),
+    "uniplus-web-configuracao": ("uniplus-web", "uniplusWeb.apps.configuracao.tag"),
+}
+
+# Só versões completas. O registry também publica `v0.7`, que é um alias móvel — e
+# promover alias tiraria do values a capacidade de dizer exatamente o que está no ar.
+SEMVER = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+def _obter(url: str, cabecalhos: dict[str, str], timeout: int) -> dict:
+    requisicao = urllib.request.Request(url, headers=cabecalhos)
+    with urllib.request.urlopen(requisicao, timeout=timeout) as resposta:
+        return json.load(resposta)
+
+
+def listar_tags(imagem: str, timeout: int = 20) -> list[tuple[int, int, int]]:
+    """Versões completas publicadas para a imagem, ordenadas da mais antiga à mais nova."""
+    token = _obter(
+        f"{REGISTRY}/token?scope=repository:{ORG}/{imagem}:pull&service=ghcr.io",
+        {},
+        timeout,
+    )["token"]
+    tags = _obter(
+        f"{REGISTRY}/v2/{ORG}/{imagem}/tags/list",
+        {"Authorization": f"Bearer {token}"},
+        timeout,
+    ).get("tags") or []
+    return sorted(
+        tuple(int(p) for p in m.groups())
+        for t in tags
+        if (m := SEMVER.match(t))
+    )
+
+
+def _agrupar_por_origem(desatualizadas: list[dict], em_dia: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Separa os bumps cujo grupo de origem ainda não concorda na versão.
+
+    Um release publica uma imagem por vez. Um ciclo que caia no meio do release do web
+    veria `uniplus-portal` já em v0.4.0 e as outras três ainda em v0.3.0, e proporia o
+    values com versões misturadas do MESMO frontend — combinação que nunca foi
+    construída junto, muito menos testada.
+
+    O critério é o consenso dentro da origem: ou todas as imagens do repositório
+    apontam para a mesma versão nova, ou nenhuma vai neste ciclo. Adiar custa dez
+    minutos; promover misturado custa um ambiente num estado que ninguém montou de
+    propósito.
+
+    Origens diferentes seguem independentes: api e web têm ciclos próprios, e segurar
+    uma porque a outra publicou seria inventar um acoplamento que não existe.
+    """
+    alvo_por_origem: dict[str, set[str]] = {}
+    for item in desatualizadas + em_dia:
+        alvo_por_origem.setdefault(item["origem"], set()).add(item["para"])
+
+    promover, adiar = [], []
+    for item in desatualizadas:
+        if len(alvo_por_origem[item["origem"]]) > 1:
+            adiar.append(item | {
+                "motivo": (
+                    f"o release de {item['origem']} ainda não publicou todas as imagens "
+                    f"nesta versão: o registry mostra "
+                    f"{', '.join(sorted(alvo_por_origem[item['origem']]))}"
+                )
+            })
+        else:
+            promover.append(item)
+    return promover, adiar
+
+
+def comparar(values: str, timeout: int = 20) -> dict:
+    desatualizadas, erros, em_dia = [], [], []
+    for imagem, (origem, chave) in IMAGENS.items():
+        try:
+            fixada = ler(values, chave)
+        except (ChaveNaoEncontrada, yaml_error) as erro:
+            erros.append({"imagem": imagem, "motivo": f"chave {chave} ilegível no values: {erro}"})
+            continue
+        try:
+            publicadas = listar_tags(imagem, timeout)
+        except (urllib.error.URLError, TimeoutError, ValueError, KeyError) as erro:
+            # Falha de rede não pode virar PR incompleto nem quebrar o agendamento:
+            # relata e deixa a decisão para quem chama.
+            erros.append({"imagem": imagem, "motivo": f"consulta ao registry falhou: {erro}"})
+            continue
+        if not publicadas:
+            erros.append({"imagem": imagem, "motivo": "nenhuma versão completa publicada"})
+            continue
+
+        # Comparação por ordem, e não por diferença. Tratar "diferente" como
+        # "desatualizada" faria o ciclo propor rebaixar o ambiente sempre que a maior
+        # tag do registry ficasse ATRÁS do pin — uma tag apagada, um registry
+        # respondendo listagem parcial — e o texto ainda chamaria o retrocesso de
+        # versão nova. Rebaixar homologação sem ninguém ter pedido é pior que não
+        # promover nada.
+        casa = SEMVER.match(fixada)
+        if casa is None:
+            erros.append({
+                "imagem": imagem,
+                "motivo": f"o values fixa '{fixada}', que não é uma versão completa vX.Y.Z",
+            })
+            continue
+
+        atual = tuple(int(parte) for parte in casa.groups())
+        maior_publicada = publicadas[-1]
+        maior = "v" + ".".join(str(parte) for parte in maior_publicada)
+        item = {"imagem": imagem, "origem": origem, "chave": chave, "de": fixada, "para": maior}
+
+        if maior_publicada > atual:
+            desatualizadas.append(item)
+        elif maior_publicada == atual:
+            em_dia.append(item)
+        else:
+            # Nada a promover, e nada que o ciclo deva decidir sozinho: ou a tag saiu
+            # do registry, ou o values aponta para algo que nunca foi publicado.
+            erros.append({
+                "imagem": imagem,
+                "motivo": (
+                    f"o values fixa {fixada}, à frente da maior publicada ({maior}) — "
+                    "promover seria rebaixar o ambiente; requer conferência"
+                ),
+            })
+    desatualizadas, adiadas = _agrupar_por_origem(desatualizadas, em_dia)
+    return {
+        "desatualizadas": desatualizadas,
+        "em_dia": em_dia,
+        "adiadas": adiadas,
+        "erros": erros,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--values", required=True, help="values.yaml do ambiente")
+    parser.add_argument("--timeout", type=int, default=20)
+    parser.add_argument(
+        "--somente-fixadas",
+        action="store_true",
+        help="imprime as tags fixadas no values, sem consultar o registry",
+    )
+    args = parser.parse_args()
+
+    with open(args.values, encoding="utf-8") as arquivo:
+        conteudo = arquivo.read()
+
+    if args.somente_fixadas:
+        # Serve para comparar dois values pelas tags que este ciclo governa, e não
+        # pelo hash do arquivo: uma edição alheia no mesmo arquivo mudaria o hash sem
+        # mudar um pin sequer. Chave ilegível vira texto no lugar do valor, para que a
+        # comparação acuse diferença em vez de fingir igualdade.
+        for imagem, (_, chave) in sorted(IMAGENS.items()):
+            try:
+                print(f"{imagem}\t{ler(conteudo, chave)}")
+            except (ChaveNaoEncontrada, yaml_error) as erro:
+                print(f"{imagem}\t<ilegível: {erro}>")
+        return 0
+
+    resultado = comparar(conteudo, args.timeout)
+
+    print(json.dumps(resultado, ensure_ascii=False, indent=2))
+
+    # Erro de consulta não deve promover nada, mesmo que outra imagem esteja pronta:
+    # um bump parcial por falha de rede seria pior que nenhum.
+    if resultado["erros"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## O que muda

A perna Git → cluster **já era automática**: o ApplicationSet usa `syncPolicy.automated`, e o ArgoCD detecta por polling. Mergear o bump *é* o deploy.

O que não era automático é a perna anterior — descobrir que há imagem publicada e escrever a tag no values. Era 100% manual, e foi por isso que homologação já ficou **cinco semanas atrasada**, com 440 commits e 37 migrations acumulados.

A cada 10 minutos, o workflow lê as tags no GHCR, compara com o values e — havendo versão nova — valida o chart, publica a branch com o bump e abre uma issue com o link para o pull request.

## Por que aqui, e não um evento vindo da `uniplus-api`

Webhook do GitHub para o ArgoCD é impossível nesta topologia — a VM não é alcançável de fora da VPN, e expor o ArgoCD à internet para ganhar segundos de latência seria trocar isolamento por conveniência.

`repository_dispatch` da api para cá funcionaria, porque é GitHub falando com GitHub e não passa pela VPN. Mas exigiria PAT ou GitHub App com escrita neste repositório. **Rodando aqui, não precisa de segredo nenhum**: as imagens são públicas e respondem à consulta anônima (verificado), e o PR sai com o `GITHUB_TOKEN` que o Actions já fornece.

Isso importa enquanto a rotação da credencial do Vault segue pendente: não é bloqueador técnico, mas dar escrita a mais um ator ampliaria exposição sem necessidade.

## Por que o cron não abre o PR

Evento originado pelo `GITHUB_TOKEN` não dispara workflows. Um PR criado aqui nasceria **sem nenhum check**, e o `main` exige `PR author is org member` — que ficaria pendente para sempre, deixando o PR impossível de mergear. Um PR permanentemente bloqueado é pior que nenhum, porque parece pronto.

Contornar isso exigiria PAT ou GitHub App com escrita neste repositório — exatamente a credencial que este desenho existe para evitar. Não se paga por um clique.

Então o cron faz o que custa — detectar, editar o values, apurar as migrations, validar o chart — e deixa a branch pronta. Abrir o PR leva um clique no link da issue, e aí ele nasce de uma conta de pessoa, com os checks rodando.

A validação roda **dentro do ciclo do cron**, já que não rodará no PR: sem isso a branch chegaria a quem revisa sem verificação alguma, o que seria pior que não automatizar.

## O aviso de risco precisa estar certo para ser lido

A promoção continua sendo decisão humana, então o texto precisa dar base para ela:

```
## Migrations no intervalo

> 1 de 1 são destrutivas. Uma migration que remove estrutura não é compatível
> com a versão anterior da aplicação: enquanto o rollout acontece, quem ainda
> responde é a versão antiga. Conferir antes de mergear.

- 20260825220605_AdicionaRegimeDeTurnoOferta.cs — destrutiva (DropColumn)
```

Esse exemplo é real: rodei contra o intervalo `v0.6.0..v0.7.0` e ele apontou exatamente a migration que derrubou a api em 26/08.

A classificação olha **apenas o corpo do `Up()`**. Numa migration aditiva, o `Down()` traz as operações inversas, e olhar o arquivo inteiro marcaria como destrutiva justamente a migration mais comum. Verifiquei contra uma real:

```
arquivo inteiro contém DropColumn: True
só o Up() contém DropColumn:      False
```

`RenameColumn` e `RenameTable` contam como destrutivas — para o código anterior, a coluna sumiu.

Há uma segunda categoria, para o que não bloqueia mas precisa ser conferido:

- **SQL bruto** — pode ser um índice novo ou um `DELETE`; o nome da operação não diz;
- **`AlterColumn`** — desde aumentar um tamanho, inofensivo, até tornar a coluna obrigatória;
- **`AddColumn` obrigatória sem valor padrão** — o caso que derrubou homologação em 25/08: a migration é recusada se a tabela já tem linhas, e durante o rollout a versão anterior insere sem a coluna;
- **restrições novas** (`AddForeignKey`, `AddCheckConstraint`, `AddUniqueConstraint`, `AddPrimaryKey`, e `CreateIndex` com `unique: true`) — recusam a linha que já viola **e** a escrita que a versão anterior continua fazendo, porque ela não conhece a regra;
- **`DeleteData`** — remove linha de seed; o efeito depende de o registro ainda ser referenciado.

Ficam de fora, e a lista importa tanto quanto a de cima: índice comum, que não recusa escrita; `AddColumn` anulável ou com valor padrão; `InsertData`, que não recusa nada; e `UpdateData` sem toque em estrutura. Marcar categorias inteiras devolveria o aviso a quase todo bump, e aviso que sempre aparece deixa de ser lido.

Distinguir `AddColumn` inofensiva de perigosa exige ler os argumentos da chamada, e é por isso que existe um scanner das chamadas do `migrationBuilder` que respeita literais de string — um `defaultValueSql: "coalesce(a, 0)"` fecharia a chamada cedo demais numa contagem ingênua de parênteses. Marcar toda `AddColumn` como suspeita seria mais simples e faria o aviso aparecer em quase todo bump; aviso que sempre aparece deixa de ser lido.

E falha ao apurar as migrations **não** vira "nenhuma migration": o texto diz que não foi possível apurar. Afirmar que não há schema a alterar quando não se sabe esconderia migrations destrutivas atrás de uma frase tranquilizadora.

## Três cuidados que valem revisão

**Leitura por parser, escrita por linha.** A leitura do values usa `yaml.compose`, que dá a marca de posição de cada nó — varrer o arquivo com expressão regular por indentação pareceria funcionar e quebraria na primeira construção válida não prevista. A escrita substitui só aquela linha, porque reserializar o documento apagaria os comentários que explicam cada pin.

**A troca é dirigida pela chave, não pelo valor.** As quatro tags do web compartilham `v0.3.0` hoje; casar por texto mudaria as quatro de uma vez. Há teste manual disso: promovi só `portal` e conferi que as outras três ficaram intactas.

**Branch e issue são decididas por sinais diferentes.** A branch é reescrita só quando o conteúdo do values muda — enquanto o PR anterior não é mergeado, a comparação acusa a mesma diferença a cada 10 minutos, e republicar seria force-push contínuo. A issue é reescrita quando o **texto** muda: a lista de migrations depende de a tag Git da api já existir, e no primeiro ciclo depois de a imagem aparecer no registry ela costuma sair como intervalo indeterminado. Amarrá-la ao values congelaria esse aviso, porque a tag Git chegar não muda um byte do arquivo.

**Branch com PR aberto não é reescrita.** Trocar a HEAD de um PR com o `GITHUB_TOKEN` deixaria os checks obrigatórios pendentes para sempre — o mesmo motivo de o cron não abrir o PR, num caminho onde o estrago é maior: um PR bom, já revisado, viraria immergível. Havendo versão mais recente, a issue avisa e o bump sai no ciclo seguinte ao merge.

**A comparação é por ordem, não por diferença.** Tratar "diferente" como "desatualizada" faria o ciclo propor **rebaixar** homologação se uma tag sumisse do registry, chamando o retrocesso de versão nova. Pin à frente do registry vira erro e interrompe o ciclo.

**O aviso termina quando o motivo termina.** Assim que a base alcança o registry, a issue pendente é encerrada. Falha de consulta não encerra nada: um ciclo que não conseguiu apurar não sabe se o pendente ainda existe.

**Imagens do mesmo release sobem juntas ou não sobem.** As quatro do web saem de um único release, e um release publica uma imagem de cada vez: um ciclo que caia no meio veria uma na versão nova e três na anterior, e escreveria versões misturadas do mesmo frontend. O critério é o consenso dentro da origem — adiar custa dez minutos, promover misturado custa um ambiente num estado que ninguém montou. Origens diferentes seguem independentes: api e web têm ciclos próprios, e segurar uma porque a outra publicou inventaria um acoplamento que não existe.

Falha de consulta também encerra o ciclo **sem publicar nada**: sem saber em que versão uma das imagens está, o values sairia com um pin escolhido às cegas ao lado de pins conferidos.

**Quatro estados, e só um deles encerra o aviso.** `bump` publica; `em-dia` encerra a issue pendente; `aguardando` (release publicando) e `erro` (consulta falhou) não fazem nem uma coisa nem outra — nenhum dos dois sabe se o pendente ainda existe.

## Verificação

- `verificar_versoes.py` rodado contra o registry real, com o mapa completo das cinco imagens.
- Consenso por origem exercitado nos dois momentos: release do web pela metade promove só a api e adia as três; release completo promove as três de uma vez.
- Escritor de tags exercitado em pin sem aspas, com aspas simples, com aspas duplas, com comentário na mesma linha e em bloco dobrado — este último recusado. Contra o values real, altera exatamente uma linha.
- Comparação exercitada nos três caminhos — pin atrás, igual e à frente do registry — e o último cai em erro, não em bump.
- `aplicar_bump.py` ensaiado com um intervalo real, conferindo que só a linha do pin muda.
- Scanner de migrations exercitado nos casos que quebram varredura ingênua (parêntese dentro de string, literal verbatim com aspas duplicadas, genérico aninhado).
- Classificação rodada contra as migrations reais de v0.5.0..v0.8.0: três das quatro trazem aviso, e a que adiciona o código do tipo de deficiência sai com quatro — coluna obrigatória, restrição de verificação, SQL bruto e índice único. A que adiciona o regime de turno sai como destrutiva **e** com o aviso de coluna obrigatória, que é exatamente o que faltou a quem promoveu aquele bump.
- Ciclo ensaiado de ponta a ponta com um values defasado real: o texto sai com a tabela de tags, o destaque das destrutivas e as marcas por migration, e o values muda em exatamente uma linha.
- Os cinco caminhos da decisão de publicar/avisar simulados com o mesmo shell do workflow.
- `make validate` com exit 0 — e é só ele que o workflow chama, porque `helm-deps` é prerequisito de `validate`, não de `lint`.

## Documentação

`docs/RUNBOOKS.md` § 22 descreve o que o cron faz, o que **não** faz e como desligar.

Closes #522




