### PR TITLE
chore(hml): promove uniplus-api-host v0.18.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.17.0
+    tag: v0.18.0
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.


### PR DESCRIPTION
## Resumo

Promove `uniplus-api-host` para `v0.18.0` em HML (`environments/hml-standalone-single/values.yaml`).

## O que entra na v0.18.0

- `feat(pagination)`: ordenação keyset por várias colunas e por sentido
- `feat(configuracao)`: ordena Cursos e Ofertas de Curso pelo nome do curso
- `fix(pagination)`: cursor só continua a ordenação que o emitiu
- `fix(configuracao)`: declara a collation na conversão para minúsculas
- `refactor(pagination)`: nomeia a API de ordenação em inglês
- `fix(pagination)`: serializa a assinatura da ordenação sem colidir separador

Imagem já publicada no GHCR (`publish-images.yml`, run verde) antes da abertura deste PR.

## Bump manual

O workflow `bump-infra-tag.yml` do `uniplus-api` segue com o secret `INFRA_BUMP_TOKEN` ausente — todas as execuções recentes falham no primeiro step. Mesmo padrão de bump manual já usado nas PRs #574, #576 e no commit `9e50fff`.

## Validação local

- `make yaml-lint` — sem novos warnings (só os pré-existentes em `platform/observability/`)
- `helm template apps/uniplus-api-host -f environments/hml-standalone-single/values.yaml --show-only templates/deployment.yaml` — confirma `ghcr.io/unifesspa-edu-br/uniplus-api-host:v0.18.0` nos três containers

## Pós-merge

ArgoCD sincroniza sozinho por polling (~3-6min). Verificação final será pela imagem em execução no pod, não pelo painel.