### PR TITLE
chore(hml): promove uniplus-api v0.13.0 e uniplus-web v0.11.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.12.0
+    tag: v0.13.0
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.10.0
+      tag: v0.11.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.10.0
+      tag: v0.11.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.10.0
+      tag: v0.11.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.10.0
+      tag: v0.11.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
## O que muda

Cinco tags no values de `hml-standalone-single`: `uniplusApiHost` para **v0.13.0** e os quatro apps
web para **v0.11.0**.

## O que entra em HML

**A cadeia da solicitação de isenção fecha no backend.** As quinze fases canônicas passam a nascer
semeadas (`uniplus-api#1365`) — antes as arestas de precedência nasciam por migration e os vértices
não, então toda base migrada tinha seis precedências apontando para fases que só existiam se alguém
rodasse carga por API. Junto entram o critério que separa seed de carga administrativa (ADR-0062
emendada, `#1346`), a revogação da cláusula de cadastro sem seed (ADR-0113), a publicação sem
emulação arm64 (`#1363`) e o código do tipo de deficiência na oferta.

## Migrations, e a que merece atenção

`AdicionaCodigoDoTipoDeficienciaNaOferta` faz backfill e **apaga** oferta cujo código não resolva.
É destrutiva em tese e **inócua aqui**: `selecao.ofertas_tipo_deficiencia` está com **zero linhas**
em HML, conferido antes de cortar a tag.

As duas de seed usam `INSERT … ON CONFLICT DO NOTHING` — acrescentam o que falta e não tocam no que
existe.

Backup verificado: `/home/jeferson/backups/hml-pre-v0.13.0-20260901-053519`, 568 entradas no TOC.

## Efeito esperado

| Tabela | Antes | Depois |
|---|---|---|
| `configuracao.fase_canonica` | 14 | **15** |
| `configuracao.tipo_documento` | 0 | **70** |

As 14 fases preexistentes ficam **como estão**, com o autor original — é o que prova que o seed não
sobrescreveu trabalho administrativo.

## Ganho colateral mensurável

A `v0.13.0` foi a primeira release sem o alvo arm64. O job de publicação do `uniplus-api-host` caiu
de **35 minutos** (v0.12.0, poucas horas antes) para **3m13s**.

## Pendência que o deploy não resolve

As 14 fases de HML foram cadastradas com o payload omitindo as booleanas: **nenhuma tem
`produz_resultado` nem `coleta_inscricao`**. O seed as preserva por decisão, então corrigi-las é ato
administrativo. Enquanto não for, a âncora da janela de isenção não existe no ambiente — nenhuma
fase declara coletar inscrição. `publicacoes.tipo_ato_publicado` também segue vazio.

## Verificações

- `make lint` e `make validate` — exit 0
- `helm template` de ambos os charts: `uniplus-api-host:v0.13.0` e os quatro web em `v0.11.0`
- As seis imagens conferidas no GHCR pelo registry anônimo

Closes #561