### PR TITLE
chore(hml): promove uniplus-api-host v0.9.1 e os quatro apps web v0.5.1

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.9.0
+    tag: v0.9.1
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.5.0
+      tag: v0.5.1
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.5.0
+      tag: v0.5.1
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.5.0
+      tag: v0.5.1
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.5.0
+      tag: v0.5.1
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Segunda promoção do dia, sobre a v0.9.0/v0.5.0 que subiu há pouco. Bump preparado pelo ciclo `bump-tags-hml` e validado localmente (`make validate`, exit 0).

## Tags

| Chave | De | Para |
|---|---|---|
| `uniplusApiHost.image.tag` | `v0.9.0` | `v0.9.1` |
| `uniplusWeb.apps.portal.tag` | `v0.5.0` | `v0.5.1` |
| `uniplusWeb.apps.selecao.tag` | `v0.5.0` | `v0.5.1` |
| `uniplusWeb.apps.ingresso.tag` | `v0.5.0` | `v0.5.1` |
| `uniplusWeb.apps.configuracao.tag` | `v0.5.0` | `v0.5.1` |

## O que entra

**API v0.9.1** — `AC_PCD` passa a exigir não ser egresso de escola pública. A vaga institucional de pessoa com deficiência existe para o candidato que a Lei de Cotas não alcança; quem vem de escola pública concorre por `LI_PCD`, e por `LB_PCD` quando elegível à renda. A regra tinha um único átomo — o opt-in por deficiência — e, com o resultado sendo a união das contribuições ativas, um candidato PcD egresso de escola pública recebia `AC_PCD` além de `LI_PCD`, concorrendo também na vaga criada para quem não tem essa via. Como vaga não ocupada retorna para AC, o efeito não era neutro para os demais candidatos.

**Web v0.5.1** — sincroniza o contrato de Seleção com a API. O baseline estava sem `CARENCIA_SOCIOECONOMICA`, o fundamento de isenção entregue na v0.9.0; sem ele o cliente gerado não conhece o valor e o passo de configuração de pagamento não teria como oferecê-lo.

## Migrations

Nenhuma no intervalo `v0.9.0..v0.9.1` — a correção é de derivação de modalidade, não de schema. O Job `pre-upgrade` sobe sem trabalho a fazer.

## Verificação

- As seis imagens existem no registry nas tags novas, conferidas por consulta anônima ao GHCR (a API de packages do GitHub responde 403 por falta de escopo nas contas do projeto).
- `make validate` exit 0.
- `helm template` do ambiente rende `uniplus-api-host:v0.9.1` e os quatro apps em `:v0.5.1`.

Closes #543