### PR TITLE
chore(hml): promove os apps web para v0.8.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.7.1
+      tag: v0.8.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.7.1
+      tag: v0.8.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.7.1
+      tag: v0.8.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.7.1
+      tag: v0.8.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Promove os quatro apps de `uniplus-web` em `environments/hml-standalone-single/values.yaml` de `v0.7.1` para `v0.8.0`.

O bump automático de tag cobre hoje só `uniplusApiHost` — escopo declarado em unifesspa-edu-br/uniplus-api#1256 —, então o web continua sendo promovido à mão.

## O que entra em v0.8.0

- Cliente do catálogo de regras versionadas em `shared-data`
- Fronteiras de layout do E2E derivadas da largura do project
- Cobertura de consistência e acessibilidade na listagem de Seleção

## Verificações

**Imagens no GHCR**, conferidas pelo registry antes de abrir o PR (a API do GitHub devolve 403 por falta de scope `read:packages` nas contas do projeto, então "ausente" ali seria falso negativo):

| Imagem | `v0.8.0` |
|---|---|
| `uniplus-portal` | HTTP 200 |
| `uniplus-web-selecao` | HTTP 200 |
| `uniplus-web-ingresso` | HTTP 200 |
| `uniplus-web-configuracao` | HTTP 200 |

**Gates locais:** `make lint` e `make validate` em exit 0. `shellcheck` não está instalado nesta máquina e não rodou localmente — o CI o exerce, e o diff não toca script algum.

**Renderização:** `helm template` do ambiente antes e depois do bump difere em exatamente quatro linhas — as quatro imagens saindo de `v0.7.1` para `v0.8.0`. Nenhum outro recurso muda.

**Escopo:** o pin fica no values do ambiente, nunca no default do chart, então `standalone-compact` e `lab-standalone-single` não são arrastados. `uniplusApiHost` não é tocado aqui — segue em `v0.9.1` até o PR automático do bump de `v0.9.2`.

Closes #549