### PR TITLE
chore(hml): promove uniplus-api-host v0.9.0 e os quatro apps web v0.5.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.8.0
+    tag: v0.9.0
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.4.1
+      tag: v0.5.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.4.1
+      tag: v0.5.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.4.1
+      tag: v0.5.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.4.1
+      tag: v0.5.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Promove homologação para as versões publicadas hoje no GHCR. O bump foi preparado pelo ciclo `bump-tags-hml` e validado localmente (`make validate`, exit 0).

## Tags

| Chave | De | Para |
|---|---|---|
| `uniplusApiHost.image.tag` | `v0.8.0` | `v0.9.0` |
| `uniplusWeb.apps.portal.tag` | `v0.4.1` | `v0.5.0` |
| `uniplusWeb.apps.selecao.tag` | `v0.4.1` | `v0.5.0` |
| `uniplusWeb.apps.ingresso.tag` | `v0.4.1` | `v0.5.0` |
| `uniplusWeb.apps.configuracao.tag` | `v0.4.1` | `v0.5.0` |

## O que entra

**API v0.9.0** — rota de leitura do documento do edital confirmado, com URL assinada emitida sob demanda (TTL 300s, resposta `no-store`, sempre a cópia selada); carência socioeconômica (Lei nº 12.799/2013) acrescentada aos fundamentos de isenção, com as mensagens de recusa passando a derivar do vocabulário em vez de repetir a lista à mão; imagem de Keycloak de desenvolvimento e testes alinhada à base 26.7.2.

**Web v0.5.0** — confirmação do cadastro inicial do Processo Seletivo antes de gravar (botão "Gravar e avançar" e resumo dos cinco campos imutáveis, com o aviso de imutabilidade exibido antes da gravação); abertura do edital anexado para conferência, com a URL assinada indo da resposta direto para a aba nova sem ser guardada; resumo do calendário contando ocorrências em vez de datas distintas (25 registros do dataset 2026.1 apareciam como 23); tela de acesso negado oferecendo saída da sessão e destino de volta declarado por quem monta a rota; shell administrativo sem teto de largura.

## Migrations

Nenhuma no intervalo `v0.8.0..v0.9.0` — o bump não altera schema. O Job `pre-upgrade` sobe sem trabalho a fazer.

## Verificação

- Imagens conferidas no registry por consulta anônima (a API de packages do GitHub responde 403 por falta de escopo): `uniplus-api-host`, `uniplus-api-portal`, `uniplus-portal`, `uniplus-web-selecao`, `uniplus-web-ingresso`, `uniplus-web-configuracao`, todas HTTP 200 nas tags novas.
- `make validate` exit 0.
- `helm template` do ambiente rende `uniplus-api-host:v0.9.0` e os quatro apps em `:v0.5.0`.

Closes #541