### PR TITLE
chore(hml): promove uniplus-api v0.14.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.13.1
+    tag: v0.14.0
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.


### PR DESCRIPTION
Promove a API em HML de `v0.13.1` para `v0.14.0`.

## O que entra

54 commits desde a v0.13.1, sem mudança incompatível — 11 feats, 29 fixes, zero breaking changes.

- **Seleção** — motores de redução do quadro institucional, reconciliação do quadro que excede quando há regra de ajuste, regras de distribuição do PSIQ e da Educação do Campo, recurso de dois dias úteis na fase de isenção
- **Discentes** — cliente resiliente de leitura dos vínculos no SIGAA e tradução para o domínio da réplica
- **Configuração** — tipo de banca e fase canônica ampliados para heteroidentificação e biopsicossocial
- **Contrato de erro** — 40 códigos que respondiam 500 genérico passaram a devolver o ProblemDetails canônico da ADR-0024, com gate que recusa código sem mapeamento

## Verificação

- Imagens da `v0.14.0` publicadas com sucesso pelo workflow `Publish Images`
- O frontend já está em `v0.13.0` desde `f820e2d`, então este PR mexe apenas na API

## Por que o bump é manual

O workflow `Bump Infra Tag` do uniplus-api falhou por ausência do secret `INFRA_BUMP_TOKEN`, ainda não cadastrado naquele repositório — o próprio workflow falha explicitamente nesse caso, por desenho. O bump segue manual, como nas promoções anteriores, até o secret existir.