### PR TITLE
fix(makefile): alinha a severidade do shellcheck à do CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,12 +103,18 @@ markdown-lint:  ## Roda markdownlint-cli2 em todos os .md
 
 .PHONY: shellcheck
 shellcheck:  ## Roda shellcheck em scripts/*.sh (skip gracefully se não instalado)
+# `--severity=warning` acompanha o `severity: warning` do ludeeus/action-shellcheck
+# em .github/workflows/validate.yml. Sem a flag, o alvo usa o padrão do binário —
+# que inclui `style` e `info` — e reprova onde o CI aprova: o gate local passa a ser
+# mais estrito que o obrigatório, e quem roda `make validate` num ambiente com o
+# binário instalado leva reprovação por achado que ninguém precisa corrigir.
 	@printf "$(BLUE)→ shellcheck$(RESET)\n"
 	@if command -v shellcheck >/dev/null 2>&1; then \
-	    shellcheck scripts/*.sh; \
+	    shellcheck --severity=warning scripts/*.sh; \
 	else \
-	    printf "$(YELLOW)⚠ shellcheck não instalado localmente — pulando (CI cobre via ludeeus/action-shellcheck)$(RESET)\n"; \
-	    printf "  Instalar: pacman -S shellcheck (Arch) | apt install shellcheck (Ubuntu)\n"; \
+	    printf "$(YELLOW)⚠ shellcheck não instalado — esta verificação NÃO foi executada$(RESET)\n"; \
+	    printf "  O CI a executa no PR; localmente, instale para exercer o gate antes de abrir:\n"; \
+	    printf "  pacman -S shellcheck (Arch) | apt install shellcheck (Ubuntu)\n"; \
 	fi
 
 .PHONY: schema-validate


### PR DESCRIPTION
## Sintoma

O ciclo de bump de tags falhou no passo de validação sem que houvesse problema com o bump: `make validate` reprovou em achados de nível `info` em `bootstrap-standalone.sh`, `smoke-dashboards.sh` e `sync-tofu-outputs.sh` — arquivos sem relação com a promoção. A branch nunca chegou a ser publicada, e a promoção do web `v0.4.0` ficou parada.

## Causa

O alvo do Makefile é mais estrito que o CI, e a divergência não estava declarada:

| | Como roda | Severidade |
|---|---|---|
| `validate.yml` | `ludeeus/action-shellcheck` | `warning` |
| `Makefile` | `shellcheck scripts/*.sh` | padrão — inclui `style` e `info` |

Verificado com a mesma versão do binário, sobre os scripts atuais: sem flag sai `exit=1`; com `--severity=warning`, `exit=0`.

## Por que ninguém tinha visto

O alvo **pula quando o binário não está instalado**, que é o caso da maioria das máquinas de desenvolvimento. Rodar `make validate` localmente devolvia sucesso sem que a verificação tivesse ocorrido — e o aviso amarelo dizia que "o CI cobre", o que reforça a leitura de que estava tudo verificado.

Registro que fui vítima disso durante a revisão do #524: rodei `make validate` dezenas de vezes lendo o `0`, e argumentei ali que o alvo era "o mesmo que o CI executa". Não era.

## O que muda

- `--severity=warning` no alvo, espelhando o CI, com o vínculo registrado em comentário para que uma mudança de um lado não passe silenciosa do outro.
- O aviso do caso sem binário passa a dizer que a verificação **não** foi executada, em vez de sugerir cobertura.

## Verificação

- `shellcheck --severity=warning scripts/*.sh` sai 0 sobre o conjunto atual.
- `make validate` em 0.

Closes #533