### PR TITLE
chore(ci): ajusta o ciclo de bump para varredura horária

### DIFF
--- a/.github/workflows/bump-tags-hml.yml
+++ b/.github/workflows/bump-tags-hml.yml
@@ -22,9 +22,28 @@ name: Bump de tags (HML)
 
 on:
   schedule:
-    # A cada 10 minutos. O custo de um ciclo é uma consulta ao registry; o custo de
-    # não rodar é homologação envelhecendo em silêncio.
-    - cron: "*/10 * * * *"
+    # De hora em hora, e não a cada dez minutos — a declaração agora corresponde ao
+    # que o GitHub entrega. Medido no primeiro dia com `*/10`: duas execuções em
+    # treze horas, onde a declaração pedia setenta e oito. O `schedule` não garante
+    # pontualidade, pula execuções sob carga, e intervalos curtos em repositório de
+    # baixa atividade são os primeiros a serem despriorizados.
+    #
+    # Pedir vinte e quatro e receber a maioria vale mais que pedir cento e quarenta
+    # e quatro e receber duas, porque o número declarado é o que forma a expectativa
+    # de quem corta uma release — e expectativa furada faz o mecanismo parecer
+    # quebrado quando ele está apenas esperando a vez.
+    #
+    # O minuto 37 não é decorativo: o início da hora é o pico de carga do Actions, e
+    # a própria documentação do GitHub recomenda agendar fora dele. Minuto zero
+    # colocaria TODAS as tentativas na janela mais congestionada, o que pioraria o
+    # problema que esta mudança existe para corrigir. Evitados também 15, 30 e 45,
+    # pelo mesmo motivo de aglomeração.
+    #
+    # O que este ciclo resolve é esquecimento, não latência: homologação chegou a
+    # ficar cinco semanas atrasada porque ninguém lembrava de consultar o registry.
+    # Algumas varreduras por dia já eliminam isso. Para promoção com pressa existe o
+    # disparo manual, abaixo.
+    - cron: "37 * * * *"
   workflow_dispatch:
 
 concurrency:

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -4332,9 +4332,39 @@ A latência medida é de até ~6 minutos, e não há webhook porque a VM não é
 O que não era automático é a perna anterior: descobrir que há imagem publicada e escrever a tag no
 values. É o que o workflow `bump-tags-hml.yml` passou a fazer.
 
+### Quando o cron roda, e o que esperar
+
+A varredura é declarada de hora em hora, no minuto 37 (`37 * * * *`), e é **oportunista**: o `schedule` do
+GitHub Actions não garante pontualidade e pula execuções sob carga. No primeiro dia de operação,
+com `*/10` declarado, houve duas execuções em treze horas — por isso a declaração passou a ser
+horária, que corresponde melhor ao que se obtém.
+
+O minuto 37 é deliberado: o início da hora é o pico de carga do Actions, e a documentação do
+GitHub recomenda agendar fora dele. Minuto zero colocaria todas as tentativas na janela mais
+congestionada. Evitados também 15, 30 e 45, pela mesma aglomeração.
+
+**Conte com latência de horas, não de minutos.** Isso é suficiente para o problema que o ciclo
+resolve, que é esquecimento: homologação chegou a ficar cinco semanas atrasada porque ninguém
+lembrava de consultar o registry e escrever a tag.
+
+Para promoção com pressa, dispare à mão — é o caminho normal, não uma gambiarra:
+
+```bash
+gh workflow run "Bump de tags (HML)" --repo unifesspa-edu-br/uniplus-infra
+```
+
+Se você cortou uma release e o bump não apareceu, o mais provável é que a varredura ainda não
+tenha rodado desde a publicação. Confira antes de suspeitar do mecanismo:
+
+```bash
+gh run list --repo unifesspa-edu-br/uniplus-infra --limit 20 \
+  --json workflowName,event,conclusion,createdAt \
+  --jq '[.[] | select(.workflowName|test("Bump"))] | .[] | "\(.conclusion)\t\(.event)\t\(.createdAt)"'
+```
+
 ### O que o cron faz
 
