### PR TITLE
chore(argocd): omite o bloco retry no app que aplica migration

### DIFF
--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -188,17 +188,28 @@ spec:
   # `aplicaMigration` é declarado em TODOS os elementos, e não só onde é verdadeiro,
   # porque `goTemplateOptions: missingkey=error` transforma chave ausente em falha
   # de geração do AppSet inteiro.
+  # Como isto aparece na Application gerada, para que ninguém "conserte" o que está
+  # certo: `selfHeal: false` e `limit: 0` são zero-values e SOMEM na serialização, em
+  # vez de aparecerem escritos. A ausência é o resultado esperado — sem `selfHeal`,
+  # sem retry, e `automated` preservado com `prune`, que é o que mantém a promoção
+  # automática. Conferir por ausência, não por valor.
+  #
+  # O bloco `retry` inteiro fica de fora quando o app aplica migration. Emitir
+  # `limit: 0` deixaria um `retry` contendo só `backoff` — um bloco que não governa
+  # nada e confunde quem inspeciona.
   templatePatch: |
     spec:
       syncPolicy:
         automated:
           selfHeal: {{ not .aplicaMigration }}
+        {{- if not .aplicaMigration }}
         retry:
-          limit: {{ if .aplicaMigration }}0{{ else }}5{{ end }}
+          limit: 5
           backoff:
             duration: 5s
             factor: 2
             maxDuration: 3m
+        {{- end }}
 
 ---
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
Acompanhamento do #523, a partir do que apareceu ao aplicar o ApplicationSet em homologação.

## O que foi observado

Desligar retry e self-heal para o `uniplus-api-host` funciona — mas o manifesto gerado não deixa ver por quê:

```json
// uniplus-api-host-in-cluster
{"automated":{"prune":true},"retry":{"backoff":{"duration":"5s","factor":2,"maxDuration":"3m"}}}

// apicurio-registry-in-cluster (controle)
{"automated":{"prune":true,"selfHeal":true},"retry":{"backoff":{...},"limit":5}}
```

`selfHeal: false` e `limit: 0` são zero-values e **somem na serialização**. A ausência equivale ao valor desejado, e `automated` sobrevive com `prune` — a promoção automática continua ligada. Não há defeito de comportamento.

## Por que ainda assim mexer

Quem inspeciona a Application vê ausência, não decisão. Sem contexto isso parece configuração faltando, e o próximo a mexer pode "consertar" o que está certo. E sobrava um `retry` contendo só `backoff`, sem `limit` — um bloco que não governa nada.

O bloco `retry` passa a sair inteiro quando o app aplica migration. Como o `template` não traz `retry`, o merge patch deixa a Application limpa. O comentário registra que zero-value some, e que a conferência é por ausência.

## Verificação

- `make validate` em 0.
- `kubectl apply --dry-run=server` contra o cluster de homologação: `uniplus-apps configured`, `uniplus-platform unchanged`.

Closes #526