### PR TITLE
chore(hml): promove uniplus-api-host v0.15.1

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.15.0
+    tag: v0.15.1
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.


### PR DESCRIPTION
Promove o `uniplusApiHost` para v0.15.1 em HML.

## O que entra

- `fix(selecao)`: retira DISTRIB-VAGAS-{LEI-12711,INSTITUCIONAL} v1 duplicada da v2
- `test(selecao)`: prova a guarda ADR-0112 da migration que retira a v1
- `fix(selecao)`: atualiza payloads do Postman de DISTRIB-VAGAS-INSTITUCIONAL para v2

## Migrations no intervalo

`RetiraRegraDistribuicaoVagasV1DuplicadaDaV2`: remove as linhas v1 de
`rol_de_regras` (DISTRIB-VAGAS-LEI-12711/INSTITUCIONAL), superadas pela v2
(superset — mesmo conteúdo mais modalidades_admitidas). Guarda `DO/RAISE
EXCEPTION` antes do `DeleteData`, cobrindo tanto `versoes_configuracao`
(estrutural, via jsonpath) quanto `configuracoes_distribuicao_vagas` (o
rascunho vivo — ADR-0061, cópia por valor sem FK). `Down` reversível
(`InsertData`).

Closes #573