### PR TITLE
chore(hml): promove as quatro SPAs para v0.9.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.8.0
+      tag: v0.9.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.8.0
+      tag: v0.9.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.8.0
+      tag: v0.9.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.8.0
+      tag: v0.9.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Promove as quatro SPAs de `v0.8.0` para `v0.9.0` no ambiente de homologação —
`uniplus-portal`, `uniplus-web-selecao`, `uniplus-web-ingresso` e
`uniplus-web-configuracao`. As quatro imagens foram conferidas no GHCR pelo
registry anônimo (HTTP 200 em todas) antes de abrir este PR.

## O que a versão traz

O editor de Processo Seletivo passa a configurar a distribuição de vagas por
oferta de curso, e o passo de modalidades sai do wizard — marcá-las num passo
e distribuí-las em outro obrigava o operador a decidir duas vezes o mesmo
conjunto. O cálculo do quadro não é replicado no cliente: a simulação é pedida
ao servidor e descartada a cada edição.

Origem: `uniplus-web#645`, que fecha `uniplus-web#541`.

## Pareamento com a api v0.11.0

Esta promoção fecha o skew de vocabulário que estava aberto desde a promoção
da API:

- o passo de taxa passa a exigir fundamento de isenção quando há cobrança, e a
  caixa de confirmação de fundamentos deixa de existir — que é exatamente o
  que a api v0.11.0 fez do lado do servidor;
- o `status` do processo passa a vir do enum gerado pelo contrato, no lugar do
  roster manual, alinhando o web à mudança de vocabulário da API.

Promover o web sem a API já estar em v0.11.0 quebraria; a ordem inversa, que é
a desta noite, é a correta.

## Sem migration

Mudança só de frontend: não há Job de migration envolvido e nenhuma alteração
de schema. O rollout é troca de imagem das quatro SPAs.

## Como validar depois do merge

O nome do bundle (`main-XXXX.js`) muda por build e é o sinal confiável — o
hash do `index.html` não serve, porque muda a cada request por causa do
nonce/CSP. Bundles em `v0.8.0`, para comparação:

| App | Bundle |
|---|---|
| selecao | `main-ND4JQQBM.js` |
| configuracao | `main-WIXXFI6Q.js` |
| portal | `main-IRPCJGEO.js` |
| ingresso | `main-5NM32M3M.js` |

Closes #557