### PR TITLE
chore(hml): promove uniplus-web v0.16.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -558,7 +558,7 @@ uniplusWeb:
       # PathPrefix real — migrado do smoke provisório na raiz (issue #486)
       # agora que uniplus-web#448 corrigiu o base href sob subpath (issue #488).
       pathPrefix: /portal
-      tag: v0.15.0
+      tag: v0.16.0
       runtimeConfig:
         # apiUrl é só a origem — os apps já montam o path com o prefixo do
         # módulo (/api/portal/...) no cliente; concatenar aqui duplicaria
@@ -580,7 +580,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /selecao
-      tag: v0.15.0
+      tag: v0.16.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/selecao/... no cliente. Backend real: já roteado no
@@ -601,7 +601,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /ingresso
-      tag: v0.15.0
+      tag: v0.16.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/ingresso/... no cliente. Rota existe no uniplus-api-host,
@@ -619,7 +619,7 @@ uniplusWeb:
       enabled: true
       host: uniplus-hml.unifesspa.edu.br
       pathPrefix: /configuracao
-      tag: v0.15.0
+      tag: v0.16.0
       runtimeConfig:
         # apiUrl é só a origem (ver comentário do portal acima) — o app já
         # monta /api/configuracao/... no cliente. Módulo Configuração já


### PR DESCRIPTION
## Resumo

Promove os quatro apps do `uniplusWeb` (`portal`, `selecao`, `ingresso`, `configuracao`) de v0.15.0 para v0.16.0 em `environments/hml-standalone-single/values.yaml`.

Motivado por unifesspa-edu-br/uniplus-web#706 — cadastro completo de Tipos de Processo Seletivo no módulo Configuração (criar, editar, inativar, reativar), UNI-REQ-0098. Só `configuracao` mudou funcionalmente, mas os quatro apps sobem juntos na mesma tag de release (ADR-0020 do uniplus-web).

Bump manual — `bump-infra-tag.yml` do `uniplus-api` está com `INFRA_BUMP_TOKEN` ausente; sem equivalente automático no `uniplus-web`.

## Verificação local

- `make yaml-lint` — sem novos apontamentos no arquivo alterado.
- `helm template apps/uniplus-web -f environments/hml-standalone-single/values.yaml --show-only templates/deployment.yaml` — as quatro imagens renderizam com `:v0.16.0`.