### PR TITLE
chore(hml): promove uniplus-portal v0.4.1, uniplus-web-selecao v0.4.1, uniplus-web-ingresso v0.4.1, uniplus-web-configuracao v0.4.1

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.4.0
+      tag: v0.4.1
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.4.0
+      tag: v0.4.1
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.4.0
+      tag: v0.4.1
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.4.0
+      tag: v0.4.1
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Versões novas publicadas no GHCR. Este PR **não** foi mergeado automaticamente:
promover para homologação continua sendo uma decisão humana.

## Tags

| Chave | De | Para |
|---|---|---|
| `uniplusWeb.apps.portal.tag` | `v0.4.0` | `v0.4.1` |
| `uniplusWeb.apps.selecao.tag` | `v0.4.0` | `v0.4.1` |
| `uniplusWeb.apps.ingresso.tag` | `v0.4.0` | `v0.4.1` |
| `uniplusWeb.apps.configuracao.tag` | `v0.4.0` | `v0.4.1` |

## Migrations no intervalo

Nenhuma. O bump não altera schema.

## Verificação

- Versões lidas do registry por consulta anônima — a API de packages do GitHub responde
  403 por falta de escopo nas contas do projeto, e usá-la faria a checagem parecer vazia.
- Todas as imagens existem: a versão só entra aqui porque foi encontrada publicada.

<details><summary>Substituições aplicadas</summary>

- uniplusWeb.apps.portal.tag: v0.4.0 → v0.4.1
- uniplusWeb.apps.selecao.tag: v0.4.0 → v0.4.1
- uniplusWeb.apps.ingresso.tag: v0.4.0 → v0.4.1
- uniplusWeb.apps.configuracao.tag: v0.4.0 → v0.4.1

</details>

