### PR TITLE
chore(hml): promove uniplus-api-host v0.10.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.9.2
+    tag: v0.10.0
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.


### PR DESCRIPTION
Versões novas publicadas no GHCR. Este PR **não** foi mergeado automaticamente:
promover para homologação continua sendo uma decisão humana.

## Tags

| Chave | De | Para |
|---|---|---|
| `uniplusApiHost.image.tag` | `v0.9.2` | `v0.10.0` |

## Migrations no intervalo

- `20260828154000_AdicionaRegimeDeFuncionamentoOferta.cs`
  - adiciona coluna obrigatória sem valor padrão — falha se a tabela já tem linhas, e durante o rollout a versão anterior insere sem ela
  - adiciona restrição de verificação — recusa linha que já viola e escrita da versão anterior

## Verificação

- Versões lidas do registry por consulta anônima — a API de packages do GitHub responde
  403 por falta de escopo nas contas do projeto, e usá-la faria a checagem parecer vazia.
- Todas as imagens existem: a versão só entra aqui porque foi encontrada publicada.

<details><summary>Substituições aplicadas</summary>

- uniplusApiHost.image.tag: v0.9.2 → v0.10.0

</details>

