### PR TITLE
chore(hml): promove uniplus-api-host v0.19.0

### DIFF
--- a/environments/hml-standalone-single/values.yaml
+++ b/environments/hml-standalone-single/values.yaml
@@ -333,7 +333,7 @@ uniplusApiHost:
   enabled: true
 
   image:
-    tag: v0.18.0
+    tag: v0.19.0
 
   # A migration passa a ser aplicada pelo Job `pre-upgrade` (ADR-0127 do
   # uniplus-api) antes do rollout, e não mais no boot do pod.


### PR DESCRIPTION
## O que vai para HML

`uniplus-api-host` de `v0.18.0` para **`v0.19.0`**.

Leva a busca e a ordenação escolhidas nas listagens de Cursos e Ofertas de Curso: `?sort=nome,-grau` e `?q=`, com os campos aceitos declarados por recurso e documentados no OpenAPI ([`uniplus-api#1419`](https://github.com/unifesspa-edu-br/uniplus-api/issues/1419), PR [#1431](https://github.com/unifesspa-edu-br/uniplus-api/pull/1431)).

Só a linha do `uniplusApiHost` muda. Os apps web permanecem em `v0.16.0` — nada do frontend entrou nesta versão.

## Migration

A versão traz uma migration de Configuração, `NormalizacaoDeBuscaComoFuncaoDoBanco`:

- cria `configuracao.normalizar_para_comparacao(text)`, declarada `IMMUTABLE`;
- altera a coluna gerada `curso.nome_ordenacao` para chamá-la, em vez de repetir a expressão embutida.

Alterar uma coluna gerada faz o Postgres regerá-la. A tabela é de cadastro institucional — dezenas de linhas —, então o custo é irrelevante. A função precede a coluna na mesma migration, porque uma coluna gerada não pode referenciar função inexistente.

A migration roda no Job de `pre-upgrade`, antes do rollout (ADR-0127 do `uniplus-api`).

## Verificação

```console
$ helm template apps/uniplus-api-host -f environments/hml-standalone-single/values.yaml \
    --show-only templates/deployment.yaml | grep image:
          image: "ghcr.io/unifesspa-edu-br/uniplus-api-host:v0.19.0"
```

Imagem confirmada no GHCR antes deste PR; `make yaml-lint` sem novos apontamentos.

## Depois do merge

O ArgoCD de HML sincroniza por polling, sem webhook — a VM não é alcançável de fora da VPN. Vou forçar o refresh e conferir a imagem no pod e o Job de migration como `Complete`, em vez de esperar o painel.