### PR TITLE
chore(hml): promove uniplus-api-host v0.11.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.10.0
+    tag: v0.11.0
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.


### PR DESCRIPTION
Promove `uniplusApiHost.image.tag` de `v0.10.0` para `v0.11.0` no ambiente de
homologação. As imagens `uniplus-api-host` e `uniplus-api-portal` foram
conferidas no GHCR pelo registry anônimo (HTTP 200 nas duas) antes de abrir
este PR.

## O que a versão traz

Catálogo de modalidades sobe de dez para treze códigos, com as três
modalidades institucionais que faltavam — `PCD_PURO`, `AC_I` e `AC_Q` — e a
base legal de `AC_PCD` corrigida para a Res. Unifesspa 532/2021, que é a norma
que institui a reserva. Em Seleção, quem cobra taxa de inscrição passa a
precisar de ao menos um fundamento de isenção, e a confirmação explícita do
administrador deixa de existir.

## Migrations — 5 no intervalo

Nenhuma cria coluna `NOT NULL` sem default, então não se repete o bloqueio de
rollout que a v0.10.0 trouxe.

| Migration | Natureza |
|---|---|
| `20260829000213_SemeiaModalidadePcdPuro` | `InsertData` |
| `20260829005332_SemeiaModalidadesInstitucionaisPsiq` | `InsertData` |
| `20260829033817_CorrigeBaseLegalInstitucionalDeAcPcd` | `UPDATE` condicionado ao texto semeado |
| `20260829000318_AtualizaComentarioFundamentosIsencao` | só comentário de coluna |
| `20260829024048_RemoveConfirmacaoFundamentosIsencao` | **destrutiva** — `DropColumn` |

### Janela de incompatibilidade durante o rollout

O `DropColumn` é uma contração sem expansão prévia. O Job `pre-upgrade` aplica
a migration antes de o Deployment ser atualizado, então entre o fim do Job e a
morte do último pod v0.10.0 existe código velho consultando uma coluna que já
não existe — erro em `selecao.configuracoes_taxa_inscricao` por alguns
segundos. Em homologação a tabela tem uma linha e não há tráfego real, então a
janela é aceitável; fica registrada porque o mesmo padrão em produção exigiria
expandir numa promoção e contrair na seguinte.

## Estado do banco antes da promoção

Levantado na VM de homologação:

- `configuracao.modalidade` — 10 linhas, sem `PCD_PURO`/`AC_I`/`AC_Q`
- `AC_PCD.base_legal` ainda é o texto semeado, então o `UPDATE` condicional
  encontra a linha e a corrige
- `selecao.configuracoes_taxa_inscricao` — 1 linha, cobrando, já com
  fundamento, então a regra nova não deixa registro em estado inválido
- `confirmacao_fundamentos` — 1 linha com `true`, dado que a regra nova torna
  obsoleto

Backup do banco `uniplus` feito antes da promoção (dump custom + plano +
globals), com integridade conferida por `pg_restore --list` e `sha256sum -c`.

## Como validar depois do merge

`GET /api/configuracao/modalidades` é anônimo e discrimina as versões: devolve
10 modalidades na v0.10.0 e deve devolver 13 na v0.11.0, com a base legal de
`AC_PCD` apontando para a Res. Unifesspa 532/2021.

Closes #555