### PR TITLE
chore(hml): promove uniplus-api-host v0.15.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.14.0
+    tag: v0.15.0
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.


### PR DESCRIPTION
Promove o `uniplusApiHost` para v0.15.0 em HML.

Bump manual, não pelo ciclo automático (#568): aquele ciclo bundlou este
bump legítimo com o bump do `uniplus-web` para uma tag `v0.14.0` órfã no
GHCR, sem tag Git correspondente (ver PR #570). Este PR promove só a API.

## O que entra

- `feat(configuracao)`: endpoint de vocabulário de tipo de banca e fase canônica
- `feat(discentes)`: reconcilia a réplica de vínculos com o SIGAA
- `fix(selecao)`: deixa a causa de domínio alcançar o cliente em três comandos

## Migrations no intervalo

- `AdicionaResumoDoConteudoDoVinculo` — `AddColumn` (default `""`) em `discentes.vinculo_discente`
- `AdicionaDataDeReferenciaDaExecucao` — `AddColumn` (default) + índice em `discentes.sync_run`

Ambas aditivas, sem `DROP`/`DELETE`.

Closes #571