### PR TITLE
chore(hml): promove os apps web para v0.4.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.3.0
+      tag: v0.4.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.3.0
+      tag: v0.4.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.3.0
+      tag: v0.4.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.3.0
+      tag: v0.4.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Bump preparado pelo ciclo automático (run 33073373682), aberto para que os checks obrigatórios rodem.

## O que muda

As quatro imagens web saem de `v0.3.0` para `v0.4.0` no values de homologação. A api-host permanece em `v0.8.0` — esta release não a toca.

| Chave | De | Para |
|---|---|---|
| `uniplusWeb.apps.portal.tag` | `v0.3.0` | `v0.4.0` |
| `uniplusWeb.apps.selecao.tag` | `v0.3.0` | `v0.4.0` |
| `uniplusWeb.apps.ingresso.tag` | `v0.3.0` | `v0.4.0` |
| `uniplusWeb.apps.configuracao.tag` | `v0.3.0` | `v0.4.0` |

## Migrations no intervalo

Nenhuma — o bump não altera schema. A release é só do frontend.

## O que entra na v0.4.0

O Processo Seletivo ganha rota própria com listagem real, e o endereço passa a identificar o que está sendo editado: `/novo` e `/:id`. Retomar deixa de depender do estado em memória — o wizard hidrata pelo id, então recarregar a página ou abrir link direto funciona.

Acompanham a leitura dos documentos do edital no cliente, o baseline do contrato sincronizado, e correções no rótulo de status, na listagem, nos cards da dashboard e na navegação lateral de Configuração.

Fecha #535