### PR TITLE
chore(hml): promove uniplus-api v0.13.1 e uniplus-web v0.12.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.13.0
+    tag: v0.13.1
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.11.0
+      tag: v0.12.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.11.0
+      tag: v0.12.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.11.0
+      tag: v0.12.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.11.0
+      tag: v0.12.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
## O que muda

Bump de imagem em `environments/hml-standalone-single/values.yaml`:

| Componente | De | Para |
|---|---|---|
| `uniplusApiHost` | v0.13.0 | v0.13.1 |
| `uniplusWeb.apps.portal` | v0.11.0 | v0.12.0 |
| `uniplusWeb.apps.selecao` | v0.11.0 | v0.12.0 |
| `uniplusWeb.apps.ingresso` | v0.11.0 | v0.12.0 |
| `uniplusWeb.apps.configuracao` | v0.11.0 | v0.12.0 |

## O que entra

**API** (`uniplus-api#1373`) — o gate de conformidade legal casa a exigência documental pela identidade do tipo de documento, não pelo código, corrigindo falso-positivo por código reciclado e falso-negativo por renomeação com regra atualizada.

**Web** (`uniplus-web#668`) — tela do cronograma de fases com etapas, entre vagas e fórmula.

## Migrations

Nenhuma nesta promoção.

## Gates locais

`make lint` e `make validate` verdes; `helm template` conferido com as imagens novas renderizadas para `hml-standalone-single`.

Closes #563