### PR TITLE
chore(hml): promove uniplus-api v0.12.0 e uniplus-web v0.10.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.11.0
+    tag: v0.12.0
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.9.0
+      tag: v0.10.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.9.0
+      tag: v0.10.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.9.0
+      tag: v0.10.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.9.0
+      tag: v0.10.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
## O que muda

Cinco tags no values de `hml-standalone-single` — uma da API, quatro dos apps web. Pin no values do
ambiente, não no default do chart, para não arrastar `standalone-compact` nem `lab-standalone-single`.

| Componente | De | Para |
|---|---|---|
| `uniplusApiHost.image.tag` | v0.11.0 | **v0.12.0** |
| `uniplusWeb.apps.portal.tag` | v0.9.0 | **v0.10.0** |
| `uniplusWeb.apps.selecao.tag` | v0.9.0 | **v0.10.0** |
| `uniplusWeb.apps.ingresso.tag` | v0.9.0 | **v0.10.0** |
| `uniplusWeb.apps.configuracao.tag` | v0.9.0 | **v0.10.0** |

## O que entra em HML

**API** — a solicitação de isenção passa a existir no vocabulário de fases canônicas
(`uniplus-api#1348`), com a migration que altera as três CHECK constraints; o código do tipo de
documento passa a formato fechado (`#1337`); entra o cadastro de categoria de documento (`#1341`,
`#1342`); e a publicação passa a recusar regra legal que não pode ser avaliada (`#1336`).

**Web** — o passo 5 do editor de processo seletivo, o cronograma do certame (`uniplus-web#657`), e
o mesmo código de isenção no roster de fases (`#674`).

## ⚠️ Migration destrutiva, com backup verificado

`MigraCodigoTipoDocumentoParaFormatoFechado` executa `DELETE FROM configuracao.tipo_documento`.
Os oito registros de HML usam código numérico (`01`, `02`, `03`, `04`, `05`, `08`, `11`, `16`) e
**nenhum atende ao formato fechado**. A migration documenta por que apaga em vez de converter: o
mapeamento seria adivinhação, e é o que o `UNI-REQ-0013` exige que quem cadastra declare.

Backup em `/home/jeferson/backups/hml-pre-v0.12.0-20260831-222729` na VM — 563 entradas no TOC,
`configuracao.tipo_documento` e `configuracao.fase_canonica` restauráveis seletivamente,
`sha256sum -c` passando. **Os tipos de documento precisam ser recadastrados após o deploy.**

## Verificações feitas

- `make lint` e `make validate` — exit 0
- `helm template` de ambos os charts contra o values de HML:
  - `ghcr.io/unifesspa-edu-br/uniplus-api-host:v0.12.0` (no Deployment **e** no Job de migração)
  - `uniplus-portal`, `uniplus-web-selecao`, `uniplus-web-ingresso`, `uniplus-web-configuracao` em `v0.10.0`
- Imagens conferidas no GHCR pelo registry anônimo antes do merge

## Ato operacional pós-rollout

`FaseCanonica` é cadastro 100% CRUD-administrado, sem seed. Depois da sincronização, cadastrar em
`/configuracao`: a fase de solicitação de isenção (CEPS, data própria, produz resultado não
definitivo) e a aresta `INSCRICAO → SOLICITACAO_ISENCAO` **com sobreposição permitida** — sem ela a
janela não pode correr dentro das inscrições.

Closes #559