### PR TITLE
chore(hml): promove os quatro apps web para v0.7.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.6.0
+      tag: v0.7.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.6.0
+      tag: v0.7.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.6.0
+      tag: v0.7.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.6.0
+      tag: v0.7.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Promove os quatro apps web de `v0.6.0` para `v0.7.0` em `hml-standalone-single`.

## O que a v0.7.0 leva

**uniplus-web#623** — o editor de Processo Seletivo recusa gravação em processo fora de rascunho.

A listagem oferece **Abrir** para qualquer processo, inclusive publicado, e o editor não lia o status: montava os mesmos controles e o botão prometia `Gravar e avançar`. A recusa vinha do servidor (`ProcessoSeletivo.MutacaoPosPublicacaoBloqueada`) só depois de o operador preencher a tela, sem indicar que o caminho é a retificação.

Agora a condição é allowlist de `Rascunho`, derivada do detalhe lido — um status novo no servidor não abre a edição por omissão. Consultar continua livre, e a releitura do que o servidor devolve tem caminho próprio, para que um processo publicado siga exibindo o edital confirmado.

## Verificação prévia

A v0.6.0, já em homologação, foi exercitada contra a API real antes desta promoção: declaração de taxa de R$ 180 com dois fundamentos gravada, relida após recarregar, com valor, fundamentos e confirmação preservados. Os três fundamentos do catálogo aparecem, incluindo `CARENCIA_SOCIOECONOMICA`.

Imagens publicadas em https://github.com/unifesspa-edu-br/uniplus-web/actions/runs/33139744230.

## Efeito

Altera apenas `tag` dos quatro apps em `environments/hml-standalone-single/values.yaml`. O ArgoCD sincroniza por polling após o merge.
