### PR TITLE
chore(hml): promove os quatro apps web para v0.7.1

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.7.0
+      tag: v0.7.1
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.7.0
+      tag: v0.7.1
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.7.0
+      tag: v0.7.1
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.7.0
+      tag: v0.7.1
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Promove os quatro apps web de `v0.7.0` para `v0.7.1` em `hml-standalone-single`.

## O que a v0.7.1 leva

**uniplus-web#624** — o valor da taxa de inscrição passa a ser lido por uma gramática de moeda em pt-BR, não por `Number`.

`Number('1.000')` é 1, não mil. O valor passava na validação, o comando levava o número errado, o servidor aceitava — e como o rascunho guarda o texto digitado, a tela seguia exibindo `1.000` enquanto a taxa gravada era outra. Sem sinal na interface. `1e2` virava 100 e `0x10` virava 16, enquanto `1.000,50` era recusado como inválido.

A gramática vale na validação, no envio e na releitura, e recusa valores acima do que a coluna `numeric(12,2)` grava — faixa em que o próprio `Number` deixa de representar o inteiro exatamente.

## Efeito

Altera apenas `tag` dos quatro apps. O ArgoCD sincroniza por polling após o merge.

Imagens publicadas em https://github.com/unifesspa-edu-br/uniplus-web/actions/runs/33169921380.