-A cada 10 minutos, e também sob acionamento manual:
+A cada varredura, agendada ou manual:
 
 1. Lê as tags de `uniplus-api-host` e dos quatro `uniplus-web-*` no GHCR, **anonimamente** — as
    imagens são públicas, e assim o workflow não precisa de segredo além do `GITHUB_TOKEN`.
@@ -4350,11 +4380,11 @@ Imagens do mesmo repositório sobem juntas ou não sobem. Um release publica uma
 cada vez, e um ciclo que caia no meio veria parte já no registry e parte ainda na versão
 anterior — o values sairia com versões misturadas do mesmo frontend, combinação que nunca
 foi construída junto. Quando isso acontece, o grupo é adiado e o ciclo registra o motivo;
-dez minutos depois o release terminou e tudo entra de uma vez. Origens diferentes seguem
+na varredura seguinte o release terminou e tudo entra de uma vez. Origens diferentes seguem
 independentes: api e web têm ciclos próprios.
 
 A branch e a issue são decididas por sinais diferentes, e de propósito. A branch é reescrita
-só quando o conteúdo do values muda, para não virar force-push de dez em dez minutos enquanto
+só quando o conteúdo do values muda, para não virar force-push a cada varredura enquanto
 o PR anterior não é mergeado. A issue é reescrita quando o **texto** muda — a lista de
 migrations depende de a tag Git da api já existir, e no primeiro ciclo depois de a imagem
 aparecer no registry ela costuma sair como intervalo indeterminado; amarrar a issue ao values
@@ -4443,7 +4473,7 @@ api e web precisam andar juntas, e um bump pela metade por falha de rede seria p
 
 **Não republica o que já propôs.** Enquanto o PR anterior não é mergeado, a comparação continua
 acusando a mesma diferença a cada ciclo. O workflow compara o values proposto com o que a branch já
-publica e não faz nada se forem iguais — sem isso, seria force-push de dez em dez minutos, com o CI
+publica e não faz nada se forem iguais — sem isso, seria force-push a cada varredura, com o CI
 reiniciando sem parar e os comentários da revisão pendurados em commits que deixaram de existir.
 
 ### Como desligar


### PR DESCRIPTION
## O problema

`*/10 * * * *` não é o que o GitHub entrega. Medido no primeiro dia de operação:

| Evento | Horário (UTC) |
|---|---|
| Workflow mergeado | 26/08 20:40 |
| 1ª execução por `schedule` | 27/08 00:19 |
| 2ª execução por `schedule` | 27/08 09:58 |

Duas execuções em treze horas, onde a declaração pedia setenta e oito.

## Por que trocar por `0 * * * *`

O número declarado é o que forma a expectativa de quem corta uma release — e expectativa furada faz o mecanismo parecer quebrado quando ele está apenas esperando a vez. Foi o que aconteceu na promoção do web `v0.4.0`: o bump não apareceu em dez minutos, e a suspeita concorreu com o diagnóstico de um defeito real que havia junto (o #533).

Intervalos curtos também são os primeiros a serem despriorizados em repositório de baixa atividade. Pedir vinte e quatro e receber a maioria vale mais que pedir cento e quarenta e quatro e receber duas.

**Isso não reduz o que o ciclo entrega.** O problema que ele resolve é esquecimento, não latência: homologação chegou a ficar cinco semanas atrasada porque ninguém lembrava de consultar o registry e escrever a tag. Algumas varreduras por dia eliminam isso.

## Documentação

O runbook deixa de prometer dez minutos. Passa a dizer que a varredura é oportunista, que a latência é de horas, e que promoção com pressa usa o disparo manual — apresentado como caminho normal, não como contorno. Ganha também o comando que mostra quando a varredura rodou pela última vez, porque essa é a primeira pergunta de quem não vê o bump aparecer.

## O que fica fora

`repository_dispatch` do `uniplus-web`/`uniplus-api` resolveria a latência de verdade, mas exige PAT ou GitHub App com escrita neste repositório — a credencial que o desenho evita de propósito, e que fica pior de justificar com a rotação do Vault ainda pendente.

## Verificação

`make validate` em 0; nenhuma promessa de dez minutos restante na documentação.

Closes #537