### PR TITLE
chore(hml): promove uniplus-api-host v0.17.0 e os apps web v0.15.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.16.0
+    tag: v0.17.0
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.14.0
+      tag: v0.15.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.14.0
+      tag: v0.15.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.14.0
+      tag: v0.15.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.14.0
+      tag: v0.15.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
Promove `uniplusApiHost.image.tag` para `v0.17.0` e os quatro apps `uniplusWeb.{portal,selecao,ingresso,configuracao}.image.tag` para `v0.15.0` em `environments/hml-standalone-single/values.yaml`.

## O que entra nesta promoção

`unifesspa-edu-br/uniplus-api#1421` (PR #1424) e `unifesspa-edu-br/uniplus-web#708` (PR #710): a regra de distribuição de vagas passa a **determinar** o rol exato de modalidades da oferta, em vez de a tela oferecer as 13 do catálogo sob qualquer regra.

**A migration do lado API é destrutiva**: `20260903215409_UnificaRegrasDeDistribuicaoEModalidadesEmV1` reescreve a identidade (código/versão) de cinco regras do catálogo de distribuição e descarta por inteiro qualquer processo seletivo de HML cuja distribuição de vagas ainda referencie alguma delas — atravessando os triggers append-only e as FKs RESTRICT do schema (revisada em cinco rodadas antes do merge). Efeito colateral aceito: sem produção, o ambiente é recadastrado.

## Por que o bump é manual

`bump-infra-tag.yml` (uniplus-api) está falhando em todas as execuções recentes por ausência do secret `INFRA_BUMP_TOKEN` neste repositório — mesmo padrão de bump manual já usado nas PRs #574 e #576.

## Verificação local

- `make yaml-lint` — só avisos pré-existentes em arquivos não tocados.
- `helm template apps/uniplus-api-host -f environments/hml-standalone-single/values.yaml` — confirma `image: ghcr.io/unifesspa-edu-br/uniplus-api-host:v0.17.0`.
- As duas releases (`v0.17.0` do uniplus-api, `v0.15.0` do uniplus-web) já publicadas e com o smoke test do workflow `Publish Images` verde nos dois repositórios.

## Pós-merge

ArgoCD sincroniza sozinho (`syncPolicy.automated`, polling ~3min). O app `uniplus-api-host` roda o hook `PreSync` da migration antes do rollout — se falhar, aborta o sync com os pods anteriores intactos.