### PR TITLE
chore(hml): promove uniplusApiHost para v0.9.2

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.9.1
+    tag: v0.9.2
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.


### PR DESCRIPTION
Promove `uniplusApiHost.image.tag` em `environments/hml-standalone-single/values.yaml` de `v0.9.1` para `v0.9.2`.

## Por que este PR é manual

Deveria ter sido aberto sozinho. `bump-infra-tag.yml` do `uniplus-api` disparou no publish da tag e parou no primeiro passo:

```
Secret INFRA_BUMP_TOKEN ausente neste repositório.
```

O secret é pré-requisito declarado desde unifesspa-edu-br/uniplus-api#1256 e nunca foi cadastrado. A falha é do pré-requisito, não da lógica — o evento entregou `workflow_run.head_branch = v0.9.2`, que é o que os passos seguintes esperam, e a execução parou antes de chegar neles. Rastreado em unifesspa-edu-br/uniplus-api#1309.

## O que entra em v0.9.2

- **Sigla de Campus recusa acentuação gráfica** (`UNI-REQ-0009`, unifesspa-edu-br/uniplus-api#1304) — único item com efeito em runtime. Recusa em vez de normalizar: remover o acento silenciosamente alteraria o valor informado e poderia colidir com sigla existente.
- **Promoção convergente no pipeline de bump** (unifesspa-edu-br/uniplus-api#1302) — workflows e ferramenta de CI, que não entram na imagem.

**Sem migrations novas** em relação a `v0.9.1`.

## Verificações

**Imagens no GHCR**, conferidas pelo registry (a API do GitHub devolveria 403 por falta de scope `read:packages`):

| Imagem | `v0.9.2` |
|---|---|
| `uniplus-api-host` | HTTP 200 |
| `uniplus-api-portal` | HTTP 200 |

**Gates locais:** `make lint` e `make validate` em exit 0. `shellcheck` não está instalado nesta máquina — o CI o exerce, e o diff não toca script.

**Renderização:** `helm template` do ambiente antes e depois difere só na tag da imagem `uniplus-api-host` e no label `app.kubernetes.io/version`. Nenhuma mudança estrutural.

**Escopo:** o pin fica no values do ambiente, não no default do chart. Os apps web não são tocados — já estão em `v0.8.0` pelo #550.

Closes #551