### PR TITLE
chore(api-host): volta o Job de migration para before-hook-creation

### DIFF
--- a/apps/uniplus-api-host/templates/migration-job.yaml
+++ b/apps/uniplus-api-host/templates/migration-job.yaml
@@ -37,20 +37,21 @@
   o initContainer basta — rotação de certificado no meio da execução não é
   cenário aqui, diferente do Deployment que roda indefinidamente.
 
-  Falha do Job: `hook-succeeded` apaga o Job que passou e PRESERVA o que falhou,
-  e a escolha faz mais do que guardar log.
+  Falha do Job: `before-hook-creation` remove o anterior apenas quando um novo vai
+  ser criado, então o Job que falhou fica no cluster para inspeção dos logs — que
+  é onde a mensagem do banco aparece.
 
-  O Job preservado bloqueia a própria recriação, e é isso que impede a migration
-  de ser reexecutada sozinha. Retry e self-heal desligados só protegem enquanto a
-  revisão não muda; num monorepo, qualquer commit produz revisão nova e habilita
-  um sync automático, que recriaria o hook. Com o Job anterior ainda no cluster,
-  esse sync para na hora de criá-lo — sem tocar no banco de novo.
+  Até quando ele fica: até o próximo sync. Como este app roda sem retry e sem
+  self-heal (`aplicaMigration` no ApplicationSet), o próximo sync só acontece
+  quando a revisão muda — na prática, quando alguém commita no repositório. Isso
+  costuma dar tempo de ler os logs.
 
-  Retomar é deliberado: ler os logs, corrigir a causa, apagar o Job e
-  sincronizar. O runbook traz os comandos.
-
-  `before-hook-creation` faria o oposto — apagaria justamente o Job que guarda a
-  mensagem, e deixaria a migration rodar de novo a cada commit no repositório.
+  A alternativa seria `hook-succeeded`, que preserva o Job falho indefinidamente
+  e, por ele existir, trava os syncs seguintes até alguém removê-lo à mão. Foi
+  descartada por decisão operacional: a trava também barra promoções legítimas, e
+  cobra de quem topa com ela um conhecimento que não está à vista. O preço aceito
+  é que um commit não relacionado pode reexecutar a migration que falhou — ela é
+  idempotente e falhará igual, custando o ciclo e o Job anterior.
 
   RESTRIÇÃO DE PROMOÇÃO: por rodar em `PreSync`, este Job vê a ServiceAccount e
   os Secrets do estado ANTERIOR — a fase Sync, que aplica `serviceaccount.yaml`
@@ -75,9 +76,9 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-5"
-    # Preserva o Job que falhou: guarda a mensagem do banco e, por existir, barra a
-    # recriação do hook no próximo sync — ver o cabeçalho.
-    "helm.sh/hook-delete-policy": hook-succeeded
+    # Remove o Job anterior só quando um novo vai ser criado — o que falhou fica
+    # para inspeção até o próximo sync. Ver o cabeçalho.
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   # Migration que falha não melhora com nova tentativa cega: o motivo costuma
   # ser schema ou dado, não instabilidade. Repetir só atrasa o diagnóstico.

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -678,25 +678,20 @@ kubectl -n uniplus get jobs -l app.kubernetes.io/name=uniplus-api-host
 JOB=$(kubectl -n uniplus get jobs -l app.kubernetes.io/name=uniplus-api-host -o name | head -1)
 kubectl -n uniplus logs "$JOB"
 
-# O Job que falhou PERMANECE no cluster. Os logs trazem a mensagem do banco.
+# O Job que falhou fica no cluster até o próximo sync. Os logs trazem a mensagem do banco.
 ```
 
-Migration que falha exige intervenção, e o Job preservado é o que garante isso. Enquanto
-ele estiver lá, o próximo sync para ao tentar recriá-lo — sem reexecutar a migration.
-Sem essa trava, qualquer commit no repositório produziria revisão nova, habilitando um
-sync automático que rodaria a migration de novo: desligar retry e self-heal só protege
-enquanto a revisão não muda.
+**Leia os logs antes de commitar qualquer coisa no repositório.** O Job anterior é removido
+quando o próximo é criado (`before-hook-creation`), e como este app roda sem retry e sem
+self-heal, o próximo sync acontece quando a revisão muda — ou seja, no primeiro commit que
+entrar na `main`, ainda que não tenha relação nenhuma com a api.
 
-Retomar depois de corrigir a causa:
+Corrigida a causa, basta sincronizar: o hook é recriado e roda de novo. Não há passo manual
+de limpeza.
 
-```bash
-JOB=$(kubectl -n uniplus get jobs -l app.kubernetes.io/name=uniplus-api-host -o name | head -1)
-kubectl -n uniplus logs "$JOB"          # ler antes de apagar
-kubectl -n uniplus delete "$JOB"
-# sincronizar pelo ArgoCD; o hook é recriado e roda de novo
-```
-
-O Job que passa é removido sozinho, então em promoção normal não sobra nada.
+Um commit não relacionado pode, portanto, reexecutar uma migration que falhou. Ela é
+idempotente e falhará do mesmo jeito — o que se perde é o Job anterior e o tempo do ciclo,
+não a integridade do banco.
 
 Ligar em ambiente novo: `migrationJob.enabled` fica **desligado** no primeiro sync, porque
 o hook roda antes dos recursos comuns e o chart ainda não instalado não tem como satisfazer


### PR DESCRIPTION
Reverte a política de remoção do hook adotada no #523, por decisão operacional.

## O que muda

`hook-succeeded` preservava o Job que falhou **indefinidamente** e, por ele existir, travava os syncs seguintes até alguém removê-lo à mão. Volta para `before-hook-creation`: o anterior sai quando um novo entra.

## Por que

A trava impedia que a migration fosse reexecutada sozinha — `retry` e `selfHeal` desligados só valem enquanto a revisão não muda, e num monorepo qualquer commit produz revisão nova.

O custo, porém, recai sobre o caso comum: um Job de falha antiga que ninguém removeu barra **promoções legítimas**, e quem topa com isso costuma estar no meio de outra coisa. O remédio exige saber que a trava existe e onde procurá-la.

## O preço, registrado e não escondido

- O Job que falhou fica disponível **até o próximo sync**, não indefinidamente.
- Como o app roda sem retry e sem self-heal, esse sync só vem quando a revisão muda — o primeiro commit que entrar na `main`, ainda que sem relação com a api. Na prática, há tempo de ler os logs.
- Um commit não relacionado **pode** reexecutar a migration que falhou. Ela é idempotente e falhará igual; perde-se o Job anterior e o tempo do ciclo, não a integridade do banco.

O runbook passa a pedir a leitura dos logs antes de commitar, e deixa de descrever limpeza manual como passo de retomada. `aplicaMigration: true` no ApplicationSet permanece — sem retry e sem self-heal segue certo, e é o que limita a reexecução ao caso de revisão nova.

## Verificação

- `helm template` rende `before-hook-creation`.
- `make validate` em 0.

Closes #531