### PR TITLE
chore(hml): promove uniplus-portal v0.13.0, uniplus-web-selecao v0.13.0, uniplus-web-ingresso v0.13.0, uniplus-web-configuracao v0.13.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.12.0
+      tag: v0.13.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.12.0
+      tag: v0.13.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.12.0
+      tag: v0.13.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.12.0
+      tag: v0.13.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Promove o `uniplus-web` para v0.13.0 em HML, nos 4 apps (portal, selecao, ingresso, configuracao).

## Tags

| Chave | De | Para |
|---|---|---|
| `uniplusWeb.apps.portal.tag` | `v0.12.0` | `v0.13.0` |
| `uniplusWeb.apps.selecao.tag` | `v0.12.0` | `v0.13.0` |
| `uniplusWeb.apps.ingresso.tag` | `v0.12.0` | `v0.13.0` |
| `uniplusWeb.apps.configuracao.tag` | `v0.12.0` | `v0.13.0` |

## Migrations no intervalo

Nenhuma — o bump não altera schema.

Closes #565