### PR TITLE
chore(hml): promove uniplus-api-host v0.16.0, uniplus-portal v0.14.0, uniplus-web-selecao v0.14.0, uniplus-web-ingresso v0.14.0, uniplus-web-configuracao v0.14.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.15.1
+    tag: v0.16.0
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.13.1
+      tag: v0.14.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.13.1
+      tag: v0.14.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.13.1
+      tag: v0.14.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.13.1
+      tag: v0.14.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Promove `uniplusApiHost` para v0.16.0 e os 4 apps do `uniplus-web` para v0.14.0 em HML.

## API v0.16.0

- `feat(configuracao)`: reativa tipo de processo seletivo desativado
- `fix(configuracao)`: corrige corrida na reativação e links de manutenção
- `docs(adr)`: emenda ADR-0122 com a reativação de tipo de processo
- `docs(configuracao)`: declara o 409 de concorrência em desativação e reativação

## Web v0.14.0

15 commits — destaque: `feat(configuracao)` adiciona coluna Grau e ajusta exibição de Curso/Unidade Ofertante; demais são fix/test/refactor em acessibilidade (WCAG) e na página de pesos por área.

## Migrations no intervalo

`AdicionaTokenConcorrenciaTipoProcesso`: no-op deliberado — mapeia `xmin` (coluna de sistema do Postgres, já existente em toda tabela) como token de concorrência otimista; não cria nem altera coluna.

Closes #575